### PR TITLE
@FIR-991: Add FP16 support to ggml kernel and add support for both Fp…

### DIFF
--- a/ggml/include/ggml-tsavorite.h
+++ b/ggml/include/ggml-tsavorite.h
@@ -164,6 +164,18 @@ extern void _mlir_ciface_txe_sin_host(void *a, void *res);
 extern void _mlir_ciface_txe_sigmoid_host(void *a, void *res);
 extern void _mlir_ciface_txe_silu_host(void *a, void *res);
 extern void _mlir_ciface_txe_rms_norm_host(void *a, void *res, void *buf);
+extern void _mlir_ciface_txe_add_16_host(void *a, void *b, void *res);
+extern void _mlir_ciface_txe_sub_16_host(void *a, void *b, void *res);
+extern void _mlir_ciface_txe_mult_16_host(void *a, void *b, void *res);
+extern void _mlir_ciface_txe_div_16_host(void *a, void *b, void *res);
+extern void _mlir_ciface_txe_sqrt_16_host(void *a, void *res);
+extern void _mlir_ciface_txe_sqr_16_host(void *a, void *res);
+extern void _mlir_ciface_txe_neg_16_host(void *a, void *res);
+extern void _mlir_ciface_txe_abs_16_host(void *a, void *res);
+extern void _mlir_ciface_txe_sin_16_host(void *a, void *res);
+extern void _mlir_ciface_txe_sigmoid_16_host(void *a, void *res);
+extern void _mlir_ciface_txe_silu_16_host(void *a, void *res);
+extern void _mlir_ciface_txe_rms_norm_16_host(void *a, void *res, void *buf);
 
 extern void ggml_tsi_log_tensor_data(tensor_log log_data);
 

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -72,9 +72,14 @@ struct _txe_device_t {
   } stats;
 };
 
+// data Type
+#define DATA_TYPE_F32_INDEX 0
+#define DATA_TYPE_F16_INDEX 1
+#define DATA_TYPE_MAX_INDEX 2
+
 struct _txe_compute_pipeline_state_t {
-  void (*_mlir_fptr_2_input)(void *, void *, void *);
-  void (*_mlir_fptr_1_input)(void *, void *);
+  void (*_mlir_fptr_2_input[DATA_TYPE_MAX_INDEX])(void *, void *, void *);
+  void (*_mlir_fptr_1_input[DATA_TYPE_MAX_INDEX])(void *, void *);
   std::string kernel_name;
   int reserved;
 };
