### PR TITLE
@FIR-1060 - FPGA Crash:for Error case or llama.cpp running for CPU mode

### DIFF
--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -13,7 +13,7 @@ set -e
 echo 'updating submodule'
 git submodule update --recursive --init
 cd ggml-tsi-kernel/
-#module load gcc/13.3.0
+module load gcc/13.3.0
 export MLIR_SDK_VERSION=/proj/rel/sw/sdk-r.0.2.0
 echo 'creating python virtual env'
 /proj/local/Python-3.10.12/bin/python3 -m venv blob-creation

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -13,7 +13,7 @@ set -e
 echo 'updating submodule'
 git submodule update --recursive --init
 cd ggml-tsi-kernel/
-module load gcc/13.3.0
+#module load gcc/13.3.0
 export MLIR_SDK_VERSION=/proj/rel/sw/sdk-r.0.2.0
 echo 'creating python virtual env'
 /proj/local/Python-3.10.12/bin/python3 -m venv blob-creation
@@ -86,18 +86,18 @@ export CMAKE_FIND_ROOT_PATH=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarc
 export TSAVORITE_SYSROOT_INCLUDE_DIR=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/include/
 if [ "$(echo "$1" | tr '[:upper:]' '[:lower:]')" = "release" ];
 then
-  cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga -DCMAKE_C_FLAGS="-DGGML_PERF_RELEASE"   -DCMAKE_CXX_FLAGS="-DGGML_PERF_RELEASE" -DCURL_INCLUDE_DIR=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/include  -DCURL_LIBRARY=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/lib/libcurl.so
+  cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga -DCMAKE_C_FLAGS="-DGGML_PERF_RELEASE -DGGML_TSAVORITE"   -DCMAKE_CXX_FLAGS="-DGGML_PERF_RELEASE -DGGML_TSAVORITE" -DCURL_INCLUDE_DIR=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/include  -DCURL_LIBRARY=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/lib/libcurl.so
 elif [ "$(echo "$1" | tr '[:upper:]' '[:lower:]')" = "debug" ]; then
-  cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga -DCMAKE_C_FLAGS="-DGGML_PERF_DETAIL"   -DCMAKE_CXX_FLAGS="-DGGML_PERF_DETAIL" -DCURL_INCLUDE_DIR=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/include  -DCURL_LIBRARY=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/lib/libcurl.so
+  cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga -DCMAKE_C_FLAGS="-DGGML_PERF_DETAIL -DGGML_TSAVORITE"   -DCMAKE_CXX_FLAGS="-DGGML_PERF_DETAIL -DGGML_TSAVORITE" -DCURL_INCLUDE_DIR=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/include  -DCURL_LIBRARY=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/lib/libcurl.so
 else
-  cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga -DCMAKE_C_FLAGS="-DGGML_PERF"   -DCMAKE_CXX_FLAGS="-DGGML_PERF" -DCURL_INCLUDE_DIR=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/include  -DCURL_LIBRARY=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/lib/libcurl.so
+  cmake -B build-fpga -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga -DCMAKE_C_FLAGS="-DGGML_PERF -DGGML_TSAVORITE"   -DCMAKE_CXX_FLAGS="-DGGML_PERF -DGGML_TSAVORITE" -DCURL_INCLUDE_DIR=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/include  -DCURL_LIBRARY=/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/lib/libcurl.so
 fi
 
 cmake --build build-fpga --config Release
 
 
 echo 'creating tar bundle for fpga'
-TSI_GGML_VERSION=0.2.0
+TSI_GGML_VERSION=0.2.1
 TSI_GGML_BUNDLE_INSTALL_DIR=tsi-ggml
 GGML_TSI_INSTALL_DIR=ggml-tsi-kernel
 TSI_GGML_RELEASE_DIR=/proj/rel/sw/ggml


### PR DESCRIPTION
FPGA Validation for CPU mode

