### PR TITLE
@FIR-777: Added additional details to health-check and system-info

### DIFF
--- a/tools/flaskIfc/flaskIfc.py
+++ b/tools/flaskIfc/flaskIfc.py
@@ -212,7 +212,7 @@ def restart_txe_serial_command():
 
 @app.route('/health-check', methods=['GET'])
 def health_check_serial_command():
-    command = f"free -h"
+    command = f"free -h; df -h; top -b -n1"
 
     try:
         result = subprocess.run(['python3', 'serial_script.py', port, baudrate, command], capture_output=True, text=True, check=True)
@@ -233,7 +233,7 @@ def test_serial_command():
 @app.route('/system-info', methods=['GET'])
 def system_info_serial_command():
 
-    command = f"{exe_path}../install/tsi-version;lscpu"
+    command = f"{exe_path}../install/tsi-version;lsmod; lscpu; lsblk"
 
     try:
         result = subprocess.run(['python3', 'serial_script.py', port, baudrate, command], capture_output=True, text=True, check=True)


### PR DESCRIPTION
    endpoints as follows
    Health check endpoint has
    1. free -h
    2. df -h
    3. top -b -n1 System info has
    1. lsmod
    2. lscpu
    3. lsblk

    The test results are as follows
    System-info
    TSAVORITE AI Assistant
    FPGA Command Output:
    -sh: /usr/bin/tsi/v0.1.1.tsv31_06_06_2025/bin/../install/tsi-version: No such file or directory
    Module                  Size  Used by
    u_dma_buf              40960  0
    Architecture:             aarch64
      CPU op-mode(s):         32-bit, 64-bit
      Byte Order:             Little Endian
    CPU(s):                   4
      On-line CPU(s) list:    0-3
    Vendor ID:                ARM
      Model name:             Cortex-A53
        Model:                4
        Thread(s) per core:   1
        Core(s) per cluster:  4
        Socket(s):            -
        Cluster(s):           1
        Stepping:             r0p4
        BogoMIPS:             800.00
        Flags:                fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
    NUMA:
      NUMA node(s):           1
      NUMA node0 CPU(s):      0-3
    Vulnerabilities:
      Gather data sampling:   Not affected
      Itlb multihit:          Not affected
      L1tf:                   Not affected
      Mds:                    Not affected
      Meltdown:               Not affected
      Mmio stale data:        Not affected
      Reg file data sampling: Not affected
      Retbleed:               Not affected
      Spec rstack overflow:   Not affected
      Spec store bypass:      Not affected
      Spectre v1:             Mitigation; __user pointer sanitization
      Spectre v2:             Not affected
      Srbds:                  Not affected
      Tsx async abort:        Not affected
    NAME      MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
    mtdblock0  31:0    0    2M  0 disk
    mtdblock1  31:1    0  510M  0 disk

    Health-check
    TSAVORITE AI Assistant
    FPGA Command Output:
                  total        used        free      shared  buff/cache   available
    Mem:        1924284     1127164      784028         228       13092      756668
    Swap:             0           0           0
    Filesystem                Size      Used Available Use% Mounted on
    ubi0:rootfs             427.3M    359.7M     67.6M  84% /
    devtmpfs                418.3M    100.0K    418.2M   0% /dev
    tmpfs                   939.6M     56.0K    939.5M   0% /run
    tmpfs                   939.6M     68.0K    939.5M   0% /var/volatile
    Mem: 1140508K used, 783776K free, 228K shrd, 0K buff, 8204K cached
    CPU:   0% usr   0% sys   0% nic 100% idle   0% io   0% irq   0% sirq
    Load average: 0.00 0.00 0.00 1/80 310
      PID  PPID USER     STAT   VSZ %VSZ %CPU COMMAND
      276     1 root     S     520m  27%   0% tsiTXEmgr_1
      271     1 root     S    80324   4%   0% tnAiHwRSM
      131     1 root     S     9604   0%   0% /sbin/udevd -d
      273     1 root     S     6432   0%   0% tnCliServer
      281     1 root     S     6428   0%   0% ./tnApcMgr
      290   287 root     S     4176   0%   0% -sh
      287     1 root     S     3808   0%   0% {start_getty} /bin/sh /bin/start_getty 921600 ttyS0 vt102
      257     1 root     S     3460   0%   0% /sbin/syslogd -n -O /var/log/messages
      260     1 root     S     3460   0%   0% /sbin/klogd -n
      310   290 root     R     3460   0%   0% top -b -n1
      288     1 root     S     2436   0%   0% /sbin/getty 38400 tty1
        1     0 root     S     2236   0%   0% init [5]
       16     2 root     IW       0   0%   0% [rcu_preempt]
       36     2 root     IW       0   0%   0% [kworker/u8:1-ev]
        2     0 root     SW       0   0%   0% [kthreadd]
        3     2 root     SW       0   0%   0% [pool_workqueue_]
        4     2 root     IW<      0   0%   0% [kworker/R-rcu_g]
        5     2 root     IW<      0   0%   0% [kworker/R-rcu_p]
        6     2 root     IW<      0   0%   0% [kworker/R-slub_]
        7     2 root     IW<      0   0%   0% [kworker/R-netns]
        8     2 root     IW       0   0%   0% [kworker/0:0-dev]
        9     2 root     IW<      0   0%   0% [kworker/0:0H-ev]
       12     2 root     IW<      0   0%   0% [kworker/R-mm_pe]
       13     2 root     IW       0   0%   0% [rcu_tasks_kthre]
       14     2 root     IW       0   0%   0% [rcu_tasks_trace]
       15     2 root     SW       0   0%   0% [ksoftirqd/0]
       17     2 root     SW       0   0%   0% [migration/0]
       18     2 root     SW       0   0%   0% [cpuhp/0]
       19     2 root     SW       0   0%   0% [cpuhp/1]
       20     2 root     SW       0   0%   0% [migration/1]
       21     2 root     SW       0   0%   0% [ksoftirqd/1]
       22     2 root     IW       0   0%   0% [kworker/1:0-mm_]
       23     2 root     IW<      0   0%   0% [kworker/1:0H-ev]
       24     2 root     SW       0   0%   0% [cpuhp/2]
       25     2 root     SW       0   0%   0% [migration/2]
       26     2 root     SW       0   0%   0% [ksoftirqd/2]
       27     2 root     IW       0   0%   0% [kworker/2:0-rcu]
       28     2 root     IW<      0   0%   0% [kworker/2:0H-ev]
       29     2 root     SW       0   0%   0% [cpuhp/3]
       30     2 root     SW       0   0%   0% [migration/3]
       31     2 root     SW       0   0%   0% [ksoftirqd/3]
       33     2 root     IW<      0   0%   0% [kworker/3:0H-ev]
       34     2 root     SW       0   0%   0% [kdevtmpfs]
       35     2 root     IW<      0   0%   0% [kworker/R-inet_]
       37     2 root     IW       0   0%   0% [kworker/2:1-pm]
       38     2 root     SW       0   0%   0% [kauditd]
       39     2 root     SW       0   0%   0% [oom_reaper]
       40     2 root     IW<      0   0%   0% [kworker/R-write]
       41     2 root     SW       0   0%   0% [kcompactd0]
       42     2 root     SWN      0   0%   0% [ksmd]
       43     2 root     SWN      0   0%   0% [khugepaged]
       44     2 root     IW<      0   0%   0% [kworker/R-kinte]
       45     2 root     IW<      0   0%   0% [kworker/R-kbloc]
       46     2 root     IW<      0   0%   0% [kworker/R-blkcg]
       47     2 root     IW<      0   0%   0% [kworker/R-tpm_d]
       48     2 root     IW<      0   0%   0% [kworker/R-ata_s]
       49     2 root     IW<      0   0%   0% [kworker/R-edac-]
       51     2 root     IW<      0   0%   0% [kworker/R-devfr]
       52     2 root     SW       0   0%   0% [watchdogd]
       53     2 root     IW       0   0%   0% [kworker/3:1-eve]
       54     2 root     IW<      0   0%   0% [kworker/0:1H]
       55     2 root     IW<      0   0%   0% [kworker/R-rpcio]
       56     2 root     IW<      0   0%   0% [kworker/R-xprti]
       57     2 root     SW       0   0%   0% [kswapd0]
       58     2 root     IW<      0   0%   0% [kworker/R-nfsio]
       59     2 root     IW       0   0%   0% [kworker/0:2-eve]
       61     2 root     IW<      0   0%   0% [kworker/R-nvme-]
       62     2 root     IW<      0   0%   0% [kworker/R-nvme-]
       63     2 root     IW<      0   0%   0% [kworker/R-nvme-]
       65     2 root     IW<      0   0%   0% [kworker/R-stmma]
       66     2 root     IW       0   0%   0% [kworker/u8:2-ev]
       67     2 root     IW       0   0%   0% [kworker/3:2]
       69     2 root     SW       0   0%   0% [ubi_bgt0d]
       70     2 root     SW       0   0%   0% [ubifs_bgt0_4]
      134     2 root     IW<      0   0%   0% [kworker/1:1H]
      136     2 root     IW<      0   0%   0% [kworker/2:1H]
      138     2 root     IW<      0   0%   0% [kworker/3:1H]
      280     2 root     IW       0   0%   0% [kworker/1:2-mm_]
      300     2 root     IW       0   0%   0% [kworker/u8:3-ev]

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
