### PR TITLE
@FIR-782 Llama.cpp: Partial Offloading of Tsavorite Operations

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -941,10 +941,9 @@ static void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct gg
                 }
 		// Below Code is Optimization which i am disabling for now since we have not implemented other
 		// Operation at tsavorite
-            } else if (cur_backend_id != -1 || (node->op == GGML_OP_UNARY)) {
-                //ggml_backend_sched_set_if_supported(sched, node, cur_backend_id, node_backend_id);
+            } else { 
                 ggml_backend_sched_set_if_supported(sched, node, 0, node_backend_id);
-            }
+	    }
         }
     }
     // expand gpu up

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -35,7 +35,8 @@ cd ../../
 #Compile for posix with build-posix as a target folder
 
 echo 'building llama.cp, ggml for tsavorite  and other binary for posix'
-cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix
+#cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix
+cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DCMAKE_C_FLAGS="-DGGML_PERF"   -DCMAKE_CXX_FLAGS="-DGGML_PERF"
 cmake --build build-posix --config Release
 
 #Compile for fpga with build-fpga as a target folder
@@ -43,7 +44,8 @@ cmake --build build-posix --config Release
 echo 'building llama.cp, ggml for tsavorite  and other binary for fpga'
 export CC="/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-gcc"
 export CXX="/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-g++"
-cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga
+#cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga
+cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga -DCMAKE_C_FLAGS="-DGGML_PERF"   -DCMAKE_CXX_FLAGS="-DGGML_PERF"
 cmake --build build-fpga --config Release
 
 

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -35,7 +35,6 @@ cd ../../
 #Compile for posix with build-posix as a target folder
 
 echo 'building llama.cp, ggml for tsavorite  and other binary for posix'
-#cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix
 cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DCMAKE_C_FLAGS="-DGGML_PERF"   -DCMAKE_CXX_FLAGS="-DGGML_PERF"
 cmake --build build-posix --config Release
 
@@ -44,7 +43,6 @@ cmake --build build-posix --config Release
 echo 'building llama.cp, ggml for tsavorite  and other binary for fpga'
 export CC="/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-gcc"
 export CXX="/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-g++"
-#cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga
 cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga -DCMAKE_C_FLAGS="-DGGML_PERF"   -DCMAKE_CXX_FLAGS="-DGGML_PERF"
 cmake --build build-fpga --config Release
 


### PR DESCRIPTION
**LOG After applying this change**
[akapoor@wssw01 llama.cpp]$ ./build-posix/bin/llama-cli -p "my cat's name is" -m /proj/work/akapoor/llama.cpp-may22/llama.cpp/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf  --device tsavorite -c 12288 --temp 0.0 --n-predict 1 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5  --no-warmup
 my cat's name is L

llama_perf_sampler_print:    sampling time =       2.06 ms /     8 runs   (    0.26 ms per token,  3887.27 tokens per second)

llama_perf_context_print:        load time =   31290.60 ms
llama_perf_context_print: prompt eval time =   30684.42 ms /     7 tokens ( 4383.49 ms per token,     0.23 tokens per second)
llama_perf_context_print:        eval time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:       total time =   31293.03 ms /     8 tokens

=== GGML Perf Summary ===
  Op              :    Runs        Total us            Avg us
  ADD             :      44         5982312         135961.64
    [TSAVORITE ] :      44         5982312         135961.64
  MUL             :      67        14356543         214276.76
    [TSAVORITE ] :      67        14356543         214276.76
  RMS_NORM        :     179            5390             30.11
    [CPU       ] :     179            5390             30.11
  MUL_MAT         :     721         7447504          10329.41
    [CPU       ] :     721         7447504          10329.41
  CPY             :     171            1061              6.20
    [CPU       ] :     171            1061              6.20
  CONT            :      87             339              3.90
    [CPU       ] :      87             339              3.90
  RESHAPE         :     322             156              0.48
    [CPU       ] :     322             156              0.48
  VIEW            :     291              52              0.18
    [CPU       ] :     291              52              0.18
  PERMUTE         :     310              48              0.15
    [CPU       ] :     310              48              0.15
  TRANSPOSE       :      66              19              0.29
    [CPU       ] :      66              19              0.29
  GET_ROWS        :      10            9980            998.00
    [CPU       ] :      10            9980            998.00
  SOFT_MAX        :      87            5937             68.24
    [CPU       ] :      87            5937             68.24
  ROPE            :     175            4274             24.42
    [CPU       ] :     175            4274             24.42
  UNARY           :      22         8294387         377017.59
    [TSAVORITE ] :      22         8294387         377017.59
    -> SILU        :      22         8294387         377017.59

