### PR TITLE
@FIR-770 - LLama.cpp: Adding Perf Status for all GGML Operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,9 @@ cd ../../
 #Compile for posix with build-posix as a target folder
 
 cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix
+to enable STatus use below command
+cmake -B build-posix   -DCMAKE_BUILD_TYPE=Debug   -DGGML_TSAVORITE=ON   -DCMAKE_C_FLAGS="-DGGML_PERF"   -DCMAKE_CXX_FLAGS="-DGGML_PERF"
+
 cmake --build build-posix --config Release
 
 #Compile for fpga with build-fpga as a target folder

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -2227,8 +2227,6 @@ void ggml_perf_write_detailed_csv(struct ggml_cgraph * cgraph, FILE *fp);
 // capture perf into totals
 void ggml_perf_accumulate(struct ggml_perf_totals totals[GGML_OP_COUNT], struct ggml_cgraph * cgraph);
 
-// print final stats
-void ggml_perf_print_totals(struct ggml_perf_totals totals[GGML_OP_COUNT]);
 #endif /* GGML_PERF */
 
 #ifdef  __cplusplus

--- a/ggml/include/ggml.h
+++ b/ggml/include/ggml.h
@@ -615,7 +615,7 @@ extern "C" {
 	int64_t perf_runs;
         int64_t perf_time_us;
 	enum ggml_compute_backend_type ggml_compute_backend;
-        char padding[8+12];
+        char padding[4];
 #else
         char padding[8];
 #endif /* GGML_PERF */

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2852,7 +2852,12 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
 #ifdef GGML_PERF
         int64_t t_end = ggml_time_us();
         node->perf_runs++;
+	if (t_end >= t_start) {
         node->perf_time_us += (t_end - t_start);
+    } else {
+        // Handle wraparound by assuming timer rolls over at max int64_t value
+        node->perf_time_us += (INT64_MAX - t_start + t_end + 1);
+    }
 #endif
 
         if (state->ith == 0 && cplan->abort_callback &&

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2844,7 +2844,16 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
     for (int node_n = 0; node_n < cgraph->n_nodes && atomic_load_explicit(&tp->abort, memory_order_relaxed) != node_n; node_n++) {
         struct ggml_tensor * node = cgraph->nodes[node_n];
 
+#ifdef GGML_PERF
+        int64_t t_start = ggml_time_us();
+#endif
         ggml_compute_forward(&params, node);
+
+#ifdef GGML_PERF
+        int64_t t_end = ggml_time_us();
+        node->perf_runs++;
+        node->perf_time_us += (t_end - t_start);
+#endif
 
         if (state->ith == 0 && cplan->abort_callback &&
                 cplan->abort_callback(cplan->abort_callback_data)) {

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2852,14 +2852,13 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
 #ifdef GGML_PERF
         int64_t t_end = ggml_time_us();
         node->perf_runs++;
-	if (t_end >= t_start) {
-        node->perf_time_us += (t_end - t_start);
-    } else {
-        // Handle wraparound by assuming timer rolls over at max int64_t value
-        node->perf_time_us += (INT64_MAX - t_start + t_end + 1);
-    }
+        if (t_end >= t_start) {
+            node->perf_time_us += (t_end - t_start);
+        } else {
+            // Handle wraparound by assuming timer rolls over at max int64_t value
+            node->perf_time_us += (INT64_MAX - t_start + t_end + 1);
+        }
 #endif
-
         if (state->ith == 0 && cplan->abort_callback &&
                 cplan->abort_callback(cplan->abort_callback_data)) {
             atomic_store_explicit(&tp->abort, node_n + 1, memory_order_relaxed);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -1128,8 +1128,13 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
 #ifdef GGML_PERF
     int64_t t_end = ggml_time_us();
     node->perf_runs++;
-    node->perf_time_us += (t_end - t_start);
     node->ggml_compute_backend = GGML_COMPUTE_BACKEND_TSAVORITE;
+    if (t_end >= t_start) {
+        node->perf_time_us += (t_end - t_start);
+    } else {
+        // Handle wraparound by assuming timer rolls over at max int64_t value
+        node->perf_time_us += (INT64_MAX - t_start + t_end + 1);
+    }
 #endif
   }
 

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -813,6 +813,9 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
   tensor_log log_data;
 
   for (int i = 0; i < cgraph->n_nodes; i++) {
+#ifdef GGML_PERF
+    int64_t t_start = ggml_time_us();
+#endif
     node = cgraph->nodes[i];
     src0 = node->src[0];
     src1 = node->src[1];
@@ -1122,6 +1125,12 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
           device->stats.op_run_count[kernel_type].max_num_of_elem < max_num_of_elem)
         device->stats.op_run_count[kernel_type].max_num_of_elem = max_num_of_elem;
     }
+#ifdef GGML_PERF
+    int64_t t_end = ggml_time_us();
+    node->perf_runs++;
+    node->perf_time_us += (t_end - t_start);
+    node->ggml_compute_backend = GGML_COMPUTE_BACKEND_TSAVORITE;
+#endif
   }
 
   // This this need to implement correctly when we have mixture of CPU and accelerator operation

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -249,7 +249,7 @@ static void ggml_log_internal_v(enum ggml_log_level level, const char * format, 
 void ggml_log_internal(enum ggml_log_level level, const char * format, ...) {
     va_list args;
     va_start(args, format);
-    //if (level == GGML_LOG_LEVEL_TSAVORITE)
+    if (level == GGML_LOG_LEVEL_TSAVORITE)
     ggml_log_internal_v(level, format, args);
     va_end(args);
 }
@@ -6580,19 +6580,6 @@ void ggml_perf_accumulate(struct ggml_perf_totals totals[GGML_OP_COUNT], struct 
         totals[op].total_us += node->perf_time_us;
         totals[op].runs     += node->perf_runs;
         totals[op].op_count++;
-    }
-}
-
-void ggml_perf_print_totals(struct ggml_perf_totals totals[GGML_OP_COUNT]) {
-    printf("\n=== GGML Perf Summary ===\n");
-    for (int i = 0; i < GGML_OP_COUNT; ++i) {
-        if (totals[i].runs > 0) {
-            printf("  %-16s: %5ld runs, %8ld us total, avg %.2f us\n",
-                   totals[i].op_name ? totals[i].op_name : "UNKNOWN",
-                   totals[i].runs,
-                   totals[i].total_us,
-                   (double)totals[i].total_us / totals[i].runs);
-        }
     }
 }
 

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -250,7 +250,7 @@ void ggml_log_internal(enum ggml_log_level level, const char * format, ...) {
     va_list args;
     va_start(args, format);
     if (level == GGML_LOG_LEVEL_TSAVORITE)
-    ggml_log_internal_v(level, format, args);
+        ggml_log_internal_v(level, format, args);
     va_end(args);
 }
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -975,9 +975,9 @@ int llama_context::decode(llama_batch & inp_batch) {
 
         const auto compute_status = graph_compute(gf, ubatch.n_tokens > 1);
 #ifdef GGML_PERF
-	if (perf_all_shape_fp) {
+        if (perf_all_shape_fp) {
             ggml_perf_write_detailed_csv(gf, perf_all_shape_fp);
-	}
+        }
         ggml_perf_accumulate(perf_totals, gf);
 #endif /* GGML_PERF */
         if (compute_status != GGML_STATUS_SUCCESS) {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -184,6 +184,9 @@ public:
     ggml_status graph_compute(
             ggml_cgraph * gf,
                    bool   batched);
+#ifdef GGML_PERF
+    struct ggml_perf_totals perf_totals[GGML_OP_COUNT] = {};  // add this to llama_context
+#endif
 
 private:
     llm_graph_result_ptr graph_build(
@@ -274,7 +277,4 @@ private:
 
     mutable int32_t n_p_eval = 0; // number of tokens in eval calls for the prompt (with batch size > 1)
     mutable int32_t n_eval   = 0; // number of eval calls
-#ifdef GGML_PERF
-    struct ggml_perf_totals perf_totals[GGML_OP_COUNT] = {};  // add this to llama_context
-#endif
 };

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -8,6 +8,7 @@
 
 #include "ggml-cpp.h"
 #include "ggml-opt.h"
+#include "ggml.h"
 
 #include <map>
 #include <vector>
@@ -273,4 +274,7 @@ private:
 
     mutable int32_t n_p_eval = 0; // number of tokens in eval calls for the prompt (with batch size > 1)
     mutable int32_t n_eval   = 0; // number of eval calls
+#ifdef GGML_PERF
+    struct ggml_perf_totals perf_totals[GGML_OP_COUNT] = {};  // add this to llama_context
+#endif
 };

--- a/tools/main/main.cpp
+++ b/tools/main/main.cpp
@@ -126,7 +126,9 @@ int main(int argc, char ** argv) {
         LOG_WRN("%s: warning: scaling RoPE frequency by %g.\n", __func__, params.rope_freq_scale);
     }
 
-    //llama_log_set(my_logger, nullptr);
+#ifdef GGML_PERF
+    llama_log_set(my_logger, nullptr);
+#endif /* GGML_PERF */
     LOG_INF("%s: llama backend init\n", __func__);
 
     llama_backend_init();

--- a/tools/main/main.cpp
+++ b/tools/main/main.cpp
@@ -126,7 +126,7 @@ int main(int argc, char ** argv) {
         LOG_WRN("%s: warning: scaling RoPE frequency by %g.\n", __func__, params.rope_freq_scale);
     }
 
-    llama_log_set(my_logger, nullptr);
+    //llama_log_set(my_logger, nullptr);
     LOG_INF("%s: llama backend init\n", __func__);
 
     llama_backend_init();


### PR DESCRIPTION
**Perf Summary:**
=== GGML Perf Summary ===
  ADD             :   172 runs,    63454 us total, avg 368.92 us
  MUL             :   133 runs,  6807770 us total, avg 51186.24 us
  RMS_NORM        :   178 runs,     3009 us total, avg 16.90 us
  MUL_MAT         :   676 runs,  6675856 us total, avg 9875.53 us
  CPY             :   168 runs,     1123 us total, avg 6.68 us
  CONT            :    87 runs,      344 us total, avg 3.95 us
  RESHAPE         :   316 runs,      284 us total, avg 0.90 us
  VIEW            :   294 runs,       67 us total, avg 0.23 us
  PERMUTE         :   294 runs,      105 us total, avg 0.36 us
  TRANSPOSE       :    68 runs,       31 us total, avg 0.46 us
  GET_ROWS        :     9 runs,      127 us total, avg 14.11 us
  SOFT_MAX        :    88 runs,     5991 us total, avg 68.08 us
  ROPE            :   175 runs,     3593 us total, avg 20.53 us
  UNARY           :    22 runs,  8535113 us total, avg 387959.68 us

**Detailed information is written to the file, including the size (shape) of each tensor node. Below is a sample output:**
cat  ggml_perf.log 
ggml_graph_compute_perf: total compute time: 22096.867 ms
 - BACKEND:CPU OP:GET_ROWS: total 0.110 ms over 4 runs (avg 0.028 ms) [shape=2048,6,1]
 - BACKEND:CPU OP:RMS_NORM: total 0.148 ms over 4 runs (avg 0.037 ms) [shape=2048,6,1]
 - BACKEND:TSAVORITE OP:MUL: total 143.046 ms over 1 runs (avg 143.046 ms) [shape=2048,6,1]
 - BACKEND:CPU OP:MUL_MAT: total 34.345 ms over 4 runs (avg 8.586 ms) [shape=2048,6,1]
 - BACKEND:CPU OP:RESHAPE: total 0.005 ms over 2 runs (avg 0.003 ms) [shape=64,32,6]
 - BACKEND:CPU OP:ROPE: total 0.329 ms over 4 runs (avg 0.082 ms) [shape=64,32,6]
 - BACKEND:CPU OP:MUL_MAT: total 4.916 ms over 4 runs (avg 1.229 ms) [shape=256,6,1]
 - BACKEND:CPU OP:RESHAPE: total 0.002 ms over 4 runs (avg 0.001 ms) [shape=64,4,6]
 - BACKEND:CPU OP:ROPE: total 0.032 ms over 4 runs (avg 0.008 ms) [shape=64,4,6]
 - BACKEND:CPU OP:MUL_MAT: total 4.840 ms over 4 runs (avg 1.210 ms) [shape=256,6,1]
 - BACKEND:CPU OP:RESHAPE: total 0.002 ms over 3 runs (avg 0.001 ms) [shape=64,4,6]
 - BACKEND:CPU OP:VIEW: total 0.007 ms over 4 runs (avg 0.002 ms) [shape=1536,1,1]
 - BACKEND:CPU OP:CPY: total 0.021 ms over 4 runs (avg 0.005 ms) [shape=1536,1,1]
 - BACKEND:CPU OP:RESHAPE: total 0.000 ms over 3 runs (avg 0.000 ms) [shape=256,6,1]
 - BACKEND:CPU OP:TRANSPOSE: total 0.002 ms over 4 runs (avg 0.001 ms) [shape=6,256,1]
 - BACKEND:CPU OP:VIEW: total 0.000 ms over 4 runs (avg 0.000 ms) [shape=6,256,1]
 - BACKEND:CPU OP:CPY: total 0.040 ms over 4 runs (avg 0.010 ms) [shape=6,256,1]
 - BACKEND:CPU OP:VIEW: total 0.001 ms over 4 runs (avg 0.000 ms) [shape=32,4,64]
 - BACKEND:CPU OP:PERMUTE: total 0.004 ms over 4 runs (avg 0.001 ms) [shape=32,64,4]

