### PR TITLE
@FIR-1430 - llama.cpp changed for SDP-2.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,24 @@ if (GGML_TSAVORITE)
         set(GGML_TSAVORITE_TARGET "posix")
     endif()
 
+    # --- Host-arch aware MLIR SDK selection (CMake equivalent of uname -m case) ---
+    execute_process(
+        COMMAND uname -m
+        OUTPUT_VARIABLE HOST_M
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if (HOST_M STREQUAL "x86_64" OR HOST_M STREQUAL "amd64")
+        set(MLIR_SDK_ARCH "x86_64")
+    elseif (HOST_M STREQUAL "aarch64" OR HOST_M STREQUAL "arm64")
+        set(MLIR_SDK_ARCH "aarch64")
+    else()
+        message(FATAL_ERROR "Unsupported host arch from uname -m: ${HOST_M}")
+    endif()
+
     if (NOT DEFINED MLIR_COMPILER_DIR)
         if (NOT DEFINED $ENV{MLIR_SDK_VERSION})
-            set (MLIR_COMPILER_DIR /proj/rel/sw/sdk-r.0.2.3/compiler)
+            set (MLIR_COMPILER_DIR /proj/rel/sw/sdk-r.0.2.4/${MLIR_SDK_ARCH}/compiler)
             message("MLIR_SDK_VERSION not set defaulting to ${MLIR_COMPILER_DIR}")
         else()
             set (MLIR_COMPILER_DIR $ENV{MLIR_SDK_VERSION}/compiler)
@@ -24,7 +39,7 @@ if (GGML_TSAVORITE)
 
     if (NOT DEFINED RUNTIME_DIR)
         if (NOT DEFINED $ENV{MLIR_SDK_VERSION})
-            set (RUNTIME_DIR /proj/rel/sw/sdk-r.0.2.3/${GGML_TSAVORITE_TARGET}/runtime)
+            set (RUNTIME_DIR /proj/rel/sw/sdk-r.0.2.4/${MLIR_SDK_ARCH}/${GGML_TSAVORITE_TARGET}/runtime)
             message("MLIR_SDK_VERSION not set defaulting to ${RUNTIME_DIR}")
         else()
             set (RUNTIME_DIR $ENV{MLIR_SDK_VERSION}/${GGML_TSAVORITE_TARGET}/runtime)

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -8,6 +8,17 @@
 
 set -e
 
+# --- Host-arch aware MLIR SDK selection
+m="$(uname -m)"
+case "$m" in
+  x86_64|amd64) arch="x86_64" ;;
+  aarch64|arm64) arch="aarch64" ;;
+  *)
+    log_error "Unsupported host arch from uname -m: $m"
+    exit 1
+    ;;
+esac
+
 # Accept MLIR_COMPILER_DIR and TOOLBOX_DIR as arguments or environment variables
 # Usage: ./tsi-pkg-build.sh [release|debug] [MLIR_COMPILER_DIR] [TOOLBOX_DIR]
 BUILD_TYPE=${1:-}
@@ -16,7 +27,7 @@ TOOLBOX_DIR=${3:-${TOOLBOX_DIR:-}}
 
 # Default to SDK paths if not provided
 if [ -z "${MLIR_COMPILER_DIR}" ]; then
-  MLIR_SDK_VERSION=${MLIR_SDK_VERSION:-/proj/rel/sw/sdk-r.0.2.3}
+  MLIR_SDK_VERSION=${MLIR_SDK_VERSION:-/proj/rel/sw/sdk-r.0.2.4/${arch}}
   MLIR_COMPILER_DIR=${MLIR_SDK_VERSION}/compiler
   echo "Using default MLIR_COMPILER_DIR: ${MLIR_COMPILER_DIR}"
 fi
@@ -45,6 +56,7 @@ echo "TOOLBOX_DIR: ${TOOLBOX_DIR}"
 export MLIR_SDK_VERSION=${MLIR_SDK_VERSION:-$(dirname ${MLIR_COMPILER_DIR})}
 export COMPILER_INSTALL_DIR=${MLIR_COMPILER_DIR}
 export TOOLBOX_DIR
+export FAU_LOOKUP_TABLE_PATH=${MLIR_SDK_VERSION}/ffm/txe-ffm-cpp/third-party/FAU/include/
 
 # Check if enable_coverage is passed as an argument
 ENABLE_COVERAGE_FLAG=""
@@ -60,7 +72,6 @@ done
 echo 'updating submodule'
 git submodule update --recursive --init
 cd ggml-tsi-kernel/
-#module load gcc/13.3.0
 # Set compiler environment variables to use GCC 13.3.0
 export CC="/proj/local/gcc-13.3.0/bin/gcc"
 export CXX="/proj/local/gcc-13.3.0/bin/g++"

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -6,6 +6,13 @@
 #git checkout master
 #git merge upstream/master
 
+# NOTE:
+# To ensure environment variables are set in the current shell,
+# always run this script using:
+#   source tsi-pkg-build.sh
+# or
+#   . tsi-pkg-build.sh
+
 set -e
 
 # --- Host-arch aware MLIR SDK selection


### PR DESCRIPTION
Since SDK‑2.4 is not an official release, we expect only incremental changes at this stage. Additionally, there will be no official llama.cpp release based on SDK‑2.4

I have test model on POSIX and its working fine
to get all ENV variable under tsi-pkg-build.sh we should as below
source tsi-pkg-build.sh or
.  tsi-pkg-build.sh