@@ -399,67 +404,81 @@ static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_
   switch (kernel_type) {
       case GGML_TSAVORITE_KERNEL_TYPE_ADD:
           if (ggml_tsavorite_kernel_mode_flag == GGML_TSAVORITE_KERNEL_MODE_CPU)
-              kernel_pipeline->_mlir_fptr_2_input = &_mlir_ciface_txe_add_test;
-          else
-              kernel_pipeline->_mlir_fptr_2_input = &_mlir_ciface_txe_add_host;
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_test;
+          else {
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host;
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_add_16_host;
+	  }
           kernel_pipeline->kernel_name = "TXE_ADD";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_SUB:
-          kernel_pipeline->_mlir_fptr_2_input = &_mlir_ciface_txe_sub_host;
+          kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_sub_host;
+          kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_sub_16_host;
           kernel_pipeline->kernel_name = "TXE_SUB";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_MULT:
           if (ggml_tsavorite_kernel_mode_flag == GGML_TSAVORITE_KERNEL_MODE_CPU)
-              kernel_pipeline->_mlir_fptr_2_input = &_mlir_ciface_txe_mult_test;
-          else
-              kernel_pipeline->_mlir_fptr_2_input = &_mlir_ciface_txe_mult_host;
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_test;
+          else {
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_host;
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_mult_16_host;
+	  }
           kernel_pipeline->kernel_name = "TXE_MULT";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_DIV:
-          kernel_pipeline->_mlir_fptr_2_input = &_mlir_ciface_txe_div_host;
+          kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_div_host;
+          kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_div_16_host;
           kernel_pipeline->kernel_name = "TXE_DIV";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_SQRT:
-          kernel_pipeline->_mlir_fptr_1_input = &_mlir_ciface_txe_sqrt_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_sqrt_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_sqrt_16_host;
           kernel_pipeline->kernel_name = "TXE_SQRT";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_SQR:
-          kernel_pipeline->_mlir_fptr_1_input = &_mlir_ciface_txe_sqr_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_sqr_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_sqr_16_host;
           kernel_pipeline->kernel_name = "TXE_SQR";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_NEG:
-          kernel_pipeline->_mlir_fptr_1_input = &_mlir_ciface_txe_neg_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_neg_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_neg_16_host;
           kernel_pipeline->kernel_name = "TXE_NEG";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_ABS:
-          kernel_pipeline->_mlir_fptr_1_input = &_mlir_ciface_txe_abs_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_abs_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_abs_16_host;
           kernel_pipeline->kernel_name = "TXE_ABS";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_SIN:
-          kernel_pipeline->_mlir_fptr_1_input = &_mlir_ciface_txe_sin_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_sin_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_sin_16_host;
           kernel_pipeline->kernel_name = "TXE_SIN";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_SIGMOID:
-          kernel_pipeline->_mlir_fptr_1_input = &_mlir_ciface_txe_sigmoid_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_sigmoid_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_sigmoid_16_host;
           kernel_pipeline->kernel_name = "TXE_SIGMOID";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_SILU:
-          kernel_pipeline->_mlir_fptr_1_input = &_mlir_ciface_txe_silu_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_silu_host;
+          kernel_pipeline->_mlir_fptr_1_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_silu_16_host;
           kernel_pipeline->kernel_name = "TXE_SILU";
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_RMS_NORM:
-          kernel_pipeline->_mlir_fptr_2_input = &_mlir_ciface_txe_rms_norm_host;
+          kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_rms_norm_host;
+          kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_rms_norm_16_host;
           kernel_pipeline->kernel_name = "TXE_RMS_NORM";
           flag = true;
           break;
@@ -690,6 +709,20 @@ static ggml_backend_tsavorite_buffer_s ggml_tsavorite_get_buffer(struct ggml_ten
     return tsi_nil;
 }
 #endif
+bool
+check_tensor_output_input_data_same_mode(const struct ggml_tensor *op) {
+  uint32_t tensor_data_type = op->type;
+  for (size_t i = 0; i < GGML_MAX_DIMS; ++i) {
+    if (op->src[i] != NULL) {
+	if(op->src[i]->type == GGML_TYPE_F32 || op->src[i]->type == GGML_TYPE_F32)      {
+        if(tensor_data_type != op->src[i]->type)
+		return false;
+        } else
+		return false;
+    }
+  }
+  return true;
+}
 
 static bool ggml_tsavorite_supports_op(const struct ggml_backend_tsavorite_device_context *ctx_dev,
                                        const struct ggml_tensor *op) {
@@ -702,7 +735,9 @@ static bool ggml_tsavorite_supports_op(const struct ggml_backend_tsavorite_devic
     }
   }
 
-  if (op->type != GGML_TYPE_F32)
+  if (op->type != GGML_TYPE_F32 || op->type != GGML_TYPE_F16)
+    return false;
+  if (!check_tensor_output_input_data_same_mode(op))
     return false;
   switch (op->op) {
   case GGML_OP_NONE:
@@ -860,6 +895,7 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
   tensor_log log_data;
 
   for (int i = 0; i < cgraph->n_nodes; i++) {
+     int32_t kernel_sub_type=-1;
 #ifdef GGML_PERF
     int64_t t_start = ggml_time_us();
 #endif
@@ -868,7 +904,15 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
     src1 = node->src[1];
     min_num_of_elem = 0;
     max_num_of_elem = 0;
+    if(node->type == GGML_TYPE_F32 && src0->type == GGML_TYPE_F32 && (!src1 || src1->type == GGML_TYPE_F32))
+	    kernel_sub_type = DATA_TYPE_F32_INDEX;
+    if(node->type == GGML_TYPE_F16 && src0->type == GGML_TYPE_F16 && (!src1 || src1->type == GGML_TYPE_F16))
+	    kernel_sub_type = DATA_TYPE_F16_INDEX;
 
+    if(kernel_sub_type == -1) {
+        printf("\n kernel_sub_type not suppored\n");
+        return GGML_STATUS_ABORTED;
+    }
     switch (node->op) {
     case GGML_OP_ADD:
       kernel_type = GGML_TSAVORITE_KERNEL_TYPE_ADD;
@@ -933,8 +977,8 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
     }
 
     if (!ctx->kernels[kernel_type].pipeline ||
-        (!ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input &&
-         !ctx->kernels[kernel_type].pipeline->_mlir_fptr_1_input)) {
+        (!ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type] &&
+         !ctx->kernels[kernel_type].pipeline->_mlir_fptr_1_input[kernel_sub_type])) {
       GGML_TSAVORITE_LOG_ERROR("Kernel Type %d, not supported \n", kernel_type);
       return GGML_STATUS_ABORTED;
     }
@@ -1045,7 +1089,7 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
               srcP0->data =  srcP0->base = (void *)(src0_ptr + r * ne10);
               nodeP->data =  nodeP->base = (void *)(dst_ptr + r * ne10);
               // kernel call
-              ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input(srcP0, srcP1, nodeP);
+              ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, srcP1, nodeP);
               ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
           }
         }
