### PR TITLE
@FIR1036 - llama.cpp build issue after picking new SDK changes

### DIFF
--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -11,7 +11,7 @@ echo 'creating python virtual env'
 /proj/local/Python-3.10.12/bin/python3 -m venv blob-creation
 source blob-creation/bin/activate
 echo 'installing mlir and python dependencies'
-#pip install --upgrade pip
+pip install --upgrade pip
 pip install -r ${MLIR_SDK_VERSION}/compiler/python/requirements-common.txt
 pip install ${MLIR_SDK_VERSION}/compiler/python/mlir_external_packages-1.4.2-py3-none-any.whl
 pip install onnxruntime-training


### PR DESCRIPTION
log

akapoor@wssw01 llama.cpp]$ ./tsi-pkg-build.sh 
updating submodule
creating python virtual env
installing mlir and python dependencies
Requirement already satisfied: pip in ./blob-creation/lib/python3.10/site-packages (23.0.1)
Collecting pip
  Using cached pip-25.2-py3-none-any.whl (1.8 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 23.0.1
    Uninstalling pip-23.0.1:
      Successfully uninstalled pip-23.0.1
Successfully installed pip-25.2
Looking in links: https://download.pytorch.org/whl/torch
Collecting numpy==1.24.4 (from -r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 2))
  Using cached numpy-1.24.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.6 kB)
Collecting onnx (from -r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 3))
  Using cached onnx-1.19.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (7.0 kB)
Collecting onnxscript (from -r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 4))
  Downloading onnxscript-0.5.4-py3-none-any.whl.metadata (13 kB)
Collecting pandas (from -r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 5))
  Using cached pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl.metadata (91 kB)
Collecting pybind11 (from -r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 6))
  Using cached pybind11-3.0.1-py3-none-any.whl.metadata (10.0 kB)
Collecting PyYAML>=5.4.1 (from -r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 7))
  Using cached pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (2.4 kB)
Collecting torch==2.7 (from -r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached https://download.pytorch.org/whl/xpu/torch-2.7.0%2Bxpu-cp310-cp310-linux_x86_64.whl.metadata (28 kB)
Collecting safetensors (from -r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 10))
  Using cached safetensors-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.1 kB)