GGML Tsavorite Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call  Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1      4.000     4.000     4.000  [ 0%] GGML Tsavorite 
========================================================================================================================
    1  32872.000 32872.000 32872.000  [100%] TOTAL
========================================================================================================================

[akapoor@wssw01 llama.cpp]$ 
[akapoor@wssw01 llama.cpp]$ 


**Log before this change**

[akapoor@wssw01 llama.cpp]$ ./build-posix/bin/llama-cli -p "my cat's name is" -m /proj/work/akapoor/llama.cpp-may22/llama.cpp/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf  --device tsavorite -c 12288 --temp 0.0 --n-predict 1 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5  --no-warmup
 my cat's name is L



llama_perf_sampler_print:    sampling time =       2.02 ms /     8 runs   (    0.25 ms per token,  3966.29 tokens per second)llama_perf_context_print:        load time =   16983.31 ms
llama_perf_context_print: prompt eval time =   16428.90 ms /     7 tokens ( 2346.99 ms per token,     0.43 tokens per second)
llama_perf_context_print:        eval time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:       total time =   16985.71 ms /     8 tokens

=== GGML Perf Summary ===
  Op              :    Runs        Total us            Avg us
  ADD             :     171           28077            164.19
    [CPU       ] :     170            5135             30.21
    [TSAVORITE ] :       1           22942          22942.00
  MUL             :     133         6164882          46352.50
    [CPU       ] :      88            7098             80.66
    [TSAVORITE ] :      45         6157784         136839.64
  RMS_NORM        :     180            3266             18.14
    [CPU       ] :     180            3266             18.14
  MUL_MAT         :     713         7003799           9823.00
    [CPU       ] :     713         7003799           9823.00
  CPY             :     170            1426              8.39
    [CPU       ] :     170            1426              8.39
  CONT            :      86             264              3.07
    [CPU       ] :      86             264              3.07
  RESHAPE         :     310             183              0.59
    [CPU       ] :     310             183              0.59
  VIEW            :     294              42              0.14
    [CPU       ] :     294              42              0.14
  PERMUTE         :     303              68              0.22
    [CPU       ] :     303              68              0.22
  TRANSPOSE       :      78              19              0.24
    [CPU       ] :      78              19              0.24
  GET_ROWS        :      11            6916            628.73
    [CPU       ] :      11            6916            628.73
  SOFT_MAX        :      88            5600             63.64
    [CPU       ] :      88            5600             63.64
  ROPE            :     170            2998             17.64
    [CPU       ] :     170            2998             17.64
  UNARY           :      22         8308663         377666.50
    [TSAVORITE ] :      22         8308663         377666.50
    -> SILU        :      22         8308663         377666.50

GGML Tsavorite Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call  Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1      2.000     2.000     2.000  [ 0%] GGML Tsavorite 
========================================================================================================================
    1  18573.000 18573.000 18573.000  [100%] TOTAL
========================================================================================================================

[akapoor@wssw01 llama.cpp]$ 
[akapoor@wssw01 llama.cpp]$ 






**#############################
10 Token Generation also correct and same with and without tsavorite at Posix**

[akapoor@wssw01 llama.cpp]$ ./build-posix/bin/llama-cli -p "my cat's name is" -m /proj/work/akapoor/llama.cpp-may22/llama.cpp/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf  --device tsavorite -c 12288 --temp 0.0 --n-predict 10 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5  --no-warmup
 my cat's name is Luna.
I'm a cat person

llama_perf_sampler_print:    sampling time =      23.47 ms /    17 runs   (    1.38 ms per token,   724.30 tokens per second)

