### PR TITLE
@FIR-731 - serial_script.py changes to identify end of output

### DIFF
--- a/tools/flaskIfc/serial_script.py
+++ b/tools/flaskIfc/serial_script.py
@@ -3,19 +3,21 @@ import sys
 
 def send_serial_command(port, baudrate, command):
     try:
-        # Open the serial port with 1 second timeout
-        ser = serial.Serial(port, baudrate, timeout=60)
+        # Open the serial port with 1 second timeout (timeout = 60 but removed it for testing!)
+        ser = serial.Serial(port, baudrate)
 
-        ser.write(command.encode())  # Encode command to bytes
-        ser.write('\n'.encode())  # Encode command to bytes
+        ser.write((command + '\n').encode())  # Send command with newline
         
         # Wait to read the serial port
         data = '\0'
         while True:
             try:
                 line = ser.readline()
+                check = line.decode('utf-8')
+                if ("run-platform-done" in check) or ("@agilex7_dk_si_agf014ea" in check):
+                    break
                 if line: # Check if line is not empty
-                    data += line.decode('utf-8')  # Keep the line as-is with newline
+                    data += check  # Keep the line as-is with newline
                 else:
                     break  # Exit loop if no data is received
             except serial.SerialException as e:
@@ -25,7 +27,6 @@ def send_serial_command(port, baudrate, command):
                 ser.close()
                 return ("Program interrupted by user")
         ser.close()
-        print (data)
         return data
 
     except serial.SerialException as e:
@@ -42,3 +43,4 @@ if __name__ == "__main__":
     baudrate = int(sys.argv[2])
     command = sys.argv[3]
     response = send_serial_command(port, baudrate, command)
+    print(response)

--- a/tools/flaskIfc/serial_script.py
+++ b/tools/flaskIfc/serial_script.py
@@ -3,7 +3,6 @@ import sys
 
 def send_serial_command(port, baudrate, command):
     try:
-        # Open the serial port with 1 second timeout (timeout = 60 but removed it for testing!)
         ser = serial.Serial(port, baudrate)
 
         ser.write((command + '\n').encode())  # Send command with newline

--- a/tools/flaskIfc/serial_script.py
+++ b/tools/flaskIfc/serial_script.py
@@ -13,11 +13,11 @@ def send_serial_command(port, baudrate, command):
         while True:
             try:
                 line = ser.readline()
-                check = line.decode('utf-8')
-                if ("run-platform-done" in check) or ("@agilex7_dk_si_agf014ea" in check):
-                    break
                 if line: # Check if line is not empty
-                    data += check  # Keep the line as-is with newline
+                    read_next_line = line.decode('utf-8')
+                    if ("run-platform-done" in read_next_line) or ("@agilex7_dk_si_agf014ea" in read_next_line):
+                        break
+                    data += read_next_line  # Keep the line as-is with newline
                 else:
                     break  # Exit loop if no data is received
             except serial.SerialException as e:
@@ -27,6 +27,7 @@ def send_serial_command(port, baudrate, command):
                 ser.close()
                 return ("Program interrupted by user")
         ser.close()
+        print(data)
         return data
 
     except serial.SerialException as e:
@@ -43,4 +44,3 @@ if __name__ == "__main__":
     baudrate = int(sys.argv[2])
     command = sys.argv[3]
     response = send_serial_command(port, baudrate, command)
-    print(response)


### PR DESCRIPTION
I tested this code alongside Anoop and Ashish and I've pasted the logs below for proof:

Model Response
/usr/bin/tsi/v0.1.1.tsv31_06_06_2025/bin/run_platform_test.sh "my cat's name" 10 tinyllama-vo-5m-para.gguf tSavorite
First argument: my cat's name
Second argument: 10
Third argument: tinyllama-vo-5m-para.gguf
Fourth argument: tSavorite
Check if tnApcMgr is running; if it is not, uncomment below line and execute the run_platform_test.sh script.
Running on v0.1.1.tsv31_06_06_2025
[2018-03-09 17:08:15.729038] 14678:14679 [[32m info[m]  :: </proj/work/mmankali/bld-setuptest/tsirel-31/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_process_req.c:129> TXE resource allocation request processed successfully.
 my cat's name. He wanted to have a
 and said,

llama_perf_sampler_print:    sampling time =     199.66 ms /    16 runs   (   12.48 ms per token,    80.14 tokens per second)
llama_perf_context_print:        load time =    1751.53 ms
llama_perf_context_print: prompt eval time =     611.10 ms /     6 tokens (  101.85 ms per token,     9.82 tokens per second)
llama_perf_context_print:        eval time =    1308.32 ms /     9 runs   (  145.37 ms per token,     6.88 tokens per second)
llama_perf_context_print:       total time =    3310.07 ms /    15 tokens
[2018-03-09 17:08:20.053686] 14678:14679 [[32m info[m]  :: </proj/work/mmankali/bld-setuptest/tsirel-31/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_process_req.c:145> TXE resource release request processed successfully.

GGML Tsavorite Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call  Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
  715    718.000     1.004     0.000  [17%] RuntimeHostShim::awaitCommandListCompletion
  460    720.041     1.565   720.041  └─ [17%] [ txe_silu ]
  245    377.932     1.543   377.932  └─ [ 9%] [ txe_mult ]
   10     15.395     1.540    15.395  └─ [ 0%] [ txe_add ]
  715      0.417     0.001     0.417  └─ [ 0%] TXE 0 Idle
    1     34.000    34.000    34.000  [ 1%] RuntimeHostShim::finalize
    1     18.000    18.000     1.000  [ 0%] GGML Tsavorite 
    1     17.000    17.000    17.000  └─ [ 0%] RuntimeHostShim::initialize
  716      0.000     0.000     0.000  [ 0%] RuntimeHostShim::allocate
 2400      0.000     0.000     0.000  [ 0%] RuntimeHostShim::getShmemManager
  715      0.000     0.000     0.000  [ 0%] RuntimeHostShim::createCommandList
  715      0.000     0.000     0.000  [ 0%] RuntimeHostShim::loadBlob
  715      0.000     0.000     0.000  [ 0%] RuntimeHostShim::launchBlob
  715      0.000     0.000     0.000  [ 0%] RuntimeHostShim::addCommandToList
  715      0.000     0.000     0.000  [ 0%] RuntimeHostShim::finalizeCommandList
  715      0.000     0.000     0.000  [ 0%] RuntimeHostShim::unloadBlob
  715      0.000     0.000     0.000  [ 0%] RuntimeHostShim::deallocate
========================================================================================================================
 8838   4336.000     0.491  4336.000  [100%] TOTAL
========================================================================================================================



⟵ Back to Form