### PR TITLE
Fir 746 (Changed run_platform_test.sh to run_llama_cli.sh in flaskIfc.py)

### DIFF
--- a/tools/flaskIfc/flaskIfc.py
+++ b/tools/flaskIfc/flaskIfc.py
@@ -101,7 +101,7 @@ def submit():
 
     # Currently the baudrate is hard coded to 921600 but can be parameterized
     baudrate = '921600'
-    script_path = "/usr/bin/tsi/v0.1.1.tsv31_06_06_2025/bin/run_platform_test.sh"
+    script_path = "/usr/bin/tsi/v0.1.1.tsv31_06_06_2025/bin/run_llama_cli.sh"
     command = f"{script_path} \"{prompt}\" {tokens} {model_path} {backend}"
 
 


### PR DESCRIPTION
I changed "run_platform_test.sh" to "run_llama_cli.sh" in the flaskIfc.py. I tested it and have pasted the logs below:

Model Response
/usr/bin/tsi/v0.1.1.tsv31_06_06_2025/bin/run_llama_cli.sh "my cat's name is" 5 tinyllama-vo-5m-para.gguf tSavorite
register_backend: registered backend Tsavorite (1 devices)
register_device: registered device Tsavorite (txe)
register_backend: registered backend CPU (1 devices)
register_device: registered device CPU (CPU)
load_backend: failed to find ggml_backend_init in /usr/bin/tsi/v0.1.1.tsv31_06_06_2025/bin/tsi-ggml/libggml-tsavorite.so
load_backend: failed to find ggml_backend_init in /usr/bin/tsi/v0.1.1.tsv31_06_06_2025/bin/tsi-ggml/libggml-cpu.so
build: 5473 (a7b7e465) with gcc (GCC) 13.3.0 for x86_64-pc-linux-gnu (debug)
main: llama backend init
main: load the model and apply lora adapter, if any

 TXE Device MEMORY Summary total 134217728 and free 134217728 