llama_perf_context_print:        load time =   31072.93 ms
llama_perf_context_print: prompt eval time =   30598.50 ms /     7 tokens ( 4371.21 ms per token,     0.23 tokens per second)
llama_perf_context_print:        eval time =   40387.30 ms /     9 runs   ( 4487.48 ms per token,     0.22 tokens per second)
llama_perf_context_print:       total time =   71489.50 ms /    16 tokens

=== GGML Perf Summary ===
  Op              :    Runs        Total us            Avg us
  ADD             :     440        13966361          31741.73
    [TSAVORITE ] :     440        13966361          31741.73
  MUL             :     670        33518136          50027.07
    [TSAVORITE ] :     670        33518136          50027.07
  RMS_NORM        :    1734           12275              7.08
    [CPU       ] :    1734           12275              7.08
  MUL_MAT         :    7842        15390785           1962.61
    [CPU       ] :    7842        15390785           1962.61
  CPY             :    1658            3925              2.37
    [CPU       ] :    1658            3925              2.37
  CONT            :     799            1036              1.30
    [CPU       ] :     799            1036              1.30
  RESHAPE         :    3168            1137              0.36
    [CPU       ] :    3168            1137              0.36
  VIEW            :    2959             436              0.15
    [CPU       ] :    2959             436              0.15
  PERMUTE         :    3103             468              0.15
    [CPU       ] :    3103             468              0.15
  TRANSPOSE       :     731             155              0.21
    [CPU       ] :     731             155              0.21
  GET_ROWS        :     109             285              2.61
    [CPU       ] :     109             285              2.61
  SOFT_MAX        :     846           15054             17.79
    [CPU       ] :     846           15054             17.79
  ROPE            :    1653           13117              7.94
    [CPU       ] :    1653           13117              7.94
  UNARY           :     220        19297880          87717.64
    [TSAVORITE ] :     220        19297880          87717.64
    -> SILU        :     220        19297880          87717.64

GGML Tsavorite Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call  Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1      3.000     3.000     3.000  [ 0%] GGML Tsavorite 
========================================================================================================================
    1  73075.000 73075.000 73075.000  [100%] TOTAL
========================================================================================================================

[akapoor@wssw01 llama.cpp]$



[akapoor@wssw01 llama.cpp]$ ./build-posix/bin/llama-cli -p "my cat's name is" -m /proj/work/akapoor/llama.cpp-may22/llama.cpp/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf  --device none -c 12288 --temp 0.0 --n-predict 1 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5  --no-warmup
 my cat's name is L



llama_perf_sampler_print:    sampling time =       2.38 ms /     8 runs   (    0.30 ms per token,  3365.59 tokens per second)llama_perf_context_print:        load time =    2378.95 ms
llama_perf_context_print: prompt eval time =    1909.08 ms /     7 tokens (  272.73 ms per token,     3.67 tokens per second)
llama_perf_context_print:        eval time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:       total time =    2381.67 ms /     8 tokens

=== GGML Perf Summary ===
  Op              :    Runs        Total us            Avg us
  ADD             :     174            5676             32.62
    [CPU       ] :     174            5676             32.62
  MUL             :     268           12641             47.17
    [CPU       ] :     268           12641             47.17
  RMS_NORM        :     176            4137             23.51
    [CPU       ] :     176            4137             23.51
  MUL_MAT         :     707         6371821           9012.48
    [CPU       ] :     707         6371821           9012.48
  CPY             :     171            1058              6.19
    [CPU       ] :     171            1058              6.19
  CONT            :      88             440              5.00
    [CPU       ] :      88             440              5.00
  RESHAPE         :     325             260              0.80
    [CPU       ] :     325             260              0.80
  VIEW            :     283              57              0.20
    [CPU       ] :     283              57              0.20
  PERMUTE         :     285              62              0.22
    [CPU       ] :     285              62              0.22
  TRANSPOSE       :      70              22              0.31
    [CPU       ] :      70              22              0.31
  GET_ROWS        :      12             108              9.00
    [CPU       ] :      12             108              9.00
  SOFT_MAX        :      86            5446             63.33
    [CPU       ] :      86            5446             63.33
  ROPE            :     176            3631             20.63
    [CPU       ] :     176            3631             20.63
  UNARY           :      88           11639            132.26
    [CPU       ] :      88           11639            132.26
    -> SILU        :      88           11639            132.26
[akapoor@wssw01 llama.cpp]$ 

























