### PR TITLE
-corrected fpga LD_LIBRARy_PATH

### DIFF
--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -88,7 +88,7 @@ fi
 cat > ./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh << EOL
 #!/bin/bash
 # Set up library paths for GCC 13.3.0 compatibility
-export LD_LIBRARY_PATH="/proj/local/gcc-13.3.0/lib64:\${LD_LIBRARY_PATH}:\$(pwd)"
+export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}:\$(pwd)
 tsi_kernels=("add" "sub" "mult" "div" "abs" "inv" "neg" "sin" "sqrt" "sqr" "sigmoid" "silu")
 
 for kernel in "\${tsi_kernels[@]}"; do


### PR DESCRIPTION
**[ggml_log_fpga.txt](https://github.com/user-attachments/files/22534812/ggml_log_fpga.txt)**

**llama log is below and other test logs are attached**

root@agilex7_dk_si_agf014ea:/usr/bin/tsi/v0.1.1.tsv37_09_25_2025/bin# ./run_llama_cli.sh 
 is Luna.




llama_perf_sampler_print:    sampling time =     106.58 ms /    11 runs   (    9.69 ms per token,   103.21 tokens per second)
llama_perf_context_print:        load time =   53196.01 ms
llama_perf_context_print: prompt eval time =   42531.56 ms /     6 tokens ( 7088.59 ms per token,     0.14 tokens per second)
llama_perf_context_print:        eval time =   48150.09 ms /     4 runs   (12037.52 ms per token,     0.08 tokens per second)
llama_perf_context_print:       total time =  101479.96 ms /    10 tokens

=== GGML Perf Summary ===
  Op                   Runs        Total us            Avg us

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    43.7950   43.7950     35.2130  [4.22e-02%] [Thread] tsi::runtime::TsavRTFPGA::initialize
    1     4.3630    4.3630      4.3630  └─ [4.21e-03%] tsi::runtime::TsavRTFPGA::initializeQueues
    1     2.3730    2.3730      1.5720  └─ [2.29e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    2     0.8010    0.4005      0.8010    └─ [7.73e-04%] tsi::runtime::executeWithTimeout
    1     1.8460    1.8460      1.8460  └─ [1.78e-03%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  870   484.2840    0.5566      0.0000  [4.67e-01%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
  870   1.01e+05  115.5797    1.01e+05  └─ [97.00%] TXE 0 Idle
  440   122.1554    0.2776    122.1554  └─ [1.18e-01%] [ txe_mult ]
  430   120.0318    0.2791    120.0318  └─ [1.16e-01%] [ txe_add ]
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  870   578.4840    0.6649    558.1550  [5.58e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
  870    20.3290    0.0234     20.3290  └─ [1.96e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  870   854.8330    0.9826     30.2820  [8.25e-01%] [Thread] tsi::runtime::TsavRT::processResponses
  870   824.5510    0.9478    824.5510  └─ [7.95e-01%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1    76.7290   76.7290     59.0200  [7.40e-02%] [Thread] tsi::runtime::TsavRTFPGA::finalize
    1    17.7090   17.7090     17.7090  └─ [1.71e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  872    47.3590    0.0543     47.3590  [4.57e-02%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     5.0720    5.0720      5.0720  [4.89e-03%] [Thread] OPU 
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  870   232.9330    0.2677    232.9330  [2.25e-01%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  870    54.3180    0.0624     54.3180  [5.24e-02%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  870    65.4520    0.0752     65.4520  [6.31e-02%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  870    10.8700    0.0125     10.8700  [1.05e-02%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    -   1.04e+05    0.0000    1.04e+05  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.7810
------------------------------------------------------------------------------------------------------------------------

