### PR TITLE
Added target_link_directories so the linker can find the FFM libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if (GGML_TSAVORITE)
         file(GLOB TLIBS  "${RUNTIME_DIR}/lib/*.so" "${GGML_TSI_KERNEL_DIR}/host/*.o" "${RUNTIME_DIR}/../utils/lib/TsavRTShimCAPI.cpp.o")
         message("Setting target as fpga")
     elseif (${GGML_TSAVORITE_TARGET} STREQUAL "posix")
-        file(GLOB TLIBS  "${RUNTIME_DIR}/lib/*.so" "${GGML_TSI_KERNEL_DIR}/host/*.o" "${MLIR_COMPILER_DIR}/lib/libFFMDeviceShim.so" "${MLIR_COMPILER_DIR}/lib/libTsavRTPosixShimCAPI.so")
+        file(GLOB TLIBS  "${RUNTIME_DIR}/lib/*.so" "${GGML_TSI_KERNEL_DIR}/host/*.o" "${MLIR_COMPILER_DIR}/lib/libFFMDeviceShim.so" "${MLIR_COMPILER_DIR}/lib/libTsavRTPosixShimCAPI.so" "${MLIR_COMPILER_DIR}/lib/libtxe-ffm-c-native.so" "${MLIR_COMPILER_DIR}/lib/libtxe-ffm-cpp.so" "${MLIR_COMPILER_DIR}/lib/libtvu_fau_full.so")
         message("Setting target as posix for tsavorite")
     endif()
 

--- a/ggml/src/ggml-tsavorite/CMakeLists.txt
+++ b/ggml/src/ggml-tsavorite/CMakeLists.txt
@@ -6,4 +6,9 @@ ggml_add_backend_library(ggml-tsavorite
                          ggml-tsavorite.cpp
                         )
 
+# Add compiler lib directory to link path for FFM libraries
+if(DEFINED MLIR_COMPILER_DIR)
+    target_link_directories(ggml-tsavorite PRIVATE "${MLIR_COMPILER_DIR}/lib")
+endif()
+
 target_link_libraries(ggml-tsavorite PRIVATE ${TLIBS} dl rt)


### PR DESCRIPTION
The undefined references to tsi::ffm::NativeTypeTvuPolicy and tsi::ffm::NativeTypeTmuPolicy functions are resolved

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
