### PR TITLE
@FIR-772: Add check for u-boot prompt to exit while loop

### DIFF
--- a/tools/flaskIfc/serial_script.py
+++ b/tools/flaskIfc/serial_script.py
@@ -16,12 +16,16 @@ def send_serial_command(port, baudrate, command):
                 line = b""
                 while True:
                     byte = ser.read(1)  # Read one byte at a time
-                    if (byte == b"\n") or (byte == b"#"):  # Stop when delimiter is found
+                    if (byte == b"\n") or (byte == b"#"): # Stop when delimiter is found
                         break
                     line += byte
                 if line: # Check if line is not empty
                     read_next_line = line.decode('utf-8')
-                    if ("run-platform-done" in read_next_line.strip()) or ("@agilex7_dk_si_agf014ea" in read_next_line.strip()) or ("imx8mpevk" in read_next_line.strip()):
+                    if ("run-platform-done" in read_next_line.strip()) or \
+                            ("SOCFPGA_AGILEX7 " in read_next_line.strip()) or \
+                            ("Unknown command " in read_next_line.strip()) or \
+                            ("@agilex7_dk_si_agf014ea" in read_next_line.strip()) or \
+                            ("imx8mpevk" in read_next_line.strip()):
                         break
                     if (first_time == 1) :
                         first_time = 0


### PR DESCRIPTION
This change checks for u-boot prompt also if the system is in u-boot prompt.

The test results are as follows
LLAMA Queury Results...
 What is Ethernet ? He was so excited to play with his toy car. He had a big box of toys and a
RAG Results...
"I\'s that you can make a special place to help me make a special place to help\n\n\n\n LLAMA.cpp profile data
Click to expand LLM Profile data

sampling time =     400.49 ms /    25 runs   (   16.02 ms per token,    62.42 tokens per second)llama_perf_context_print:        load time =    1950.40 ms
llama_perf_context_print: prompt eval time =     832.66 ms /     5 tokens (  166.53 ms per token,     6.00 tokens per second)
llama_perf_context_print:        eval time =    4094.16 ms /    19 runs   (  215.48 ms per token,     4.64 tokens per second)
llama_perf_context_print:       total time =    6547.02 ms /    24 tokens

GGML Tsavorite Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call  Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
 1172   3513.000     2.997  1736.861  [46%] RuntimeHostShim::awaitCommandListCompletion
  752   1144.224     1.522  1144.224  └─ [15%] [ txe_silu ]
  400    599.436     1.499   599.436  └─ [ 8%] [ txe_mult ]
   20     29.920     1.496    29.920  └─ [ 0%] [ txe_add ]
 1172      1.057     0.001     1.057  └─ [ 0%] TXE 0 Idle
    1     34.000    34.000    34.000  [ 0%] RuntimeHostShim::finalize
    1     17.000    17.000     0.000  [ 0%] GGML Tsavorite
    1     17.000    17.000    17.000  └─ [ 0%] RuntimeHostShim::initialize
 1173      0.000     0.000     0.000  [ 0%] RuntimeHostShim::allocate
 3936      0.000     0.000     0.000  [ 0%] RuntimeHostShim::getShmemManager
 1172      0.000     0.000     0.000  [ 0%] RuntimeHostShim::createCommandList
 1172      0.000     0.000     0.000  [ 0%] RuntimeHostShim::loadBlob
 1172      0.000     0.000     0.000  [ 0%] RuntimeHostShim::launchBlob
 1172      0.000     0.000     0.000  [ 0%] RuntimeHostShim::addCommandToList
 1172      0.000     0.000     0.000  [ 0%] RuntimeHostShim::finalizeCommandList
 1172      0.000     0.000     0.000  [ 0%] RuntimeHostShim::unloadBlob
 1172      0.000     0.000     0.000  [ 0%] RuntimeHostShim::deallocate
========================================================================================================================
14487   7591.000     0.524  7591.000  [100%] TOTAL
========================================================================================================================
Click to expand RAG LLM Profile data

sampling time =     400.57 ms /   522 runs   (    0.77 ms per token,  1303.13 tokens per second)llama_perf_context_print:        load time =  108212.49 ms\nllama_perf_context_print: prompt eval time =  107054.15 ms /   502 tokens (  213.26 ms per token,     4.69 tokens per second)\nllama_perf_context_print:        eval time =    4444.41 ms /    19 runs   (  233.92 ms per token,     4.28 tokens per second)\nllama_perf_context_print:       total time =  113160.30 ms /   521 tokens\n\nGGML Tsavorite Profiling Results:\n------------------------------------------------------------------------------------------------------------------------\nCalls  Total(ms)    T/call  Self(ms)  Function\n------------------------------------------------------------------------------------------------------------------------\n29572  88591.000     2.996 43946.673  [78%] RuntimeHostShim::awaitCommandListCompletion\n14668  22325.086     1.522 22325.086  └─ [20%] [ txe_silu ]\n 7855  11773.495     1.499 11773.495  └─ [10%] [ txe_mult ]\n 7049  10543.061     1.496 10543.061  └─ [ 9%] [ txe_add ]\n29572      1.184     0.000     1.184  └─ [ 0%] TXE 0 Idle\n    1     34.000    34.000    34.000  [ 0%] RuntimeHostShim::finalize\n    1     15.000    15.000     0.000  [ 0%] GGML Tsavorite \n    1     15.000    15.000    15.000  └─ [ 0%] RuntimeHostShim::initialize\n29573      0.000     0.000     0.000  [ 0%] RuntimeHostShim::allocate\n103620      0.000     0.000     0.000  [ 0%] RuntimeHostShim::getShmemManager\n29572      0.000     0.000     0.000  [ 0%] RuntimeHostShim::createCommandList\n29572      0.000     0.000     0.000  [ 0%] RuntimeHostShim::loadBlob\n29572      0.000     0.000     0.000  [ 0%] RuntimeHostShim::launchBlob\n29572      0.000     0.000     0.000  [ 0%] RuntimeHostShim::addCommandToList\n29572      0.000     0.000     0.000  [ 0%] RuntimeHostShim::finalizeCommandList\n29572      0.000     0.000     0.000  [ 0%] RuntimeHostShim::unloadBlob\n29572      0.000     0.000     0.000  [ 0%] RuntimeHostShim::deallocate\n========================================================================================================================\n369771 114210.000     0.309114210.000  [100%] TOTAL\n========================================================================================================================\n\n'}

When in boot prompt
SOCFPGA_AGILEX7 #

LLAMA Queury Results...
Desired phrase not found in the response.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