oot@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# tax -zxvf tsi-ggml-0.2.0.tz 
-sh: tax: command not found
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# tar -zxvf tsi-ggml-0.2.0.tz 
tsi-ggml/blobs/
tsi-ggml/blobs/txe_add.blob
tsi-ggml/blobs/txe_sub.blob
tsi-ggml/blobs/txe_mult.blob
tsi-ggml/blobs/txe_div.blob
tsi-ggml/blobs/txe_abs.blob
tsi-ggml/blobs/txe_neg.blob
tsi-ggml/blobs/txe_sqrt.blob
tsi-ggml/blobs/txe_sqr.blob
tsi-ggml/blobs/txe_inv.blob
tsi-ggml/blobs/txe_sin.blob
tsi-ggml/blobs/txe_sigmoid.blob
tsi-ggml/blobs/txe_silu.blob
tsi-ggml/blobs/txe_swiglu.blob
tsi-ggml/blobs/txe_rms_norm.blob
tsi-ggml/blobs/txe_soft_max.blob
tsi-ggml/blobs/txe_add_16.blob
tsi-ggml/blobs/txe_sub_16.blob
tsi-ggml/blobs/txe_mult_16.blob
tsi-ggml/blobs/txe_div_16.blob
tsi-ggml/blobs/txe_abs_16.blob
tsi-ggml/blobs/txe_neg_16.blob
tsi-ggml/blobs/txe_sqrt_16.blob
tsi-ggml/blobs/txe_sqr_16.blob
tsi-ggml/blobs/txe_inv_16.blob
tsi-ggml/blobs/txe_sin_16.blob
tsi-ggml/blobs/txe_sigmoid_16.blob
tsi-ggml/blobs/txe_silu_16.blob
tsi-ggml/blobs/txe_swiglu_16.blob
tsi-ggml/blobs/txe_rms_norm_16.blob
tsi-ggml/ggml.sh
tsi-ggml/libggml-base.so
tsi-ggml/libggml-cpu.so
tsi-ggml/libggml.so
tsi-ggml/libggml-tsavorite.so
tsi-ggml/libllama.so
tsi-ggml/llama-cli
tsi-ggml/simple-backend-tsi
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# ./run_llama_cli.sh 
 is Luna.