./build-posix/bin/llama-cli -p "my cat's name is" -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf --device tSavorite  -c 12288 --temp 0.0 --n-predict 4 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5  --no-warmup
 my cat's name is Luna.




llama_perf_sampler_print:    sampling time =      10.90 ms /    11 runs   (    0.99 ms per token,  1008.80 tokens per second)
llama_perf_context_print:        load time =   79843.68 ms
llama_perf_context_print: prompt eval time =    5157.70 ms /     7 tokens (  736.81 ms per token,     1.36 tokens per second)
llama_perf_context_print:        eval time =    1175.24 ms /     3 runs   (  391.75 ms per token,     2.55 tokens per second)
llama_perf_context_print:       total time =   81031.09 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          308             560            550103           1786.05
  MUL              OPU          315             573            311986            990.43
  RMS_NORM         OPU          315             315           2695774           8558.01
  MUL_MAT          CPU         5477               0          12875888           2350.90
  CONT             CPU         1177               0             58652             49.83
  RESHAPE          CPU         1694               0               823              0.49
  VIEW             CPU         2668               0               316              0.12
  PERMUTE          CPU         2080               0               316              0.15
  TRANSPOSE        CPU          528               0               154              0.29
  GET_ROWS         CPU           62               0              3011             48.56
  SET_ROWS         CPU         1139               0              1248              1.10
  SOFT_MAX         CPU          576               0             80477            139.72
  ROPE             CPU         1169               0              8064              6.90
  GLU              OPU          154             280            344806           2239.00

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1   162.5630  162.5630      7.3810  [2.00e-01%] [Thread] tsi::runtime::TsavRTPosix::initialize
    1   154.9710  154.9710      8.4770  └─ [1.91e-01%] tsi::runtime::TsavRTPosix::initializeQueues
    1   143.3140  143.3140    143.3140    └─ [1.76e-01%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     3.0480    3.0480      3.0480    └─ [3.75e-03%] tsi::runtime::TsavRTPosix::requestTXEDevice
    1     0.1320    0.1320      0.1260    └─ [1.62e-04%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0060    0.0060      0.0060      └─ [7.39e-06%] tsi::runtime::executeWithTimeout
    1     0.2110    0.2110      0.2110  └─ [2.60e-04%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     5.1180    5.1180      4.5670  [6.30e-03%] [Thread] tsi::runtime::TsavRT::finalize
    1     0.5410    0.5410      0.0530  └─ [6.66e-04%] tsi::runtime::TsavRTPosix::detachFromTXEDevice
    1     0.4880    0.4880      0.0760    └─ [6.01e-04%] tsi::runtime::TsavRT::executeSyncCommand
    1     0.3870    0.3870      0.3870      └─ [4.76e-04%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     0.0250    0.0250      0.0220      └─ [3.08e-05%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0030    0.0030      0.0030        └─ [3.69e-06%] tsi::runtime::executeWithTimeout
    2     0.0100    0.0050      0.0100  └─ [1.23e-05%] tsi::runtime::TsavRT::deallocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260  2776.0290    2.2032     37.5570  [ 3.42%] [Thread] tsi::runtime::TsavRTPosix::loadBlob
 2520  2738.1860    1.0866   2738.1860  └─ [ 3.37%] tsi::runtime::executeWithTimeout
 1260     0.2860  2.27e-04      0.2860  └─ [3.52e-04%] LOAD_BLOB Command Execution
  180     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2148010624[0x800...
 1260     0.0000    0.0000      0.0000  └─ [0.00e+00%] TXE 0 Idle
 1080     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2148009600[0x800...
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260   205.2600    0.1629     38.5420  [2.53e-01%] [Thread] tsi::runtime::TsavRTPosix::unloadBlob
 2520   166.2710    0.0660    166.2710  └─ [2.05e-01%] tsi::runtime::executeWithTimeout
 1260     0.4470  3.55e-04      0.4470  └─ [5.50e-04%] UNLOAD_BLOB Command Execution
  180     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2148010624[0x8...
 1260     0.0000    0.0000      0.0000  └─ [0.00e+00%] TXE 0 Idle
 1080     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2148009600[0x8...
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1262   471.3470    0.3735      9.2270  [5.80e-01%] [Thread] tsi::runtime::TsavRT::processResponses
 1262   462.1200    0.3662    462.1200  └─ [5.69e-01%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     0.0730    0.0730      0.0460  [8.99e-05%] [Thread] OPU 
    1     0.0270    0.0270      0.0270  └─ [3.32e-05%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260    20.3050    0.0161     18.6220  [2.50e-02%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
 1260     1.6830    0.0013      1.6830  └─ [2.07e-03%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 5042     5.1620    0.0010      5.1620  [6.35e-03%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::stridedCopy (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 7200    17.7140    0.0025     17.7140  [2.18e-02%] [Thread] tsi::runtime::TsavRT::stridedCopy
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::copy (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  360     0.0940  2.61e-04      0.0940  [1.16e-04%] [Thread] tsi::runtime::TsavRT::copy
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260     4.9270    0.0039      4.9270  [6.06e-03%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260   365.8040    0.2903    365.8040  [4.50e-01%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 8820     5.3640  6.08e-04      5.3640  [6.60e-03%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    - 81237.9400    0.0000  81237.9400  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.9992
------------------------------------------------------------------------------------------------------------------------

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 

