### PR TITLE
@FIR-1112 - LLama.cpp: Re-enable Python Virtual ENV

### DIFF
--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -11,25 +11,22 @@ set -e
 
 export MLIR_SDK_VERSION=/proj/rel/sw/sdk-r.0.2.2
 export TOOLBOX_DIR=${MLIR_SDK_VERSION}/toolbox/build/install
-pip install --upgrade pip
-pip install torch==2.7.0
-pip install -r ${MLIR_SDK_VERSION}/compiler/python/requirements-common.txt
-pip install ${MLIR_SDK_VERSION}/compiler/python/mlir_external_packages-1.5.0-py3-none-any.whl
-pip install onnxruntime-training
+
 #Ensure prerequisites are met as follows
 echo 'updating submodule'
 git submodule update --recursive --init
 cd ggml-tsi-kernel/
 #module load gcc/13.3.0
-#echo 'creating python virtual env'
-#/proj/local/Python-3.10.12/bin/python3 -m venv blob-creation
-#source blob-creation/bin/activate
-#echo 'installing mlir and python dependencies'
-#pip install --upgrade pip
-#pip install torch==2.7.0
-#pip install -r ${MLIR_SDK_VERSION}/compiler/python/requirements-common.txt
-#pip install ${MLIR_SDK_VERSION}/compiler/python/mlir_external_packages-1.5.0-py3-none-any.whl
-#pip install onnxruntime-training
+
+echo 'creating python virtual env'
+/proj/local/Python-3.11.12/bin/python3 -m venv blob-creation
+source blob-creation/bin/activate
+echo 'installing mlir and python dependencies'
+pip install --upgrade pip
+pip install torch==2.7.0
+pip install -r ${MLIR_SDK_VERSION}/compiler/python/requirements-common.txt
+pip install ${MLIR_SDK_VERSION}/compiler/python/mlir_external_packages-1.5.0-py3-none-any.whl
+pip install onnxruntime-training
 
 #build TSI kernels for the Tsavorite backend
 #First for FPGA


### PR DESCRIPTION
Able to build and test


[akapoor@ws01 llama.cpp]$ ./build-posix/bin/llama-cli -p "my cat's name is" -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf --device tSavorite  -c 12288 --temp 0.0 --n-predict 10 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5  --no-warmup
 my cat's name is Luna.
I'm a cat person



llama_perf_sampler_print:    sampling time =      27.23 ms /    17 runs   (    1.60 ms per token,   624.43 tokens per second)
llama_perf_context_print:        load time =    3526.80 ms
llama_perf_context_print: prompt eval time =    2929.38 ms /     7 tokens (  418.48 ms per token,     2.39 tokens per second)
llama_perf_context_print:        eval time =    3884.06 ms /     9 runs   (  431.56 ms per token,     2.32 tokens per second)
llama_perf_context_print:       total time =    7440.54 ms /    16 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU         2024            2276           3469505           1714.18
  MUL              OPU         2070            2328           1455299            703.04
  RMS_NORM         OPU         2070            2070           1377869            665.64
  MUL_MAT          CPU        36399               0          51704073           1420.48
  CONT             CPU         7736               0            410594             53.08
  RESHAPE          CPU        11379               0              4985              0.44
  VIEW             CPU        17176               0              2387              0.14
  PERMUTE          CPU        13727               0              2144              0.16
  TRANSPOSE        CPU         3404               0               884              0.26
  GET_ROWS         CPU          379               0               927              2.45
  SET_ROWS         CPU         7278               0              6366              0.87
  SOFT_MAX         CPU         3754               0            315162             83.95
  ROPE             CPU         7752               0             36275              4.68
  GLU              OPU         1012            1138           1813060           1791.56

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    32.4580   32.4580      6.9750  [4.32e-01%] [Thread] tsi::runtime::TsavRTPosix::initialize
    1    25.3020   25.3020      2.2760  └─ [3.37e-01%] tsi::runtime::TsavRTPosix::initializeQueues
    1    21.8340   21.8340     21.8340    └─ [2.91e-01%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     1.1240    1.1240      1.1240    └─ [1.50e-02%] tsi::runtime::TsavRTPosix::requestTXEDevice
    1     0.0680    0.0680      0.0630    └─ [9.06e-04%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0050    0.0050      0.0050      └─ [6.66e-05%] tsi::runtime::executeWithTimeout
    1     0.1810    0.1810      0.1810  └─ [2.41e-03%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     4.2130    4.2130      3.8030  [5.61e-02%] [Thread] tsi::runtime::TsavRT::finalize
    1     0.4040    0.4040      0.0510  └─ [5.38e-03%] tsi::runtime::TsavRTPosix::detachFromTXEDevice
    1     0.3530    0.3530      0.0430    └─ [4.70e-03%] tsi::runtime::TsavRT::executeSyncCommand
    1     0.2760    0.2760      0.2760      └─ [3.68e-03%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     0.0340    0.0340      0.0310      └─ [4.53e-04%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0030    0.0030      0.0030        └─ [4.00e-05%] tsi::runtime::executeWithTimeout
    2     0.0060    0.0030      0.0060  └─ [7.99e-05%] tsi::runtime::TsavRT::deallocate