llama_perf_sampler_print:    sampling time =     107.48 ms /    11 runs   (    9.77 ms per token,   102.35 tokens per second)
llama_perf_context_print:        load time =   23551.24 ms
llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =   49585.32 ms /     4 runs   (12396.33 ms per token,     0.08 tokens per second)
llama_perf_context_print:       total time =   60734.17 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          440             440           1175604           2671.83
  MUL              OPU          450             450            679805           1510.68
  RMS_NORM         OPU          450             450           1115583           2479.07
  MUL_MAT          CPU         7832               0         448915767          57318.15
  CONT             CPU         1284               0           1234909            961.77
  RESHAPE          CPU         1160               0             57688             49.73
  VIEW             CPU         1971               0              2623              1.33
  PERMUTE          CPU         1339               0              2912              2.17
  TRANSPOSE        CPU          387               0               697              1.80
  GET_ROWS         CPU           72               0             15867            220.38
  SET_ROWS         CPU         1404               0             36332             25.88
  SOFT_MAX         CPU          538               0            656121           1219.56
  ROPE             CPU         1325               0             86368             65.18
  GLU              OPU          220             220            819323           3724.20

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    29.0080   29.0080     24.8720  [4.76e-02%] [Thread] tsi::runtime::TsavRTFPGA::initialize
    1     2.8580    2.8580      2.8580  └─ [4.69e-03%] tsi::runtime::TsavRTFPGA::initializeQueues
    1     0.6780    0.6780      0.6230  └─ [1.11e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    2     0.0550    0.0275      0.0550    └─ [9.03e-05%] tsi::runtime::executeWithTimeout
    1     0.6000    0.6000      0.6000  └─ [9.85e-04%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   477.7660    0.7657      0.0000  [7.85e-01%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
  624 59793.9157   95.8236  59793.9157  └─ [98.19%] TXE 0 Idle
   88    77.5974    0.8818     77.5974  └─ [1.27e-01%] [ txe_swiglu ]
  180    62.4945    0.3472     62.4945  └─ [1.03e-01%] [ txe_rms_norm ]
  180    51.4220    0.2857     51.4220  └─ [8.44e-02%] [ txe_mult ]
  176    47.6981    0.2710     47.6981  └─ [7.83e-02%] [ txe_add ]
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     5.1500    5.1500      4.9140  [8.46e-03%] [Thread] OPU 
    1     0.2360    0.2360      0.2360  └─ [3.88e-04%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   470.6730    0.7543    431.9500  [7.73e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
  624    38.7230    0.0621     38.7230  └─ [6.36e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   753.8640    1.2081     23.7600  [ 1.24%] [Thread] tsi::runtime::TsavRT::processResponses
  624   730.1040    1.1700    730.1040  └─ [ 1.20%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1    74.9180   74.9180     57.8360  [1.23e-01%] [Thread] tsi::runtime::TsavRTFPGA::finalize
    1    17.0820   17.0820     17.0820  └─ [2.81e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  626    49.1970    0.0786     49.1970  [8.08e-02%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   222.4110    0.3564    222.4110  [3.65e-01%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624    44.8990    0.0720     44.8990  [7.37e-02%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624    47.7030    0.0764     47.7030  [7.83e-02%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624     7.7690    0.0125      7.7690  [1.28e-02%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    - 60896.8670    0.0000  60896.8670  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.6821
------------------------------------------------------------------------------------------------------------------------

root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# vi run_llama_cli.sh 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# cp run_llama_cli.sh run_llama_cli.sh_orig
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# vi run_llama_cli.sh
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# ./run_llama_cli.sh 
 is Luna.




llama_perf_sampler_print:    sampling time =     109.94 ms /    11 runs   (    9.99 ms per token,   100.06 tokens per second)
llama_perf_context_print:        load time =   24480.55 ms
llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =   47767.58 ms /     4 runs   (11941.89 ms per token,     0.08 tokens per second)
llama_perf_context_print:       total time =   60420.86 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              CPU         1327               0            119605             90.13
  MUL              CPU         1424               0            188032            132.04
  RMS_NORM         CPU         1198               0             89981             75.11
  MUL_MAT          CPU         6182               0         444323565          71873.76
  CPY              CPU           37               0             36370            982.97
  RESHAPE          CPU         1560               0             18689             11.98
  VIEW             CPU         1728               0              2226              1.29
  PERMUTE          CPU         1029               0              1432              1.39
  GET_ROWS         CPU          114               0             30863            270.73
  SET_ROWS         CPU         1416               0             33130             23.40
  ROPE             CPU         1426               0             99172             69.55
  FLASH_ATTN_EXT   CPU          766               0            416114            543.23
  GLU              CPU          731               0            274706            375.79
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# mv run_llama_cli.sh_orig run_llama_cli.sh
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# ./run_llama_cli.sh 
 is Luna.




llama_perf_sampler_print:    sampling time =     112.21 ms /    11 runs   (   10.20 ms per token,    98.03 tokens per second)
llama_perf_context_print:        load time =   24687.01 ms
llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =   49841.07 ms /     4 runs   (12460.27 ms per token,     0.08 tokens per second)
llama_perf_context_print:       total time =   62071.49 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          440             440           1165285           2648.38
  MUL              OPU          450             450            624243           1387.21
  RMS_NORM         OPU          450             450           1027940           2284.31
  MUL_MAT          CPU         7881               0         453735469          57573.34
  CONT             CPU         1277               0           1326503           1038.77
  RESHAPE          CPU         1119               0             18162             16.23
  VIEW             CPU         1877               0              2620              1.40
  PERMUTE          CPU         1347               0              2213              1.64
  TRANSPOSE        CPU          375               0               691              1.84
  GET_ROWS         CPU           78               0             15555            199.42
  SET_ROWS         CPU         1388               0             28940             20.85
  SOFT_MAX         CPU          504               0            656510           1302.60
  ROPE             CPU         1356               0            113455             83.67
  GLU              OPU          220             220            734956           3340.71

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    34.7730   34.7730     27.3120  [5.59e-02%] [Thread] tsi::runtime::TsavRTFPGA::initialize
    1     4.2170    4.2170      4.2170  └─ [6.77e-03%] tsi::runtime::TsavRTFPGA::initializeQueues
    1     1.8960    1.8960      1.4800  └─ [3.05e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    2     0.4160    0.2080      0.4160    └─ [6.68e-04%] tsi::runtime::executeWithTimeout
    1     1.3480    1.3480      1.3480  └─ [2.17e-03%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   480.3460    0.7698      0.0000  [7.72e-01%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
  624 61153.4085   98.0023  61153.4085  └─ [98.23%] TXE 0 Idle
   88    77.4575    0.8802     77.4575  └─ [1.24e-01%] [ txe_swiglu ]
  180    62.5699    0.3476     62.5699  └─ [1.01e-01%] [ txe_rms_norm ]
  180    51.4713    0.2860     51.4713  └─ [8.27e-02%] [ txe_mult ]
  176    47.8107    0.2717     47.8107  └─ [7.68e-02%] [ txe_add ]
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     5.1420    5.1420      4.8990  [8.26e-03%] [Thread] OPU 
    1     0.2430    0.2430      0.2430  └─ [3.90e-04%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   424.0650    0.6796    391.3170  [6.81e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
  624    32.7480    0.0525     32.7480  └─ [5.26e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   702.5520    1.1259     28.5110  [ 1.13%] [Thread] tsi::runtime::TsavRT::processResponses
  624   674.0410    1.0802    674.0410  └─ [ 1.08%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1    73.4260   73.4260     56.5430  [1.18e-01%] [Thread] tsi::runtime::TsavRTFPGA::finalize
    1    16.8830   16.8830     16.8830  └─ [2.71e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  626    55.8560    0.0892     55.8560  [8.97e-02%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   214.6620    0.3440    214.6620  [3.45e-01%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624    46.9030    0.0752     46.9030  [7.53e-02%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624    47.4900    0.0761     47.4900  [7.63e-02%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624     7.8100    0.0125      7.8100  [1.25e-02%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    - 62253.1070    0.0000  62253.1070  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.7029
------------------------------------------------------------------------------------------------------------------------

root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 


############
ERROR Cases

root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# ./run_llama_cli.sh 
error: invalid argument: -mm
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# vi run_llama_cli.sh 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# ./run_llama_cli.sh 
 is Luna.




llama_perf_sampler_print:    sampling time =     109.78 ms /    11 runs   (    9.98 ms per token,   100.20 tokens per second)
llama_perf_context_print:        load time =   25565.09 ms
llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =   50196.71 ms /     4 runs   (12549.18 ms per token,     0.08 tokens per second)
llama_perf_context_print:       total time =   63154.62 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          440             440           1294788           2942.70
  MUL              OPU          450             450            635371           1411.94
  RMS_NORM         OPU          450             450           1036558           2303.46
  MUL_MAT          CPU         7884               0         454877694          57696.31
  CONT             CPU         1318               0           1223999            928.68
  RESHAPE          CPU         1121               0             18095             16.14
  VIEW             CPU         1933               0              2623              1.36
  PERMUTE          CPU         1304               0              2022              1.55
  TRANSPOSE        CPU          388               0               704              1.81
  GET_ROWS         CPU           70               0             17666            252.37
  SET_ROWS         CPU         1373               0             30792             22.43
  SOFT_MAX         CPU          525               0            658201           1253.72
  ROPE             CPU         1313               0            108703             82.79
  GLU              OPU          220             220            783283           3560.38

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    20.9270   20.9270     19.3940  [3.31e-02%] [Thread] tsi::runtime::TsavRTFPGA::initialize
    1     0.6780    0.6780      0.6780  └─ [1.07e-03%] tsi::runtime::TsavRTFPGA::initializeQueues
    1     0.6300    0.6300      0.6300  └─ [9.95e-04%] tsi::runtime::TsavRT::initialize
    1     0.2250    0.2250      0.1490  └─ [3.55e-04%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    2     0.0760    0.0380      0.0760    └─ [1.20e-04%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   490.8670    0.7866      0.0000  [7.75e-01%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
  624 62197.1337   99.6749  62197.1337  └─ [98.25%] TXE 0 Idle
   88    78.1152    0.8877     78.1152  └─ [1.23e-01%] [ txe_swiglu ]
  180    62.5486    0.3475     62.5486  └─ [9.88e-02%] [ txe_rms_norm ]
  180    51.4427    0.2858     51.4427  └─ [8.13e-02%] [ txe_mult ]
  176    47.6908    0.2710     47.6908  └─ [7.53e-02%] [ txe_add ]
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     5.1300    5.1300      4.8930  [8.10e-03%] [Thread] OPU 
    1     0.2370    0.2370      0.2370  └─ [3.74e-04%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   427.0220    0.6843    397.0870  [6.75e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
  624    29.9350    0.0480     29.9350  └─ [4.73e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   729.8770    1.1697     26.2420  [ 1.15%] [Thread] tsi::runtime::TsavRT::processResponses
  624   703.6350    1.1276    703.6350  └─ [ 1.11%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1    74.2550   74.2550     56.1800  [1.17e-01%] [Thread] tsi::runtime::TsavRTFPGA::finalize
    1    18.0750   18.0750     18.0750  └─ [2.86e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  626    52.8780    0.0845     52.8780  [8.35e-02%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624   217.1980    0.3481    217.1980  [3.43e-01%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624    43.5160    0.0697     43.5160  [6.87e-02%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624    47.7310    0.0765     47.7310  [7.54e-02%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  624     7.8740    0.0126      7.8740  [1.24e-02%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    - 63305.4410    0.0000  63305.4410  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.6709
------------------------------------------------------------------------------------------------------------------------

root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# vi run_llama_cli.sh 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# ./run_llama_cli.sh 

 Unable to load Model
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# vi run_llama_cli.sh 
root@agilex7_dk_si_agf014eb:/usr/bin/tsi/v0.1.1.tsv39_10_23_2025/bin# ./run_llama_cli.sh 



