### PR TITLE
@FIR-790 -LLama.cpp: Add all Src tensor shape & size

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6641,16 +6641,24 @@ void ggml_perf_write_detailed_csv(struct ggml_cgraph * cgraph, FILE *fp) {
         }
 
         fprintf(fp,
-            "%-12s %-20s %10d %12.3f %10.3f %10ld %10ld %10ld %10ld\n",
+            "%-12s %-20s %10" PRId64 " %12.3f %10.3f %10ld %10ld %10ld %10ld\n",
             ggml_backend_type(node->ggml_compute_backend),
             op_name,
             node->perf_runs,
             t_ms,
             avg_ms,
-            node->ne[0],
-            node->ne[1],
-            node->ne[2],
-            node->ne[3]);
+            node->ne[0], node->ne[1], node->ne[2], node->ne[3]);
+
+        // Loop over all possible source tensors
+        for (int s = 0; s < GGML_MAX_SRC; ++s) {
+            struct ggml_tensor * src = node->src[s];
+            if (src) {
+                fprintf(fp,
+                    "             src%-2d:                             ne[0]=%6ld  ne[1]=%6ld  ne[2]=%6ld  ne[3]=%6ld\n",
+                    s,
+                    src->ne[0], src->ne[1], src->ne[2], src->ne[3]);
+            }
+        }
     }
 
     fprintf(fp, "--------------------------------------------------------------------------------------------------------\n\n");


### PR DESCRIPTION

<img width="1079" alt="Screenshot 2025-07-03 at 12 05 45 PM" src="https://github.com/user-attachments/assets/9eed95e9-35aa-4be8-803e-d271940ebb4a" />
Here are output look like after printing src tensor size/shape

=== GGML Detailed Op Perf (36059.700 ms total) ===
Backend      Op                         Runs     Total ms     Avg ms      ne[0]      ne[1]      ne[2]      ne[3]
CPU          GET_ROWS                      4        9.937      2.484       2048          7          1          1
             src0 :                             ne[0]=  2048  ne[1]= 32003  ne[2]=     1  ne[3]=     1
             src1 :                             ne[0]=     7  ne[1]=     1  ne[2]=     1  ne[3]=     1
CPU          RMS_NORM                      4        0.162      0.041       2048          7          1          1
             src0 :                             ne[0]=  2048  ne[1]=     7  ne[2]=     1  ne[3]=     1
TSAVORITE    MUL                           1      150.026    150.026       2048          7          1          1
             src0 :                             ne[0]=  2048  ne[1]=     7  ne[2]=     1  ne[3]=     1
             src1 :                             ne[0]=  2048  ne[1]=     1  ne[2]=     1  ne[3]=     1
CPU          MUL_MAT                       4       31.865      7.966       2048          7          1          1
             src0 :                             ne[0]=  2048  ne[1]=  2048  ne[2]=     1  ne[3]=     1
             src1 :                             ne[0]=  2048  ne[1]=     7  ne[2]=     1  ne[3]=     1
CPU          RESHAPE                       4        0.032      0.008         64         32          7          1
             src0 :                             ne[0]=  2048  ne[1]=     7  ne[2]=     1  ne[3]=     1
CPU          ROPE                          4        0.282      0.070         64         32          7          1
             src0 :                             ne[0]=    64  ne[1]=    32  ne[2]=     7  ne[3]=     1
             src1 :                             ne[0]=     7  ne[1]=     1  ne[2]=     1  ne[3]=     1
CPU          MUL_MAT                       4        4.767      1.192        256          7          1          1
             src0 :                             ne[0]=  2048  ne[1]=   256  ne[2]=     1  ne[3]=     1
             src1 :                             ne[0]=  2048  ne[1]=     7  ne[2]=     1  ne[3]=     1
CPU          RESHAPE                       3        0.002      0.001         64          4          7          1
             src0 :                             ne[0]=   256  ne[1]=     7  ne[2]=     1  ne[3]=     1
CPU          ROPE                          4        0.044      0.011         64          4          7          1
             src0 :                             ne[0]=    64  ne[1]=     4  ne[2]=     7  ne[3]=     1
             src1 :                             ne[0]=     7  ne[1]=     1  ne[2]=     1  ne[3]=     1
CPU          MUL_MAT                       3        3.539      1.180        256          7          1          1