@@ -1159,11 +1203,11 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
 			strides = strides * src0->ne[i];
 	    }
 
-            ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input(srcP0, nodeP, buf);
+            ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, nodeP, buf);
         }
         else {
             // kernel call
-            ctx->kernels[kernel_type].pipeline->_mlir_fptr_1_input(srcP0, nodeP);
+            ctx->kernels[kernel_type].pipeline->_mlir_fptr_1_input[kernel_sub_type](srcP0, nodeP);
 	}
         ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
 
@@ -1878,7 +1922,9 @@ static bool ggml_backend_tsavorite_device_supports_buft(ggml_backend_dev_t dev,
 // ggml_backend_sched_backend_id_from_cur  -> ggml_backend_offload_op ->
 static bool ggml_backend_tsavorite_device_offload_op(ggml_backend_dev_t dev,
                                                      const struct ggml_tensor *op) {
-  if (op->type != GGML_TYPE_F32)
+  if (op->type != GGML_TYPE_F32 || op->type != GGML_TYPE_F16)
+    return false;
+  if (!check_tensor_output_input_data_same_mode(op))
     return false;
   switch (op->op) {
   case GGML_OP_NONE:

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -18,7 +18,7 @@ pip install onnxruntime-training
 #build TSI kernels for the Tsavorite backend
 #First for FPGA
 
-echo 'creating fpga kernel'
+#echo 'creating fpga kernel'
 cd fpga-kernel
 cmake -B build-fpga
 ./create-all-kernels.sh
@@ -90,7 +90,7 @@ cat > ./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh << EOL
 # Set up library paths for GCC 13.3.0 compatibility
 export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}:\$(pwd)
 
-tsi_kernels=("add" "sub" "mult" "div" "abs" "inv" "neg" "sin" "sqrt" "sqr" "sigmoid" "silu" "rms_norm")
+tsi_kernels=("add" "sub" "mult" "div" "abs" "inv" "neg" "sin" "sqrt" "sqr" "sigmoid" "silu" "rms_norm" "add_16" "sub_16" "mult_16" "div_16" "abs_16" "inv_16" "neg_16" "sin_16" "sqrt_16" "sqr_16" "sigmoid_16" "silu_16" "rms_norm_16")
 
 for kernel in "\${tsi_kernels[@]}"; do
     mkdir -p ${TSI_BLOB_INSTALL_DIR}/txe_\$kernel


### PR DESCRIPTION
…32 and 16 OPs support

The changes consists of adding FP32 and FP16 kernels as well as enable all currently supported OPs as FP16

The test results are as follows
with FP16 on Posix
[atrivedi@wssw01 llama.cpp]$ build-posix/bin/llama-cli -p "My cat's name" -m /proj/rel/sw/ggml/models_bf16/mradermacher/gemma-3N-LyricGen/gemma-3N-LyricGen-fp16-0.1.f16.gguf --device tSavorite -c 12288 --temp 0.0 --n-predict 10 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5 --no-warmup --no-display-prompt --single-turn That's wonderful! It sounds like you have

llama_perf_sampler_print:    sampling time =     171.91 ms /    24 runs   (    7.16 ms per token,   139.61 tokens per second)
llama_perf_context_print:        load time =   20008.14 ms
llama_perf_context_print: prompt eval time =   17557.56 ms /    14 tokens ( 1254.11 ms per token,     0.80 tokens per second)
llama_perf_context_print:        eval time =   16555.33 ms /     9 runs   ( 1839.48 ms per token,     0.54 tokens per second)
llama_perf_context_print:       total time =   36747.20 ms /    23 tokens

=== GGML Perf Summary ===
  Op                   Runs        Total us            Avg us

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    27.6330   27.6330      8.0980  [7.12e-02%] [Thread] tsi::runtime::TsavRTPosix::initialize
    1    19.3560   19.3560      4.4590  └─ [4.99e-02%] tsi::runtime::TsavRTPosix::initializeQueues
    1    13.4930   13.4930     13.4930    └─ [3.48e-02%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     1.2510    1.2510      1.2510    └─ [3.22e-03%] tsi::runtime::TsavRTPosix::requestTXEDevice
    1     0.1530    0.1530      0.0940    └─ [3.94e-04%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0590    0.0590      0.0590      └─ [1.52e-04%] tsi::runtime::executeWithTimeout
    1     0.1790    0.1790      0.1790  └─ [4.61e-04%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     4.1200    4.1200      3.4510  [1.06e-02%] [Thread] tsi::runtime::TsavRT::finalize
    1     0.6490    0.6490      0.0570  └─ [1.67e-03%] tsi::runtime::TsavRTPosix::detachFromTXEDevice
    1     0.5920    0.5920      0.1230    └─ [1.53e-03%] tsi::runtime::TsavRT::executeSyncCommand
    1     0.4210    0.4210      0.4210      └─ [1.08e-03%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     0.0480    0.0480      0.0430      └─ [1.24e-04%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0050    0.0050      0.0050        └─ [1.29e-05%] tsi::runtime::executeWithTimeout
    2     0.0200    0.0100      0.0200  └─ [5.15e-05%] tsi::runtime::TsavRT::deallocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    2    13.9800    6.9900      0.1340  [3.60e-02%] [Thread] tsi::runtime::TsavRT::processResponses
    2    13.8460    6.9230     13.8460  └─ [3.57e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     0.0530    0.0530      0.0530  [1.37e-04%] [Thread] OPU
========================================================================================================================
    - 38811.5460    0.0000  38811.5460  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.6667
------------------------------------------------------------------------------------------------------------------------

On FPGA with current regressions run for FP32 and for FP16 the model works but the models are upscaled to FP32 so need to do more testing for right model root@agilex7_dk_si_agf014ea:/usr/bin/tsi/v0.1.1.tsv37_09_25_2025/bin# ./run_llama_cli.sh
 is Luna.

llama_perf_sampler_print:    sampling time =     106.50 ms /    11 runs   (    9.68 ms per token,   103.29 tokens per second)
llama_perf_context_print:        load time =   53278.10 ms
llama_perf_context_print: prompt eval time =   42451.91 ms /     6 tokens ( 7075.32 ms per token,     0.14 tokens per second)
llama_perf_context_print:        eval time =   49423.57 ms /     4 runs   (12355.89 ms per token,     0.08 tokens per second)
llama_perf_context_print:       total time =  102841.04 ms /    10 tokens

=== GGML Perf Summary ===
  Op                   Runs        Total us            Avg us

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    50.3520   50.3520     41.2940  [4.79e-02%] [Thread] tsi::runtime::TsavRTFPGA::initialize
    1     4.6280    4.6280      4.6280  └─ [4.40e-03%] tsi::runtime::TsavRTFPGA::initializeQueues
    1     2.4910    2.4910      1.6500  └─ [2.37e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    2     0.8410    0.4205      0.8410    └─ [8.00e-04%] tsi::runtime::executeWithTimeout
    1     1.9390    1.9390      1.9390  └─ [1.85e-03%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1    90.5270   90.5270     70.6740  [8.61e-02%] [Thread] tsi::runtime::TsavRTFPGA::finalize
    1    19.8530   19.8530     19.8530  └─ [1.89e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     8.5440    8.5440      8.5440  [8.13e-03%] [Thread] OPU
========================================================================================================================
    -   1.05e+05    0.0000    1.05e+05  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         0.0000         0.0000
------------------------------------------------------------------------------------------------------------------------

root@agilex7_dk_si_agf014ea:/usr/bin/tsi/v0.1.1.tsv37_09_25_2025/bin# Terminating...

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