Collecting filelock (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached filelock-3.20.0-py3-none-any.whl.metadata (2.1 kB)
Collecting typing-extensions>=4.10.0 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached typing_extensions-4.15.0-py3-none-any.whl.metadata (3.3 kB)
Collecting sympy>=1.13.3 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached sympy-1.14.0-py3-none-any.whl.metadata (12 kB)
Collecting networkx (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached networkx-3.4.2-py3-none-any.whl.metadata (6.3 kB)
Collecting jinja2 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached jinja2-3.1.6-py3-none-any.whl.metadata (2.9 kB)
Collecting fsspec (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached fsspec-2025.9.0-py3-none-any.whl.metadata (10 kB)
Collecting intel-cmplr-lib-rt==2025.0.4 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached intel_cmplr_lib_rt-2025.0.4-py2.py3-none-manylinux_2_28_x86_64.whl.metadata (1.2 kB)
Collecting intel-cmplr-lib-ur==2025.0.4 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached intel_cmplr_lib_ur-2025.0.4-py2.py3-none-manylinux_2_28_x86_64.whl.metadata (1.2 kB)
Collecting intel-cmplr-lic-rt==2025.0.4 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached intel_cmplr_lic_rt-2025.0.4-py2.py3-none-manylinux_2_28_x86_64.whl.metadata (1.2 kB)
Collecting intel-sycl-rt==2025.0.4 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached intel_sycl_rt-2025.0.4-py2.py3-none-manylinux_2_28_x86_64.whl.metadata (1.4 kB)
Collecting tcmlib==1.2.0 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached tcmlib-1.2.0-py2.py3-none-manylinux_2_28_x86_64.whl.metadata (964 bytes)
Collecting umf==0.9.1 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached umf-0.9.1-py2.py3-none-manylinux_2_28_x86_64.whl.metadata (1.0 kB)
Collecting intel-pti==0.10.1 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached intel_pti-0.10.1-py2.py3-none-manylinux_2_28_x86_64.whl.metadata (982 bytes)
INFO: pip is looking at multiple versions of torch to determine which version is compatible with other requirements. This could take a while.
Collecting torch==2.7 (from -r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached https://download.pytorch.org/whl/rocm6.3/torch-2.7.0%2Brocm6.3-cp310-cp310-manylinux_2_28_x86_64.whl (4543.9 MB)
  Using cached https://download.pytorch.org/whl/rocm6.2.4/torch-2.7.0%2Brocm6.2.4-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (27 kB)
  Using cached https://download.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl.metadata (29 kB)
Collecting nvidia-cuda-nvrtc-cu12==12.8.61 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl.metadata (1.7 kB)
Collecting nvidia-cuda-runtime-cu12==12.8.57 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_cuda_runtime_cu12-12.8.57-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (1.7 kB)
Collecting nvidia-cuda-cupti-cu12==12.8.57 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_cuda_cupti_cu12-12.8.57-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (1.7 kB)
Collecting nvidia-cudnn-cu12==9.7.1.26 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_cudnn_cu12-9.7.1.26-py3-none-manylinux_2_27_x86_64.whl.metadata (1.8 kB)
Collecting nvidia-cublas-cu12==12.8.3.14 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_cublas_cu12-12.8.3.14-py3-none-manylinux_2_27_x86_64.whl.metadata (1.7 kB)
Collecting nvidia-cufft-cu12==11.3.3.41 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_cufft_cu12-11.3.3.41-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (1.5 kB)
Collecting nvidia-curand-cu12==10.3.9.55 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_curand_cu12-10.3.9.55-py3-none-manylinux_2_27_x86_64.whl.metadata (1.5 kB)
Collecting nvidia-cusolver-cu12==11.7.2.55 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_x86_64.whl.metadata (1.6 kB)
Collecting nvidia-cusparse-cu12==12.5.7.53 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_cusparse_cu12-12.5.7.53-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (1.6 kB)
Collecting nvidia-cusparselt-cu12==0.6.3 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl.metadata (6.8 kB)
Collecting nvidia-nccl-cu12==2.26.2 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (2.0 kB)
Collecting nvidia-nvtx-cu12==12.8.55 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_nvtx_cu12-12.8.55-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (1.6 kB)
Collecting nvidia-nvjitlink-cu12==12.8.61 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl.metadata (1.7 kB)
Collecting nvidia-cufile-cu12==1.13.0.11 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached nvidia_cufile_cu12-1.13.0.11-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl.metadata (1.5 kB)
Collecting triton==3.3.0 (from torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached triton-3.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (1.5 kB)
Requirement already satisfied: setuptools>=40.8.0 in ./blob-creation/lib/python3.10/site-packages (from triton==3.3.0->torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9)) (65.5.0)
Collecting protobuf>=4.25.1 (from onnx->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 3))
  Using cached protobuf-6.33.0-cp39-abi3-manylinux2014_x86_64.whl.metadata (593 bytes)
Collecting ml_dtypes>=0.5.0 (from onnx->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 3))
  Using cached ml_dtypes-0.5.3-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (8.9 kB)
Collecting onnx_ir<2,>=0.1.10 (from onnxscript->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 4))
  Using cached onnx_ir-0.1.11-py3-none-any.whl.metadata (3.4 kB)
Collecting packaging (from onnxscript->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 4))
  Using cached packaging-25.0-py3-none-any.whl.metadata (3.3 kB)
Collecting python-dateutil>=2.8.2 (from pandas->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 5))
  Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting pytz>=2020.1 (from pandas->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 5))
  Using cached pytz-2025.2-py2.py3-none-any.whl.metadata (22 kB)
Collecting tzdata>=2022.7 (from pandas->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 5))
  Using cached tzdata-2025.2-py2.py3-none-any.whl.metadata (1.4 kB)
Collecting six>=1.5 (from python-dateutil>=2.8.2->pandas->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 5))
  Using cached six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
