### PR TITLE
@FIR-999 - Create SOFT_MAX for tsavorite-backend for GGML

### DIFF
--- a/ggml/include/ggml-tsavorite.h
+++ b/ggml/include/ggml-tsavorite.h
@@ -140,6 +140,8 @@ enum ggml_tsavorite_kernel_type {
   GGML_TSAVORITE_KERNEL_TYPE_GEGLU_ERF,
   GGML_TSAVORITE_KERNEL_TYPE_GEGLU_QUICK,
 
+  GGML_TSAVORITE_KERNEL_TYPE_SOFT_MAX,
+
   GGML_TSAVORITE_KERNEL_TYPE_COUNT
 };
 
@@ -156,7 +158,7 @@ typedef struct tensor_log_ {
   uint32_t leaf2_len;
   uint32_t node_len;
   enum ggml_tsavorite_tensor_data_type data_type;
-  enum ggml_tsavorite_kernel_type kernel_type;
+  enum ggml_op kernel_type;
   uint64_t num_of_op;
   FILE *log_file;
   const ggml_tensor *tensor;
@@ -185,6 +187,7 @@ extern void _mlir_ciface_txe_sin_host(void *a, void *res);
 extern void _mlir_ciface_txe_sigmoid_host(void *a, void *res);
 extern void _mlir_ciface_txe_silu_host(void *a, void *res);
 extern void _mlir_ciface_txe_swiglu_host(void *a, void *b, void *res);
+extern void _mlir_ciface_txe_soft_max_host(void *a, void *b, void *res, void *buf);
 extern void _mlir_ciface_txe_rms_norm_host(void *a, void *res, void *buf);
 
 /* 

--- a/ggml/include/ggml-tsavorite.h
+++ b/ggml/include/ggml-tsavorite.h
@@ -213,7 +213,7 @@ extern void ggml_tsi_log_tensor_data(tensor_log log_data);
 
 // GGML supports tensors with a maximum rank of 4
 #define MEM_REF_DESCRIPTOR_RANK 4
-#define TSI_TVU_LOAD_SIZE 32
+#define TSI_TVU_MEM_ALIGN 128
 
 //
 // backend API

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -52,6 +52,38 @@ typedef struct _txe_command_buffer_t *txe_command_buffer_s;
 #endif /* USE_COMMAND_BUFFERS */
 typedef struct ggml_backend_tsavorite_buffer ggml_backend_tsavorite_buffer_s;
 
+const int Rank = MEM_REF_DESCRIPTOR_RANK;
+MemRefDescriptor<Rank>* glob_buf;
+
+template<int Rank>
+// Assumes tsi_alloc is available and returns a pointer to allocated memory
+static MemRefDescriptor<Rank>* create_mlir_buf(int K) {
+    // TVU load size (e.g., 32 for 1024-bit vector with 32-bit elements)
+    const int32_t mem_align = TSI_TVU_MEM_ALIGN;
+    // we are supporting only float or F32
+    int data_type_len = 4;
+    // MemRef Header also added
+    int total_bytes = (sizeof(MemRefDescriptor<Rank>) + 4*K);
+
+    // Round up K to the next multiple of tvu_size
+    int32_t total_align_bytes = ((total_bytes % mem_align) != 0) ? ((total_bytes / mem_align) + 1) * mem_align : total_bytes;
+
+    // Allocate memory dynamically: space for header + data
+    MemRefDescriptor<Rank>* header = (MemRefDescriptor<Rank>*) tsi_alloc(total_align_bytes);
+
+    if (!header) {
+        return header;
+    }
+    // Advance pointer to skip header and get to data
+    int32_t* data = (int32_t*)(header + 1);
+
+    for (int32_t i = 0; i < K; ++i) {
+        data[i] = 0;
+    }
+    return header;
+}
+
+
 struct _txe_device_t {
   char name[100];
   uint32_t max_buf_len;
@@ -343,7 +375,6 @@ static void _mlir_ciface_txe_add_test (void *src0, void *src1, void *res)
     if (!src0 || !src1 || !res)
         return;
 
-    const int Rank = MEM_REF_DESCRIPTOR_RANK;
     MemRefDescriptor<Rank> *srcP0, *srcP1, *nodeP;
     srcP0 = (MemRefDescriptor<Rank> *)src0;
     srcP1 = (MemRefDescriptor<Rank> *)src1;
@@ -368,7 +399,6 @@ static void _mlir_ciface_txe_mult_test (void *src0, void *src1, void *res)
     if (!src0 || !src1 || !res)
         return;
 
-    const int Rank = MEM_REF_DESCRIPTOR_RANK;
     MemRefDescriptor<Rank> *srcP0, *srcP1, *nodeP;
     srcP0 = (MemRefDescriptor<Rank> *)src0;
     srcP1 = (MemRefDescriptor<Rank> *)src1;
@@ -489,6 +519,7 @@ static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_
       case GGML_TSAVORITE_KERNEL_TYPE_SOFT_MAX:
 	  {
           kernel_pipeline->_mlir_fptr_3_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_soft_max_host;
+          //kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_soft_max_16_host;
           kernel_pipeline->kernel_name = "TXE_SOFTMAX";
           flag = true;
           break;
@@ -553,7 +584,11 @@ static void *ggml_tsavorite_host_malloc(size_t n) {
   void *data = NULL;
   GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
   GGML_TSAVORITE_LOG_INFO("\n Allocating memory from tsi_alloc with size  %ld \n", n);
-  data = tsi_alloc(n);
+
+  const int32_t mem_align = TSI_TVU_MEM_ALIGN;
+  int total_align_bytes = (n/mem_align +1)*mem_align;
+  data = tsi_alloc(total_align_bytes);
+
   GGML_TSAVORITE_LOG_CONT("\n Allocating memory from tsi_alloc with size  %ld starting memory %p\n",
                           n, data);
 
@@ -643,6 +678,12 @@ static struct ggml_backend_tsavorite_context *ggml_tsavorite_init(ggml_backend_d
     GGML_TSAVORITE_KERNEL(GGML_TSAVORITE_KERNEL_TYPE_RMS_NORM,           true);
     GGML_TSAVORITE_KERNEL(GGML_TSAVORITE_KERNEL_TYPE_SWIGLU,             true);
     GGML_TSAVORITE_KERNEL(GGML_TSAVORITE_KERNEL_TYPE_SOFT_MAX,           true);
+  }
+  glob_buf = create_mlir_buf<Rank>(96);
+  if (!glob_buf) {
+      GGML_TSAVORITE_LOG_ERROR("tsi_alloc failied for creating memory for buf \n");
+      free(ctx);
+      return NULL;
   }
 
   GGML_TSAVORITE_LOG_INFO("End %s\n", __func__);
@@ -755,7 +796,9 @@ static bool ggml_tsavorite_supports_op(const struct ggml_backend_tsavorite_devic
   case GGML_OP_SQR:
   case GGML_OP_SIN:
   case GGML_OP_RMS_NORM:
-  case GGML_OP_SOFT_MAX:
+  #ifdef GGML_TARGET_POSIX
+      case GGML_OP_SOFT_MAX:
+  #endif /* GGML_TARGET_POSIX */
     break;
   case GGML_OP_GLU:
     {
@@ -811,31 +854,6 @@ static void ggml_tsavorite_decompose_unary_kernel(uint32_t num_elem, ggml_tensor
   return;
 }
 
-template<int Rank>
-// Assumes tsi_alloc is available and returns a pointer to allocated memory
-static MemRefDescriptor<Rank>* create_mlir_buf(int K) {
-    // TVU load size (e.g., 32 for 1024-bit vector with 32-bit elements)
-    const int32_t tvu_size = TSI_TVU_LOAD_SIZE;
-
-    // Round up K to the next multiple of tvu_size
-    int32_t num_of_elem = ((K % tvu_size) != 0) ? ((K / tvu_size) + 1) * tvu_size : K;
-
-    // Allocate memory dynamically: space for header + data
-    MemRefDescriptor<Rank>* header = (MemRefDescriptor<Rank>*) tsi_alloc(
-        sizeof(MemRefDescriptor<Rank>) + num_of_elem * sizeof(float)
-    );
-
-    if (!header) {
-        return header;
-    }
-    // Advance pointer to skip header and get to data
-    int32_t* data = (int32_t*)(header + 1);
-
-    for (int32_t i = 0; i < num_of_elem; ++i) {
-        data[i] = 0;
-    }
-    return header;
-}
 
 static enum ggml_tsavorite_kernel_type tsi_glu_kernel_type(struct ggml_tensor *node) {
     const ggml_glu_op op = ggml_get_glu_op(node);
@@ -926,7 +944,6 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
     return GGML_STATUS_FAILED;
   }
   // MemRefDescriptor
-  const int Rank = MEM_REF_DESCRIPTOR_RANK;
   MemRefDescriptor<Rank> *srcP0, *srcP1, *nodeP;
   struct ggml_tensor *src0, *src1, *node;
   uint32_t num_elem_src0, num_elem_src1, num_elem_node;
@@ -937,14 +954,6 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
   enum ggml_tsavorite_input_tensors_count num_of_input_tensors;
   tensor_log log_data;
 
-  MemRefDescriptor<Rank>* buf = create_mlir_buf<Rank>(96);
-
-  if (!buf) {
-      GGML_TSAVORITE_LOG_ERROR("tsi_alloc failied for creating memory for buf \n");
-      return GGML_STATUS_ABORTED;
-  }
-  buf->offset = 0;
-  buf->data   = buf->base = (void *)(buf+1);
 
   for (int i = 0; i < cgraph->n_nodes; i++) {
      int32_t kernel_sub_type=-1;
@@ -968,6 +977,21 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
         printf("\n kernel_sub_type not suppored\n");
         return GGML_STATUS_ABORTED;
     }
+
+    if (node->op == GGML_OP_RMS_NORM ||  node->op == GGML_OP_SOFT_MAX) {
+        if (!glob_buf) {
+            GGML_TSAVORITE_LOG_ERROR("tsi_alloc failied for creating memory for buf \n");
+            return GGML_STATUS_ABORTED;
+        }
+        glob_buf->offset = 0;
+        glob_buf->data   = glob_buf->base = (void *)(glob_buf+1);
+
+        float *vall = (float *)glob_buf->data;
+        int ii;
+        for(ii=0; ii <= 95; ++ii)
+               vall[ii] = 0;
+    }
+
     switch (node->op) {
     case GGML_OP_ADD:
       kernel_type = GGML_TSAVORITE_KERNEL_TYPE_ADD;
@@ -1115,6 +1139,7 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
           log_data.node_len = num_elem_node;
           log_data.log_file = tsi_op_log_file;
           log_data.num_of_op = num_of_op;
+          //log_data.kernel_type = kernel_type;
           log_data.kernel_type = node->op;
 
           log_data.data_type = GGML_TSAVORITE_TENSOR_HEADER;
@@ -1169,7 +1194,7 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
             const float * sk = src2 ? (float *)((char *) src2->data) : nullptr;
 	    //here src2 is NULL for particular model hence u can ignore this for now
 	    if (src2) {
-		    printf("\n ANOOP src2 is not null\n");
+		    printf("\n  src2 is not null for SOFT_MAX\n");
 	    }
             for (int64_t i03 = 0; i03 < ne03; i03++) {
                 for (int64_t i02 = 0; i02 < ne02; i02++) {
@@ -1196,9 +1221,10 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
                         srcP0->data =  srcP0->base = (void *)(sp);
                         nodeP->data =  nodeP->base = (void *)(dp);
 
-                        float *val = (float *)buf->data;
+                        float *val = (float *)glob_buf->data;
                         val[0] = scale;
-                        ctx->kernels[kernel_type].pipeline->_mlir_fptr_3_input[kernel_sub_type](srcP0, srcP1, nodeP, buf);
+                        ctx->kernels[kernel_type].pipeline->_mlir_fptr_3_input[kernel_sub_type](srcP0, srcP1, nodeP, glob_buf);
+                        ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
 	            }
 	        }
 	    }
@@ -1280,6 +1306,7 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
           log_data.node_len = num_elem_src0;
           log_data.log_file = tsi_op_log_file;
           log_data.num_of_op = num_of_op;
+          //log_data.kernel_type = kernel_type;
           log_data.kernel_type = node->op;
 
           log_data.data_type = GGML_TSAVORITE_TENSOR_HEADER;
@@ -1310,7 +1337,8 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
         // Although only 32 elements are strictly necessary, reducing this would require changes to the RMS kernel.
         // The remaining 32 elements are used to store src0->ne[0], replicated across each of the last 32 entries.
 
-            float *val = (float *)buf->data;
+
+            float *val = (float *)glob_buf->data;
             int i;
             for(i=64; i <= 95; ++i)
                     val[i] = node->ne[0];
@@ -1336,7 +1364,7 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
 			strides = strides * src0->ne[i];
 	    }
 
-            ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, nodeP, buf);
+            ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, nodeP, glob_buf);
 
         }
         else {
@@ -1442,7 +1470,6 @@ static void *ggml_backend_tsavorite_buffer_get_base(ggml_backend_buffer_t buffer
 static ggml_status ggml_backend_tsavorite_buffer_init_tensor(ggml_backend_buffer_t buffer,
                                                       struct ggml_tensor *tensor) {
   GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
-  const int Rank = MEM_REF_DESCRIPTOR_RANK;
   MemRefDescriptor<Rank> tensor_data_header;
   tensor->data = (void *)(sizeof(tensor_data_header) + (char *)tensor->data);
   GGML_TSAVORITE_LOG_INFO("End %s\n", __func__);
@@ -1633,7 +1660,6 @@ static size_t ggml_backend_tsavorite_buffer_type_get_alloc_size(ggml_backend_buf
     GGML_TSAVORITE_LOG_ERROR("\n tsavorite device is NULL \n");
     return 0;
   }
-  const int Rank = MEM_REF_DESCRIPTOR_RANK;
   MemRefDescriptor<Rank> tensor_data_header;
   ggml_backend_tsavorite_device_rel(
       (struct ggml_backend_tsavorite_device_context *)buft->device->context);
@@ -1645,7 +1671,10 @@ static size_t ggml_backend_tsavorite_buffer_type_get_alloc_size(ggml_backend_buf
 
   // Add 128-byte buffer to avoid crossing memory boundaries during TVU 1024-bit operations.
   // TVU processes data in 1024-bit chunks, so the last elements may exceed allocated space without this padding.
-  return (sizeof(tensor_data_header) + ggml_nbytes(tensor) + 128);
+  const int32_t mem_align = TSI_TVU_MEM_ALIGN;
+  // I also added extra Padding buffer
+  size_t n =  (((sizeof(tensor_data_header) + ggml_nbytes(tensor))/mem_align +1)*mem_align + mem_align);
+  return (n);
 
   TSI_UNUSED(buft);
 }
@@ -2073,7 +2102,9 @@ static bool ggml_backend_tsavorite_device_offload_op(ggml_backend_dev_t dev,
   case GGML_OP_SQR:
   case GGML_OP_SIN:
   case GGML_OP_RMS_NORM:
-  case GGML_OP_SOFT_MAX:
+  #ifdef GGML_TARGET_POSIX
+      case GGML_OP_SOFT_MAX:
+  #endif /* GGML_TARGET_POSIX */
     break;
   case GGML_OP_GLU:
     {

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -38,11 +38,11 @@ cd ../../
 echo 'building llama.cp, ggml for tsavorite  and other binary for posix'
 if [ "$(echo "$1" | tr '[:upper:]' '[:lower:]')" = "release" ];
 then
-  cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DCMAKE_C_FLAGS="-DGGML_PERF_RELEASE"   -DCMAKE_CXX_FLAGS="-DGGML_PERF_RELEASE"
+  cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DCMAKE_C_FLAGS="-DGGML_PERF_RELEASE -DGGML_TARGET_POSIX"   -DCMAKE_CXX_FLAGS="-DGGML_PERF_RELEASE -DGGML_TARGET_POSIX"
 elif [ "$(echo "$1" | tr '[:upper:]' '[:lower:]')" = "debug" ]; then
-  cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DCMAKE_C_FLAGS="-DGGML_PERF_DETAIL"   -DCMAKE_CXX_FLAGS="-DGGML_PERF_DETAIL"
+  cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DCMAKE_C_FLAGS="-DGGML_PERF_DETAIL -DGGML_TARGET_POSIX"   -DCMAKE_CXX_FLAGS="-DGGML_PERF_DETAIL -DGGML_TARGET_POSIX"
 else
-  cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DCMAKE_C_FLAGS="-DGGML_PERF"   -DCMAKE_CXX_FLAGS="-DGGML_PERF"
+  cmake -B build-posix -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DCMAKE_C_FLAGS="-DGGML_PERF -DGGML_TARGET_POSIX"   -DCMAKE_CXX_FLAGS="-DGGML_PERF -DGGML_TARGET_POSIX"
 fi
 
 cmake --build build-posix --config Release


### PR DESCRIPTION
Posix Result
build-posix/bin/llama-cli -p "my cat's name" -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf --device tSavorite -c 12288 --temp 0.0 --n-predict 1 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5 --no-warmup --no-display-prompt
llama_perf_sampler_print:    sampling time =       2.32 ms /     7 runs   (    0.33 ms per token,  3021.15 tokens per second)


llama_perf_context_print:        load time =   14263.70 ms
llama_perf_context_print: prompt eval time =    4560.23 ms /     6 tokens (  760.04 ms per token,     1.32 tokens per second)
llama_perf_context_print:        eval time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:       total time =   14266.72 ms /     7 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU           44             254            156411           3554.80
  MUL              OPU           45             260            144592           3213.16
  RMS_NORM         OPU           45              45             66228           1471.73
  MUL_MAT          CPU          693               0           5878977           8483.37
  CONT             CPU          172               0              9045             52.59
  RESHAPE          CPU          239               0               170              0.71
  VIEW             CPU          398               0                68              0.17
  PERMUTE          CPU          298               0                94              0.32
  TRANSPOSE        CPU           71               0                17              0.24
  GET_ROWS         CPU            9               0              1907            211.89
  SET_ROWS         CPU          173               0               259              1.50
  SOFT_MAX         OPU           22            4224           2242909         101950.41
  ROPE             CPU          174               0              3156             18.14
  GLU              OPU           22             127            133368           6062.18

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    27.9170   27.9170      9.1830  [1.71e-01%] [Thread] tsi::runtime::TsavRTPosix::initialize
    1    18.5750   18.5750      2.1900  └─ [1.13e-01%] tsi::runtime::TsavRTPosix::initializeQueues
    1    15.2600   15.2600     15.2600    └─ [9.32e-02%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     1.0570    1.0570      1.0570    └─ [6.46e-03%] tsi::runtime::TsavRTPosix::requestTXEDevice
    1     0.0680    0.0680      0.0630    └─ [4.15e-04%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0050    0.0050      0.0050      └─ [3.05e-05%] tsi::runtime::executeWithTimeout
    1     0.1590    0.1590      0.1590  └─ [9.71e-04%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1    40.3820   40.3820     39.8780  [2.47e-01%] [Thread] tsi::runtime::TsavRT::finalize
    1     0.4940    0.4940      0.0530  └─ [3.02e-03%] tsi::runtime::TsavRTPosix::detachFromTXEDevice
    1     0.4410    0.4410      0.0820    └─ [2.69e-03%] tsi::runtime::TsavRT::executeSyncCommand
    1     0.3290    0.3290      0.3290      └─ [2.01e-03%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     0.0300    0.0300      0.0270      └─ [1.83e-04%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0030    0.0030      0.0030        └─ [1.83e-05%] tsi::runtime::executeWithTimeout
    2     0.0100    0.0050      0.0100  └─ [6.11e-05%] tsi::runtime::TsavRT::deallocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 4910   781.6510    0.1592    138.1140  [ 4.77%] [Thread] tsi::runtime::TsavRTPosix::loadBlob
 9820   642.4060    0.0654    642.4060  └─ [ 3.92%] tsi::runtime::executeWithTimeout
 4910     1.1310  2.30e-04      1.1310  └─ [6.91e-03%] LOAD_BLOB Command Execution
 4910     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2148009600[0x800...
 4910     0.0000    0.0000      0.0000  └─ [0.00e+00%] TXE 0 Idle
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 4910   791.2890    0.1612    158.7450  [ 4.83%] [Thread] tsi::runtime::TsavRTPosix::unloadBlob
 9820   630.9930    0.0643    630.9930  └─ [ 3.85%] tsi::runtime::executeWithTimeout
 4910     1.5510  3.16e-04      1.5510  └─ [9.47e-03%] UNLOAD_BLOB Command Execution
 4910     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2148009600[0x8...
 4910     0.0000    0.0000      0.0000  └─ [0.00e+00%] TXE 0 Idle
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 4912   865.4440    0.1762     37.8030  [ 5.29%] [Thread] tsi::runtime::TsavRT::processResponses
 4912   827.6410    0.1685    827.6410  └─ [ 5.06%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------






FPGA Result
Currently this is failing due Memory Alloc Failure, Dushmanta is chasing
 perror("tsi_aligned_malloc: Failed to allocate aligned memory\n");
 
 hence i have disable SOFT_MAX for fpga and tested, below is result
 
 root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv38_10_12_2025/bin# tar -zxvf tsi-ggml-0.0.10_working.tz 
tsi-ggml/blobs/
tsi-ggml/blobs/txe_add.blob
tsi-ggml/blobs/txe_sub.blob
tsi-ggml/blobs/txe_mult.blob
tsi-ggml/blobs/txe_div.blob
tsi-ggml/blobs/txe_abs.blob
tsi-ggml/blobs/txe_neg.blob
tsi-ggml/blobs/txe_sqrt.blob
tsi-ggml/blobs/txe_sqr.blob
tsi-ggml/blobs/txe_inv.blob
tsi-ggml/blobs/txe_sin.blob
tsi-ggml/blobs/txe_sigmoid.blob
tsi-ggml/blobs/txe_silu.blob
tsi-ggml/blobs/txe_swiglu.blob
tsi-ggml/blobs/txe_div_16.blob
tsi-ggml/blobs/txe_abs_16.blob
tsi-ggml/blobs/txe_rms_norm.blob
tsi-ggml/blobs/txe_soft_max.blob
tsi-ggml/blobs/txe_add_16.blob
tsi-ggml/blobs/txe_sub_16.blob
tsi-ggml/blobs/txe_mult_16.blob
tsi-ggml/blobs/txe_neg_16.blob
tsi-ggml/blobs/txe_sqrt_16.blob
tsi-ggml/blobs/txe_sqr_16.blob
tsi-ggml/blobs/txe_inv_16.blob
tsi-ggml/blobs/txe_sin_16.blob
tsi-ggml/blobs/txe_sigmoid_16.blob
tsi-ggml/blobs/txe_silu_16.blob
tsi-ggml/blobs/txe_swiglu_16.blob
tsi-ggml/blobs/txe_rms_norm_16.blob
tsi-ggml/ggml.sh
tsi-ggml/libggml-base.so
tsi-ggml/libggml-cpu.so
tsi-ggml/libggml.so
tsi-ggml/libggml-tsavorite.so
tsi-ggml/libllama.so
tsi-ggml/llama-cli
tsi-ggml/simple-backend-tsi
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv38_10_12_2025/bin# ./run_llama_cli.sh 
 is Luna.




llama_perf_sampler_print:    sampling time =     119.16 ms /    11 runs   (   10.83 ms per token,    92.32 tokens per second)
llama_perf_context_print:        load time =   54439.14 ms
llama_perf_context_print: prompt eval time =   43831.27 ms /     6 tokens ( 7305.21 ms per token,     0.14 tokens per second)
llama_perf_context_print:        eval time =   51031.02 ms /     4 runs   (12757.75 ms per token,     0.08 tokens per second)
llama_perf_context_print:       total time =  105619.16 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs        Total us            Avg us
  ADD              OPU          484         1680847           3472.82
  MUL              OPU          495         1064577           2150.66
  RMS_NORM         OPU          495         1029119           2079.03
  MUL_MAT          CPU         8227       544547653          66190.31
  CONT             CPU         1431         1299315            907.98
  RESHAPE          CPU         1366           17971             13.16
  VIEW             CPU         2174            3322              1.53
  PERMUTE          CPU         1591            2693              1.69
  TRANSPOSE        CPU          404             813              2.01
  GET_ROWS         CPU           82           17480            213.17
  SET_ROWS         CPU         1604           34087             21.25
  SOFT_MAX         CPU          585         1001348           1711.71
  ROPE             CPU         1557          101817             65.39
  GLU              OPU          242         1067356           4410.56

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    41.6820   41.6820     31.8990  [3.87e-02%] [Thread] tsi::runtime::TsavRTFPGA::initialize
    1     5.3710    5.3710      5.3710  └─ [4.98e-03%] tsi::runtime::TsavRTFPGA::initializeQueues
    1     2.4750    2.4750      1.6420  └─ [2.30e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    2     0.8330    0.4165      0.8330    └─ [7.73e-04%] tsi::runtime::executeWithTimeout
    1     1.9370    1.9370      1.9370  └─ [1.80e-03%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310  1017.7360    0.7769      0.0000  [9.44e-01%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
 1310   1.04e+05   79.5849    1.04e+05  └─ [96.71%] TXE 0 Idle
  215   196.1439    0.9123    196.1439  └─ [1.82e-01%] [ txe_swiglu ]
  225   140.6145    0.6250    140.6145  └─ [1.30e-01%] [ txe_rms_norm ]
  440   133.5208    0.3035    133.5208  └─ [1.24e-01%] [ txe_mult ]
  430   126.5711    0.2944    126.5711  └─ [1.17e-01%] [ txe_add ]
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     5.3030    5.3030      5.0330  [4.92e-03%] [Thread] OPU 
    1     0.2700    0.2700      0.2700  └─ [2.50e-04%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310   746.8850    0.5701    729.0130  [6.93e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
 1310    17.8720    0.0136     17.8720  └─ [1.66e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310  1492.0960    1.1390     53.5740  [ 1.38%] [Thread] tsi::runtime::TsavRT::processResponses
 1310  1438.5220    1.0981   1438.5220  └─ [ 1.33%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1    80.1760   80.1760     62.3420  [7.44e-02%] [Thread] tsi::runtime::TsavRTFPGA::finalize
    1    17.8340   17.8340     17.8340  └─ [1.65e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1312    68.7070    0.0524     68.7070  [6.37e-02%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310   369.7450    0.2822    369.7450  [3.43e-01%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310    76.1190    0.0581     76.1190  [7.06e-02%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310    98.7010    0.0753     98.7010  [9.16e-02%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310    15.6920    0.0120     15.6920  [1.46e-02%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    -   1.08e+05    0.0000    1.08e+05  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.8544
------------------------------------------------------------------------------------------------------------------------

root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv38_10_12_2025/bin# 