llama_model_load_from_file_impl: using device Tsavorite (txe) - 128 MiB free
llama_model_loader: loaded meta data with 24 key-value pairs and 75 tensors from /tsi/proj/model-cache/gguf/tinyllama-vo-5m-para.gguf (version GGUF V3 (latest))
llama_model_loader: Dumping metadata keys/values. Note: KV overrides do not apply in this output.
llama_model_loader: - kv   0:                       general.architecture str              = llama
llama_model_loader: - kv   1:                               general.type str              = model
llama_model_loader: - kv   2:                               general.name str              = Vicuna Hf
llama_model_loader: - kv   3:                         general.size_label str              = 4.6M
llama_model_loader: - kv   4:                            general.license str              = apache-2.0
llama_model_loader: - kv   5:                          llama.block_count u32              = 8
llama_model_loader: - kv   6:                       llama.context_length u32              = 2048
llama_model_loader: - kv   7:                     llama.embedding_length u32              = 64
llama_model_loader: - kv   8:                  llama.feed_forward_length u32              = 256
llama_model_loader: - kv   9:                 llama.attention.head_count u32              = 16
llama_model_loader: - kv  10:     llama.attention.layer_norm_rms_epsilon f32              = 0.000001
llama_model_loader: - kv  11:                          general.file_type u32              = 32
llama_model_loader: - kv  12:                           llama.vocab_size u32              = 32000
llama_model_loader: - kv  13:                 llama.rope.dimension_count u32              = 4
llama_model_loader: - kv  14:                       tokenizer.ggml.model str              = llama
llama_model_loader: - kv  15:                         tokenizer.ggml.pre str              = default
llama_model_loader: - kv  16:                      tokenizer.ggml.tokens arr[str,32000]   = ["<unk>", "<s>", "</s>", "<0x00>", "<...
llama_model_loader: - kv  17:                      tokenizer.ggml.scores arr[f32,32000]   = [0.000000, 0.000000, 0.000000, 0.0000...
llama_model_loader: - kv  18:                  tokenizer.ggml.token_type arr[i32,32000]   = [2, 3, 3, 6, 6, 6, 6, 6, 6, 6, 6, 6, ...
llama_model_loader: - kv  19:                tokenizer.ggml.bos_token_id u32              = 1
llama_model_loader: - kv  20:                tokenizer.ggml.eos_token_id u32              = 2
llama_model_loader: - kv  21:            tokenizer.ggml.unknown_token_id u32              = 0
llama_model_loader: - kv  22:            tokenizer.ggml.padding_token_id u32              = 0
llama_model_loader: - kv  23:               general.quantization_version u32              = 2
llama_model_loader: - type  f32:   17 tensors
llama_model_loader: - type bf16:   58 tensors
print_info: file format = GGUF V3 (latest)
print_info: file type   = BF16
print_info: file size   = 8.82 MiB (16.00 BPW) 
load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
load: special tokens cache size = 3
load: token to piece cache size = 0.1914 MB
print_info: arch             = llama
print_info: vocab_only       = 0
print_info: n_ctx_train      = 2048
print_info: n_embd           = 64
print_info: n_layer          = 8
print_info: n_head           = 16
print_info: n_head_kv        = 16
print_info: n_rot            = 4
print_info: n_swa            = 0
print_info: n_swa_pattern    = 1
print_info: n_embd_head_k    = 4
print_info: n_embd_head_v    = 4
print_info: n_gqa            = 1
print_info: n_embd_k_gqa     = 64
print_info: n_embd_v_gqa     = 64
print_info: f_norm_eps       = 0.0e+00
print_info: f_norm_rms_eps   = 1.0e-06
print_info: f_clamp_kqv      = 0.0e+00
print_info: f_max_alibi_bias = 0.0e+00
print_info: f_logit_scale    = 0.0e+00
print_info: f_attn_scale     = 0.0e+00
print_info: n_ff             = 256
print_info: n_expert         = 0
print_info: n_expert_used    = 0
print_info: causal attn      = 1
print_info: pooling type     = 0
print_info: rope type        = 0
print_info: rope scaling     = linear
print_info: freq_base_train  = 10000.0
print_info: freq_scale_train = 1
print_info: n_ctx_orig_yarn  = 2048
print_info: rope_finetuned   = unknown
print_info: ssm_d_conv       = 0
print_info: ssm_d_inner      = 0
print_info: ssm_d_state      = 0
print_info: ssm_dt_rank      = 0
print_info: ssm_dt_b_c_rms   = 0
print_info: model type       = ?B
print_info: model params     = 4.62 M
print_info: general.name     = Vicuna Hf
print_info: vocab type       = SPM
print_info: n_vocab          = 32000
print_info: n_merges         = 0
print_info: BOS token        = 1 '<s>'
print_info: EOS token        = 2 '</s>'
print_info: UNK token        = 0 '<unk>'
print_info: PAD token        = 0 '<unk>'
print_info: LF token         = 13 '<0x0A>'
print_info: EOG token        = 2 '</s>'
print_info: max token length = 18
load_tensors: loading model tensors, this can take a while... (mmap = true)

 TXE Device MEMORY Summary total 134217728 and free 134217728 
load_tensors: offloading 0 repeating layers to GPU
load_tensors: offloaded 0/9 layers to GPU
load_tensors:   CPU_Mapped model buffer size =     8.82 MiB
..............
llama_context: constructing llama_context
llama_context: n_seq_max     = 1
llama_context: n_ctx         = 12288
llama_context: n_ctx_per_seq = 12288
llama_context: n_batch       = 1024
llama_context: n_ubatch      = 512
llama_context: causal_attn   = 1
llama_context: flash_attn    = 0
llama_context: freq_base     = 10000.0
llama_context: freq_scale    = 1
llama_context: n_ctx_per_seq (12288) > n_ctx_train (2048) -- possible training context overflow
[2018-03-09 12:45:16.481564] 282:283 [[32m info[m]  :: </proj/work/mmankali/bld-setuptest/tsirel-32-TMU-update/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_process_req.c:129> TXE resource allocation request processed successfully.
llama_context:        CPU  output buffer size =     0.12 MiB
llama_kv_cache_unified:        CPU KV buffer size =    24.00 MiB
llama_kv_cache_unified: size =   24.00 MiB ( 12288 cells,   8 layers,  1 seqs), K (f16):   12.00 MiB, V (f16):   12.00 MiB
ggml_backend_tsavorite_buffer_type_alloc_buffer is called from llama data Loader 

 ANoop Allocating memory from tsi_alloc with size  659456 

 Allocating memory from tsi_alloc with size  659456 starting memory 0xffffb3e00080

Address of Newly Created BUffer 0xffffb3e00080 and size 659456 
llama_context:  tsavorite compute buffer size =     0.63 MiB
llama_context:        CPU compute buffer size =   408.51 MiB
llama_context: graph nodes  = 294
llama_context: graph splits = 83 (with bs=512), 53 (with bs=1)
common_init_from_params: setting dry_penalty_last_n to ctx_size = 12288
main: llama threadpool init, n_threads = 4
main: model was trained on only 2048 context tokens (12288 specified)

system_info: n_threads = 4 (n_threads_batch = 4) / 4 | CPU : NEON = 1 | ARM_FMA = 1 | LLAMAFILE = 1 | AARCH64_REPACK = 1 | 

sampler seed: 3941540127
sampler params: 
	repeat_last_n = 5, repeat_penalty = 1.500, frequency_penalty = 0.000, presence_penalty = 0.000
	dry_multiplier = 0.000, dry_base = 1.750, dry_allowed_length = 2, dry_penalty_last_n = 12288
	top_k = 50, top_p = 0.900, min_p = 0.050, xtc_probability = 0.000, xtc_threshold = 0.100, typical_p = 1.000, top_n_sigma = -1.000, temp = 0.000
	mirostat = 0, mirostat_lr = 0.100, mirostat_ent = 5.000
sampler chain: logits -> logit-bias -> penalties -> dry -> top-n-sigma -> top-k -> typical -> top-p -> min-p -> xtc -> temp-ext -> dist 
generate: n_ctx = 12288, n_batch = 1024, n_predict = 5, n_keep = 1

 my cat's name is Tim. He has a

llama_perf_sampler_print:    sampling time =      97.84 ms /    12 runs   (    8.15 ms per token,   122.65 tokens per second)
llama_perf_context_print:        load time =    1861.22 ms
llama_perf_context_print: prompt eval time =     700.24 ms /     7 tokens (  100.03 ms per token,    10.00 tokens per second)
llama_perf_context_print:        eval time =     582.48 ms /     4 runs   (  145.62 ms per token,     6.87 tokens per second)
llama_perf_context_print:       total time =    2565.99 ms /    11 tokens

 TXE_ADD Operation, total tensor: 5  Number of Kernel Call: 5  Number of tensor got spilt: 0 Min Num of Elem 64 Max Num of Elem 64 

 TXE_SUB Operation, total tensor: 0  Number of Kernel Call: 0  Number of tensor got spilt: 0 Min Num of Elem 0 Max Num of Elem 0 

 TXE_MULT Operation, total tensor: 85  Number of Kernel Call: 175  Number of tensor got spilt: 0 Min Num of Elem 64 Max Num of Elem 448 

 TXE_DIV Operation, total tensor: 0  Number of Kernel Call: 0  Number of tensor got spilt: 0 Min Num of Elem 0 Max Num of Elem 0 

 TXE_SQRT Operation, total tensor: 0  Number of Kernel Call: 0  Number of tensor got spilt: 0 Min Num of Elem 0 Max Num of Elem 0 

 TXE_NEG Operation, total tensor: 0  Number of Kernel Call: 0  Number of tensor got spilt: 0 Min Num of Elem 0 Max Num of Elem 0 

 TXE_ABS Operation, total tensor: 0  Number of Kernel Call: 0  Number of tensor got spilt: 0 Min Num of Elem 0 Max Num of Elem 0 

 TXE_SIN Operation, total tensor: 0  Number of Kernel Call: 0  Number of tensor got spilt: 0 Min Num of Elem 0 Max Num of Elem 0 

 TXE_SIGMOID Operation, total tensor: 0  Number of Kernel Call: 0  Number of tensor got spilt: 0 Min Num of Elem 0 Max Num of Elem 0 

 TXE_SILU Operation, total tensor: 40  Number of Kernel Call: 328  Number of tensor got spilt: 40 Min Num of Elem 256 Max Num of Elem 1792 
[2018-03-09 12:45:20.043699] 282:283 [[32m info[m]  :: </proj/work/mmankali/bld-setuptest/tsirel-32-TMU-update/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_process_req.c:145> TXE resource release request processed successfully.

GGML Tsavorite Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call  Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
  508    508.000     1.000     0.000  [14%] RuntimeHostShim::awaitCommandListCompletion
  328    513.307     1.565   513.307  └─ [14%] [ txe_silu ]
  175    269.951     1.543   269.951  └─ [ 8%] [ txe_mult ]
    5      7.713     1.543     7.713  └─ [ 0%] [ txe_add ]
  508      0.412     0.001     0.412  └─ [ 0%] TXE 0 Idle
    1     35.000    35.000    35.000  [ 1%] RuntimeHostShim::finalize
    1     18.000    18.000     1.000  [ 1%] GGML Tsavorite 
    1     17.000    17.000    17.000  └─ [ 0%] RuntimeHostShim::initialize
  509      0.000     0.000     0.000  [ 0%] RuntimeHostShim::allocate
 1704      0.000     0.000     0.000  [ 0%] RuntimeHostShim::getShmemManager
  508      0.000     0.000     0.000  [ 0%] RuntimeHostShim::createCommandList
  508      0.000     0.000     0.000  [ 0%] RuntimeHostShim::loadBlob
  508      0.000     0.000     0.000  [ 0%] RuntimeHostShim::launchBlob
  508      0.000     0.000     0.000  [ 0%] RuntimeHostShim::addCommandToList
  508      0.000     0.000     0.000  [ 0%] RuntimeHostShim::finalizeCommandList
  508      0.000     0.000     0.000  [ 0%] RuntimeHostShim::unloadBlob
  508      0.000     0.000     0.000  [ 0%] RuntimeHostShim::deallocate
========================================================================================================================
 6279   3574.000     0.569  3574.000  [100%] TOTAL
========================================================================================================================


⟵ Back to Form