Collecting mpmath<1.4,>=1.1.0 (from sympy>=1.13.3->torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached mpmath-1.3.0-py3-none-any.whl.metadata (8.6 kB)
Collecting MarkupSafe>=2.0 (from jinja2->torch==2.7->-r /proj/rel/sw/sdk-r.0.1.10/compiler/python/requirements-common.txt (line 9))
  Using cached markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (2.7 kB)
Using cached numpy-1.24.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (17.3 MB)
Using cached https://download.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl (1097.8 MB)
Using cached nvidia_cublas_cu12-12.8.3.14-py3-none-manylinux_2_27_x86_64.whl (609.6 MB)
Using cached nvidia_cuda_cupti_cu12-12.8.57-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (10.2 MB)
Using cached nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl (88.0 MB)
Using cached nvidia_cuda_runtime_cu12-12.8.57-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (954 kB)
Using cached nvidia_cudnn_cu12-9.7.1.26-py3-none-manylinux_2_27_x86_64.whl (726.9 MB)
Using cached nvidia_cufft_cu12-11.3.3.41-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (193.1 MB)
Using cached nvidia_cufile_cu12-1.13.0.11-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (1.2 MB)
Using cached nvidia_curand_cu12-10.3.9.55-py3-none-manylinux_2_27_x86_64.whl (63.6 MB)
Using cached nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_x86_64.whl (260.4 MB)
Using cached nvidia_cusparse_cu12-12.5.7.53-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (292.1 MB)
Using cached nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl (156.8 MB)
Using cached nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (201.3 MB)
Using cached nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl (39.2 MB)
Using cached nvidia_nvtx_cu12-12.8.55-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (89 kB)
Using cached triton-3.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (156.4 MB)
Using cached onnx-1.19.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (18.2 MB)
Downloading onnxscript-0.5.4-py3-none-any.whl (679 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 679.3/679.3 kB 6.6 MB/s  0:00:00
Using cached onnx_ir-0.1.11-py3-none-any.whl (128 kB)
Using cached pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (12.8 MB)
Using cached pybind11-3.0.1-py3-none-any.whl (293 kB)
Using cached pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (770 kB)
Using cached safetensors-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (485 kB)
Using cached ml_dtypes-0.5.3-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (4.9 MB)
Using cached protobuf-6.33.0-cp39-abi3-manylinux2014_x86_64.whl (323 kB)
Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Using cached pytz-2025.2-py2.py3-none-any.whl (509 kB)
Using cached six-1.17.0-py2.py3-none-any.whl (11 kB)
Using cached sympy-1.14.0-py3-none-any.whl (6.3 MB)
Using cached mpmath-1.3.0-py3-none-any.whl (536 kB)
Using cached typing_extensions-4.15.0-py3-none-any.whl (44 kB)
Using cached tzdata-2025.2-py2.py3-none-any.whl (347 kB)
Using cached filelock-3.20.0-py3-none-any.whl (16 kB)
Using cached fsspec-2025.9.0-py3-none-any.whl (199 kB)
Using cached jinja2-3.1.6-py3-none-any.whl (134 kB)
Using cached markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (20 kB)
Using cached networkx-3.4.2-py3-none-any.whl (1.7 MB)
Using cached packaging-25.0-py3-none-any.whl (66 kB)
Installing collected packages: pytz, nvidia-cusparselt-cu12, mpmath, tzdata, typing-extensions, triton, sympy, six, safetensors, PyYAML, pybind11, protobuf, packaging, nvidia-nvtx-cu12, nvidia-nvjitlink-cu12, nvidia-nccl-cu12, nvidia-curand-cu12, nvidia-cufile-cu12, nvidia-cuda-runtime-cu12, nvidia-cuda-nvrtc-cu12, nvidia-cuda-cupti-cu12, nvidia-cublas-cu12, numpy, networkx, MarkupSafe, fsspec, filelock, python-dateutil, nvidia-cusparse-cu12, nvidia-cufft-cu12, nvidia-cudnn-cu12, ml_dtypes, jinja2, pandas, onnx, nvidia-cusolver-cu12, torch, onnx_ir, onnxscript
Successfully installed MarkupSafe-3.0.3 PyYAML-6.0.3 filelock-3.20.0 fsspec-2025.9.0 jinja2-3.1.6 ml_dtypes-0.5.3 mpmath-1.3.0 networkx-3.4.2 numpy-1.24.4 nvidia-cublas-cu12-12.8.3.14 nvidia-cuda-cupti-cu12-12.8.57 nvidia-cuda-nvrtc-cu12-12.8.61 nvidia-cuda-runtime-cu12-12.8.57 nvidia-cudnn-cu12-9.7.1.26 nvidia-cufft-cu12-11.3.3.41 nvidia-cufile-cu12-1.13.0.11 nvidia-curand-cu12-10.3.9.55 nvidia-cusolver-cu12-11.7.2.55 nvidia-cusparse-cu12-12.5.7.53 nvidia-cusparselt-cu12-0.6.3 nvidia-nccl-cu12-2.26.2 nvidia-nvjitlink-cu12-12.8.61 nvidia-nvtx-cu12-12.8.55 onnx-1.19.1 onnx_ir-0.1.11 onnxscript-0.5.4 packaging-25.0 pandas-2.3.3 protobuf-6.33.0 pybind11-3.0.1 python-dateutil-2.9.0.post0 pytz-2025.2 safetensors-0.6.2 six-1.17.0 sympy-1.14.0 torch-2.7.0+cu128 triton-3.3.0 typing-extensions-4.15.0 tzdata-2025.2
Processing /proj/rel/sw/sdk-r.0.1.10/compiler/python/mlir_external_packages-1.4.2-py3-none-any.whl
Collecting black (from mlir-external-packages==1.4.2)
  Using cached black-25.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl.metadata (83 kB)
Collecting isort (from mlir-external-packages==1.4.2)
  Using cached isort-7.0.0-py3-none-any.whl.metadata (11 kB)
Requirement already satisfied: numpy==1.24.4 in ./blob-creation/lib/python3.10/site-packages (from mlir-external-packages==1.4.2) (1.24.4)
Requirement already satisfied: onnx in ./blob-creation/lib/python3.10/site-packages (from mlir-external-packages==1.4.2) (1.19.1)
Requirement already satisfied: onnxscript in ./blob-creation/lib/python3.10/site-packages (from mlir-external-packages==1.4.2) (0.5.4)
Requirement already satisfied: pandas in ./blob-creation/lib/python3.10/site-packages (from mlir-external-packages==1.4.2) (2.3.3)
Requirement already satisfied: pybind11 in ./blob-creation/lib/python3.10/site-packages (from mlir-external-packages==1.4.2) (3.0.1)
Requirement already satisfied: PyYAML>=5.4.1 in ./blob-creation/lib/python3.10/site-packages (from mlir-external-packages==1.4.2) (6.0.3)
Collecting wheel (from mlir-external-packages==1.4.2)
  Using cached wheel-0.45.1-py3-none-any.whl.metadata (2.3 kB)
Collecting click>=8.0.0 (from black->mlir-external-packages==1.4.2)
  Using cached click-8.3.0-py3-none-any.whl.metadata (2.6 kB)
Collecting mypy-extensions>=0.4.3 (from black->mlir-external-packages==1.4.2)
  Using cached mypy_extensions-1.1.0-py3-none-any.whl.metadata (1.1 kB)
Requirement already satisfied: packaging>=22.0 in ./blob-creation/lib/python3.10/site-packages (from black->mlir-external-packages==1.4.2) (25.0)
Collecting pathspec>=0.9.0 (from black->mlir-external-packages==1.4.2)
  Using cached pathspec-0.12.1-py3-none-any.whl.metadata (21 kB)
Collecting platformdirs>=2 (from black->mlir-external-packages==1.4.2)
  Using cached platformdirs-4.5.0-py3-none-any.whl.metadata (12 kB)
Collecting pytokens>=0.1.10 (from black->mlir-external-packages==1.4.2)
  Using cached pytokens-0.2.0-py3-none-any.whl.metadata (2.0 kB)
Collecting tomli>=1.1.0 (from black->mlir-external-packages==1.4.2)
  Using cached tomli-2.3.0-py3-none-any.whl.metadata (10 kB)
Requirement already satisfied: typing-extensions>=4.0.1 in ./blob-creation/lib/python3.10/site-packages (from black->mlir-external-packages==1.4.2) (4.15.0)
Requirement already satisfied: protobuf>=4.25.1 in ./blob-creation/lib/python3.10/site-packages (from onnx->mlir-external-packages==1.4.2) (6.33.0)
Requirement already satisfied: ml_dtypes>=0.5.0 in ./blob-creation/lib/python3.10/site-packages (from onnx->mlir-external-packages==1.4.2) (0.5.3)
Requirement already satisfied: onnx_ir<2,>=0.1.10 in ./blob-creation/lib/python3.10/site-packages (from onnxscript->mlir-external-packages==1.4.2) (0.1.11)
Requirement already satisfied: python-dateutil>=2.8.2 in ./blob-creation/lib/python3.10/site-packages (from pandas->mlir-external-packages==1.4.2) (2.9.0.post0)
Requirement already satisfied: pytz>=2020.1 in ./blob-creation/lib/python3.10/site-packages (from pandas->mlir-external-packages==1.4.2) (2025.2)
Requirement already satisfied: tzdata>=2022.7 in ./blob-creation/lib/python3.10/site-packages (from pandas->mlir-external-packages==1.4.2) (2025.2)
Requirement already satisfied: six>=1.5 in ./blob-creation/lib/python3.10/site-packages (from python-dateutil>=2.8.2->pandas->mlir-external-packages==1.4.2) (1.17.0)
Using cached black-25.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl (1.6 MB)
Using cached click-8.3.0-py3-none-any.whl (107 kB)
Using cached mypy_extensions-1.1.0-py3-none-any.whl (5.0 kB)
Using cached pathspec-0.12.1-py3-none-any.whl (31 kB)
Using cached platformdirs-4.5.0-py3-none-any.whl (18 kB)
Using cached pytokens-0.2.0-py3-none-any.whl (12 kB)
Using cached tomli-2.3.0-py3-none-any.whl (14 kB)
Using cached isort-7.0.0-py3-none-any.whl (94 kB)
Using cached wheel-0.45.1-py3-none-any.whl (72 kB)
Installing collected packages: wheel, tomli, pytokens, platformdirs, pathspec, mypy-extensions, isort, click, black, mlir-external-packages
Successfully installed black-25.9.0 click-8.3.0 isort-7.0.0 mlir-external-packages-1.4.2 mypy-extensions-1.1.0 pathspec-0.12.1 platformdirs-4.5.0 pytokens-0.2.0 tomli-2.3.0 wheel-0.45.1
Collecting onnxruntime-training
  Using cached onnxruntime_training-1.19.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (4.6 kB)
Collecting cerberus (from onnxruntime-training)
  Using cached Cerberus-1.3.7-py3-none-any.whl.metadata (5.5 kB)
Collecting flatbuffers (from onnxruntime-training)
  Using cached flatbuffers-25.9.23-py2.py3-none-any.whl.metadata (875 bytes)
Collecting h5py (from onnxruntime-training)
  Downloading h5py-3.15.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (3.0 kB)
Requirement already satisfied: numpy>=1.16.6 in ./blob-creation/lib/python3.10/site-packages (from onnxruntime-training) (1.24.4)
Requirement already satisfied: onnx in ./blob-creation/lib/python3.10/site-packages (from onnxruntime-training) (1.19.1)
Requirement already satisfied: packaging in ./blob-creation/lib/python3.10/site-packages (from onnxruntime-training) (25.0)
Requirement already satisfied: protobuf in ./blob-creation/lib/python3.10/site-packages (from onnxruntime-training) (6.33.0)
Requirement already satisfied: sympy in ./blob-creation/lib/python3.10/site-packages (from onnxruntime-training) (1.14.0)
Requirement already satisfied: setuptools>=61.0.0 in ./blob-creation/lib/python3.10/site-packages (from onnxruntime-training) (65.5.0)
Requirement already satisfied: typing_extensions>=4.7.1 in ./blob-creation/lib/python3.10/site-packages (from onnx->onnxruntime-training) (4.15.0)
Requirement already satisfied: ml_dtypes>=0.5.0 in ./blob-creation/lib/python3.10/site-packages (from onnx->onnxruntime-training) (0.5.3)
Requirement already satisfied: mpmath<1.4,>=1.1.0 in ./blob-creation/lib/python3.10/site-packages (from sympy->onnxruntime-training) (1.3.0)
Using cached onnxruntime_training-1.19.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (299.3 MB)
Using cached Cerberus-1.3.7-py3-none-any.whl (30 kB)
Using cached flatbuffers-25.9.23-py2.py3-none-any.whl (30 kB)
Downloading h5py-3.15.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (4.7 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.7/4.7 MB 74.1 MB/s  0:00:00
Installing collected packages: flatbuffers, h5py, cerberus, onnxruntime-training
Successfully installed cerberus-1.3.7 flatbuffers-25.9.23 h5py-3.15.1 onnxruntime-training-1.19.2
CMake Warning (dev) at CMakeLists.txt:13:
  Syntax Warning in cmake code at column 60

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in CMakeLists.txt:
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- The C compiler identification is GNU 13.3.0
-- The CXX compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /proj/local/gcc-13.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /proj/local/gcc-13.3.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
MLIR_SDK_VERSION  and COMPILER_INSTALL_DIR /proj/rel/sw/sdk-r.0.1.10/compiler
-- Found Python3: /proj/work/akapoor/llama.cpp-oct21/llama.cpp/ggml-tsi-kernel/blob-creation/bin/python3.10 (found suitable exact version "3.10.12") found components: Interpreter 
CMake Warning (dev) in CMakeLists.txt:
  No cmake_minimum_required command is present.  A line of code such as

    cmake_minimum_required(VERSION 3.26)

  should be added at the top of the file.  The version specified may be lower
  if you wish to support older CMake versions for this project.  For more
  information run "cmake --help-policy CMP0000".
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Configuring done (5.5s)
-- Generating done (0.3s)
-- Build files have been written to: /proj/work/akapoor/llama.cpp-oct21/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga
CMake Warning (dev) at CMakeLists.txt:13:
  Syntax Warning in cmake code at column 60

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in CMakeLists.txt:
  No project() command is present.  The top-level CMakeLists.txt file must
  contain a literal, direct call to the project() command.  Add a line of
  code such as

    project(ProjectName)

  near the top of the file, but after cmake_minimum_required().

  CMake is pretending there is a "project(Project)" command on the first
  line.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) in CMakeLists.txt:
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- The C compiler identification is GNU 13.3.0
-- The CXX compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /proj/local/gcc-13.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /proj/local/gcc-13.3.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
MLIR_SDK_VERSION  and COMPILER_INSTALL_DIR /proj/rel/sw/sdk-r.0.1.10/compiler
-- Found Python3: /proj/work/akapoor/llama.cpp-oct21/llama.cpp/ggml-tsi-kernel/blob-creation/bin/python3.10 (found suitable exact version "3.10.12") found components: Interpreter 
CMake Warning (dev) in CMakeLists.txt:
  No cmake_minimum_required command is present.  A line of code such as

    cmake_minimum_required(VERSION 3.26)

  should be added at the top of the file.  The version specified may be lower
  if you wish to support older CMake versions for this project.  For more
  information run "cmake --help-policy CMP0000".
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Configuring done (2.3s)
-- Generating done (0.3s)
-- Build files have been written to: /proj/work/akapoor/llama.cpp-oct21/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga
../fpga
[100%] Compiling txe_add
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_add_compiled_host
[100%] Compiling txe_sub
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_sub_compiled_host
[100%] Compiling txe_mult
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_mult_compiled_host
[100%] Compiling txe_div
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_div_compiled_host
[100%] Compiling txe_abs
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_abs_compiled_host
[100%] Compiling txe_neg
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_neg_compiled_host
[100%] Compiling txe_sqrt
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_sqrt_compiled_host
[100%] Compiling txe_sqr
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_sqr_compiled_host
[100%] Compiling txe_inv
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_inv_compiled_host
[100%] Compiling txe_sin
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_sin_compiled_host
[100%] Compiling txe_sigmoid
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_sigmoid_compiled_host
[100%] Compiling txe_silu
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_silu_compiled_host
[100%] Compiling txe_swiglu
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_swiglu_compiled_host
[100%] Compiling txe_rms_norm
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_rms_norm_compiled_host
[100%] Compiling txe_soft_max
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_soft_max_compiled_host
[100%] Compiling txe_add_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_add_16_compiled_host
[100%] Compiling txe_sub_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_sub_16_compiled_host
[100%] Compiling txe_mult_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_mult_16_compiled_host
[100%] Compiling txe_div_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_div_16_compiled_host
[100%] Compiling txe_abs_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_abs_16_compiled_host
[100%] Compiling txe_neg_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_neg_16_compiled_host
[100%] Compiling txe_sqrt_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_sqrt_16_compiled_host
[100%] Compiling txe_sqr_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_sqr_16_compiled_host
[100%] Compiling txe_inv_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_inv_16_compiled_host
[100%] Compiling txe_sin_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_sin_16_compiled_host
[100%] Compiling txe_sigmoid_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_sigmoid_16_compiled_host
[100%] Compiling txe_silu_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_silu_16_compiled_host
[100%] Compiling txe_swiglu_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_swiglu_16_compiled_host
[100%] Compiling txe_rms_norm_16
clang-15: warning: argument unused during compilation: '-I /proj/rel/sw/ralutil' [-Wunused-command-line-argument]
warning: overriding the module target triple with xtensa-unknown-unknown [-Woverride-module]
1 warning generated.
Removing nonloadable sections...
Building empty object file...
Copying library...
Writing linker script...
Writing linker script...
Linking into relocatable object...
[100%] Built target txe_rms_norm_16_compiled_host
creating posix kernel
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
Generating TXE module TXEFunction
Compiling blobs...
Compiling host code to llvm...
Compiling host code to object
building llama.cp, ggml for tsavorite  and other binary for posix
-- The C compiler identification is GNU 13.3.0
-- The CXX compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /proj/local/gcc-13.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /proj/local/gcc-13.3.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
MLIR_SDK_VERSION not set defaulting to /proj/rel/sw/sdk-r.0.1.10/compiler
MLIR_SDK_VERSION not set defaulting to /proj/rel/sw/sdk-r.0.1.10/posix/runtime
Setting target as posix for tsavorite
tsavorite backend is enabled
CMAKE_BUILD_TYPE=Debug
-- Found Git: /proj/local/bin/git (found version "2.41.0") 
-- The ASM compiler identification is GNU
-- Found assembler: /proj/local/gcc-13.3.0/bin/gcc
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - yes
-- Found Threads: TRUE  
-- ccache found, compilation results will be cached. Disable with GGML_CCACHE=OFF.
-- CMAKE_SYSTEM_PROCESSOR: x86_64
-- GGML_SYSTEM_ARCH: x86
-- Including CPU backend
-- Found OpenMP_C: -fopenmp (found version "4.5") 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5")  
-- x86 detected
-- Adding CPU backend variant ggml-cpu: -march=native 
-- Tsavorite framework is found
-- Including TSAVORITE backend
-- ggml version: 0.0.6642
-- ggml commit:  0c8e868f
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found CURL: /usr/lib64/libcurl.so (found version "7.61.1")  
-- Configuring done (9.6s)
CMake Warning at ggml/src/CMakeLists.txt:243 (add_library):
  Cannot generate a safe runtime search path for target ggml-tsavorite
  because there is a cycle in the constraint graph:

    dir 0 is [/proj/work/akapoor/llama.cpp-oct21/llama.cpp/build-posix/bin]
    dir 1 is [/proj/rel/sw/sdk-r.0.1.10/compiler/lib]
      dir 2 must precede it due to runtime library [libFloatTypes.so.0.2.0]
    dir 2 is [/proj/rel/sw/sdk-r.0.1.10/posix/runtime/lib]
      dir 1 must precede it due to runtime library [libTsavRTPosixShimCAPI.so]

  Some of these libraries may not be found correctly.
Call Stack (most recent call first):
  ggml/src/ggml-tsavorite/CMakeLists.txt:5 (ggml_add_backend_library)


CMake Warning at tests/CMakeLists.txt:220 (add_executable):
  Cannot generate a safe runtime search path for target test-c because there
  is a cycle in the constraint graph:

    dir 0 is [/proj/rel/sw/sdk-r.0.1.10/compiler/lib]
      dir 1 must precede it due to runtime library [libFloatTypes.so.0.2.0]
    dir 1 is [/proj/rel/sw/sdk-r.0.1.10/posix/runtime/lib]
      dir 0 must precede it due to runtime library [libTsavRTPosixShimCAPI.so]
    dir 2 is [/proj/work/akapoor/llama.cpp-oct21/llama.cpp/build-posix/bin]

  Some of these libraries may not be found correctly.


CMake Warning at examples/gguf-hash/CMakeLists.txt:2 (add_executable):
  Cannot generate a safe runtime search path for target llama-gguf-hash
  because there is a cycle in the constraint graph:

    dir 0 is [/proj/rel/sw/sdk-r.0.1.10/compiler/lib]
      dir 1 must precede it due to runtime library [libFloatTypes.so.0.2.0]
    dir 1 is [/proj/rel/sw/sdk-r.0.1.10/posix/runtime/lib]
      dir 0 must precede it due to runtime library [libTsavRTPosixShimCAPI.so]
    dir 2 is [/proj/work/akapoor/llama.cpp-oct21/llama.cpp/build-posix/bin]

  Some of these libraries may not be found correctly.


CMake Warning at examples/gguf/CMakeLists.txt:2 (add_executable):
  Cannot generate a safe runtime search path for target llama-gguf because
  there is a cycle in the constraint graph:

    dir 0 is [/proj/work/akapoor/llama.cpp-oct21/llama.cpp/build-posix/bin]
    dir 1 is [/proj/rel/sw/sdk-r.0.1.10/compiler/lib]
      dir 2 must precede it due to runtime library [libFloatTypes.so.0.2.0]
    dir 2 is [/proj/rel/sw/sdk-r.0.1.10/posix/runtime/lib]
      dir 1 must precede it due to runtime library [libTsavRTPosixShimCAPI.so]

  Some of these libraries may not be found correctly.


CMake Warning at examples/lookup/CMakeLists.txt:2 (add_executable):
  Cannot generate a safe runtime search path for target llama-lookup because
  there is a cycle in the constraint graph:

    dir 0 is [/proj/work/akapoor/llama.cpp-oct21/llama.cpp/build-posix/bin]
    dir 1 is [/proj/rel/sw/sdk-r.0.1.10/compiler/lib]
      dir 2 must precede it due to runtime library [libFloatTypes.so.0.2.0]
    dir 2 is [/proj/rel/sw/sdk-r.0.1.10/posix/runtime/lib]
      dir 1 must precede it due to runtime library [libTsavRTPosixShimCAPI.so]

  Some of these libraries may not be found correctly.


CMake Warning at examples/lookup/CMakeLists.txt:8 (add_executable):
  Cannot generate a safe runtime search path for target llama-lookup-create
  because there is a cycle in the constraint graph:

    dir 0 is [/proj/work/akapoor/llama.cpp-oct21/llama.cpp/build-posix/bin]
    dir 1 is [/proj/rel/sw/sdk-r.0.1.10/compiler/lib]
      dir 2 must precede it due to runtime library [libFloatTypes.so.0.2.0]
    dir 2 is [/proj/rel/sw/sdk-r.0.1.10/posix/runtime/lib]
      dir 1 must precede it due to runtime library [libTsavRTPosixShimCAPI.so]

  Some of these libraries may not be found correctly.


CMake Warning at examples/lookup/CMakeLists.txt:14 (add_executable):
  Cannot generate a safe runtime search path for target llama-lookup-merge
  because there is a cycle in the constraint graph:

    dir 0 is [/proj/work/akapoor/llama.cpp-oct21/llama.cpp/build-posix/bin]
    dir 1 is [/proj/rel/sw/sdk-r.0.1.10/compiler/lib]
      dir 2 must precede it due to runtime library [libFloatTypes.so.0.2.0]
    dir 2 is [/proj/rel/sw/sdk-r.0.1.10/posix/runtime/lib]
      dir 1 must precede it due to runtime library [libTsavRTPosixShimCAPI.so]

  Some of these libraries may not be found correctly.


CMake Warning at examples/lookup/CMakeLists.txt:20 (add_executable):
  Cannot generate a safe runtime search path for target llama-lookup-stats
  because there is a cycle in the constraint graph:

    dir 0 is [/proj/work/akapoor/llama.cpp-oct21/llama.cpp/build-posix/bin]
    dir 1 is [/proj/rel/sw/sdk-r.0.1.10/compiler/lib]
      dir 2 must precede it due to runtime library [libFloatTypes.so.0.2.0]
    dir 2 is [/proj/rel/sw/sdk-r.0.1.10/posix/runtime/lib]
      dir 1 must precede it due to runtime library [libTsavRTPosixShimCAPI.so]

  Some of these libraries may not be found correctly.


CMake Warning at examples/simple/CMakeLists.txt:4 (add_executable):
  Cannot generate a safe runtime search path for target llama-simple because
  there is a cycle in the constraint graph:

    dir 0 is [/proj/work/akapoor/llama.cpp-oct21/llama.cpp/build-posix/bin]
    dir 1 is [/proj/rel/sw/sdk-r.0.1.10/compiler/lib]
      dir 2 must precede it due to runtime library [libFloatTypes.so.0.2.0]
    dir 2 is [/proj/rel/sw/sdk-r.0.1.10/posix/runtime/lib]
      dir 1 must precede it due to runtime library [libTsavRTPosixShimCAPI.so]

  Some of these libraries may not be found correctly.


CMake Warning at examples/simple-chat/CMakeLists.txt:2 (add_executable):
  Cannot generate a safe runtime search path for target llama-simple-chat
  because there is a cycle in the constraint graph:

    dir 0 is [/proj/work/akapoor/llama.cpp-oct21/llama.cpp/build-posix/bin]
    dir 1 is [/proj/rel/sw/sdk-r.0.1.10/compiler/lib]
      dir 2 must precede it due to runtime library [libFloatTypes.so.0.2.0]
    dir 2 is [/proj/rel/sw/sdk-r.0.1.10/posix/runtime/lib]
      dir 1 must precede it due to runtime library [libTsavRTPosixShimCAPI.so]

  Some of these libraries may not be found correctly.


-- Generating done (5.6s)
