### PR TITLE
@FIR-1417 - GGML:Support software‑managed K‑tiling (min‑K tiling) for TMU MatMul in GGML/Tsavorite backend

### DIFF
--- a/ggml/include/ggml-tsavorite.h
+++ b/ggml/include/ggml-tsavorite.h
@@ -17,12 +17,11 @@
 
 //
 //
-// Note: this description is outdated
 //
-// An interface allowing to compute ggml_cgraph with tSovrite
+// An interface allowing to compute ggml_cgraph with tSavorite
 //
 // This is a fully functional interface that extends ggml with Hardware Accelerator support for
-// tSovrite devices. A similar interface can be created for other GPU backends (e.g. Vulkan, CUDA,
+// tSavorite devices. A similar interface can be created for other GPU backends (e.g. Vulkan, CUDA,
 // etc.)
 //
 // How it works?
@@ -37,9 +36,12 @@
 //
 // Synchronization between device and host memory (for example for input and output tensors)
 // is done with the ggml_tsavorite_set_tensor() and ggml_tsavorite_get_tensor() functions.
+// See TMU MUL_MAT TILE BLOB ABI below for current contract.
 //
 
 #pragma once
+
+
 
 #include "ggml-backend.h"
 #include "ggml.h"
@@ -48,6 +50,9 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,35 +62,8 @@ extern "C" {
 #define TSAVORITE_GGML_ASSERT(x) do { if (!(x)) abort(); } while (0)
 #endif
 
-// ============================================================================
-//                           EDIT ONLY THESE #defines
-// ============================================================================
 
-// Max rows per TMU call (MAR window)
-#ifndef TMU_M_TILE_MAX
-#define TMU_M_TILE_MAX    64
-#endif
-
-// TMU FP32 store granularity (floats per output cacheline)
-#ifndef TMU_N_BLOCK
-#define TMU_N_BLOCK       32
-#endif
-
-// K alignment for FP32 streaming
-#ifndef TMU_K_MULTIPLE
-#define TMU_K_MULTIPLE    32
-#endif
-
-
-// Supported static K shapes in this build:
-#define TMU_K_576   576
-#define TMU_K_1536  1536
-#define TMU_K_2048  2048
-
-// ============================================================================
-
-
-#define TSAVORITE_DEVICE_MAX_BUF_LEN 1024 * 1024 * 128
+#define TSAVORITE_DEVICE_MAX_BUF_LEN (1024 * 1024 * 128)
 
 enum ggml_tsavorite_input_tensors_count {
   TSAVORITE_UNARY_INPUT_TENSORS = 1,
@@ -230,13 +208,99 @@ extern void _mlir_ciface_txe_soft_max_host(void *a, void *b, void *res, void *bu
 extern void _mlir_ciface_txe_rms_norm_host(void *a, void *res, void *buf);
 
 
-// -----------------------------------------------------------------------------
-// TMU static MUL_MAT entrypoints generated for Python blobs
-// (These must match the function names produced by TXEBlobBuilderBackend.)
-// -----------------------------------------------------------------------------
-extern void _mlir_ciface_txe_mul_mat_tile_f32_k576_host(void *a, void *b, void *res);
-extern void _mlir_ciface_txe_mul_mat_tile_f32_k1536_host(void *a, void *b, void *res);
-extern void _mlir_ciface_txe_mul_mat_tile_f32_k2048_host(void *a, void *b, void *res);
+// ============================================================================
+// TMU TILE CONSTANTS
+// ============================================================================
+
+// Fixed TMU tile geometry
+// Max rows per TMU call (MAR window)
+#define TMU_M_TILE_MAX   64     // rows
+
+// TMU FP32 store granularity (floats per output cacheline)
+#define TMU_N_BLOCK     32     // columns (PP width)
+
+// K must be multiple of this
+// K alignment for FP32 streaming
+#define TMU_K_MULTIPLE  32
+
+
+#define TMU_NUM_K_BUCKETS 7
+
+
+// ============================================================================
+// TMU MUL_MAT TILE BLOB ABI (STATIC AOT, SINGLE‑PHASE PER‑K)
+// ============================================================================
+//
+// SINGLE‑PHASE CONTRACT (CURRENT DESIGN)
+//
+// FUNCTION SIGNATURE (C ABI):
+//
+//   void tmu_mul_mat_k<K>(
+//       const void * A_tile,   // [1,1,64,K] FP32, packed, zero‑padded
+//       const void * B_tile,   // [1,1,32,K] FP32, packed, zero‑padded
+//       void       * C_tile    // [1,1,64,32] FP32 scratchpad + output
+//   );
+//
+// SEMANTICS (per invocation):
+//
+//   • Blob LOADS PP from C_tile
+//   • Executes PP = A × B + PP for all internal K stripes
+//   • LAST internal update materializes C = A × B + PP
+//   • Blob STORES result back to C_tile
+//
+// IMPORTANT RULES:
+//
+//   • C_tile acts as BOTH scratchpad and final output
+//   • Host MUST zero C_tile before the first K‑chunk
+//   • Host MAY call multiple K‑blobs sequentially:
+//       K = 2048 + 2048 + 2048 + 2048 + 2048 + 512 + 128 + 32
+//   • No BEGIN / ACCUM / FINAL phases exist in this ABI
+//
+// SOFTWARE RESPONSIBILITY:
+//
+//   • Decompose K into supported buckets
+//   • Pack A/B tiles per K‑chunk
+//   • Zero C_tile once per output tile
+//   • Call tmu_mul_mat_k<K>() in K‑decomposition order
+//   • Copy C_tile → GGML output after last K call
+//
+// ============================================================================
+
+typedef void (*tmu_mul_mat_tile_fn)(
+    const void * A_tile,
+    const void * B_tile,
+    void       * C_tile
+);
+
+/* ---- Supported K bucket values ---- */
+#define TMU_K_BUCKET_32   32
+#define TMU_K_BUCKET_64   64
+#define TMU_K_BUCKET_128  128
+#define TMU_K_BUCKET_256  256
+#define TMU_K_BUCKET_512  512
+#define TMU_K_BUCKET_1024 1024
+#define TMU_K_BUCKET_2048 2048
+
+/* ---- Externs generated by AOT blobs (ONE per K) ---- */
+
+void tmu_mul_mat_k32  (const void *A, const void *B, void *C);
+void tmu_mul_mat_k64  (const void *A, const void *B, void *C);
+void tmu_mul_mat_k128 (const void *A, const void *B, void *C);
+void tmu_mul_mat_k256 (const void *A, const void *B, void *C);
+void tmu_mul_mat_k512 (const void *A, const void *B, void *C);
+void tmu_mul_mat_k1024(const void *A, const void *B, void *C);
+void tmu_mul_mat_k2048(const void *A, const void *B, void *C);
+
+
+extern void _mlir_ciface_txe_mul_mat_tile_f32_k32_host  (void *A_tile, void *B_tile, void *C_tile);
+extern void _mlir_ciface_txe_mul_mat_tile_f32_k64_host  (void *A_tile, void *B_tile, void *C_tile);
+extern void _mlir_ciface_txe_mul_mat_tile_f32_k128_host (void *A_tile, void *B_tile, void *C_tile);
+extern void _mlir_ciface_txe_mul_mat_tile_f32_k256_host (void *A_tile, void *B_tile, void *C_tile);
+extern void _mlir_ciface_txe_mul_mat_tile_f32_k512_host (void *A_tile, void *B_tile, void *C_tile);
+extern void _mlir_ciface_txe_mul_mat_tile_f32_k1024_host(void *A_tile, void *B_tile, void *C_tile);
+extern void _mlir_ciface_txe_mul_mat_tile_f32_k2048_host(void *A_tile, void *B_tile, void *C_tile);
+
+
 
 /* 
  * FP16 Kernels 

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -887,36 +887,6 @@ static bool is_op_dtype_consistent_with_src(const struct ggml_tensor *op) {
   return true;
 }
 
-
-#if 0
-static void anoop_test() {
-	return;
-}
-
-static bool mul_mat_supported_size(const struct ggml_tensor *op) {
-    const struct ggml_tensor *a = op->src[0];
-    const struct ggml_tensor *b = op->src[1];
-    if (!a || !b) return false;
-
-    const int64_t K = a->ne[0];
-    if ((K % TMU_K_MULTIPLE) != 0) return false;
-
-    // avoid GEMV
-    if (b->ne[1] == 1) return false;
-
-    // sanity: reduction dims match
-    if (b->ne[0] != K) return false;
-
-    if((op->ne[0]  == 2048 && op->ne[1] ==  512))
-	    return true;
-    if((op->ne[0]  == 32003 && op->ne[1] ==  512))
-	    return true;
-    anoop_test();
-
-    return false;
-}
-#endif
-
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     const struct ggml_tensor *a = op->src[0];
     const struct ggml_tensor *b = op->src[1];
@@ -938,6 +908,9 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
 
     // reduction dims must match
     if (b->ne[0] != K) return false;
+
+    if (K == 64 || K == 576 || K == 1536 || K == 256)
+	    return true;
 
     // (optional but usually correct for ggml mul_mat wiring)
     // If this blocks valid cases in your build, comment it out.

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -32,28 +32,70 @@
 #include "tsi-rt/utils/Profiler.h"
 
 #ifdef TMU_DEBUG_VALIDATE
-static void cpu_ref_mul_mat_f32(
-        const float * A,
-        const float * B,
-        float * C,
-        int M,
-        int N,
-        int K,
-        int lda,
-        int ldb,
-        int ldc) {
 
-    for (int i = 0; i < M; ++i) {
-        for (int j = 0; j < N; ++j) {
+// CPU reference GEMM for TMU packed tiles using the SAME MemRefDescriptor<4>
+// struct used by your MLIR ciface wrappers (base/data/offset/shape/strides). 
+// Interprets shapes as you set them in init_memref_4d():
+//   A: [1,1,M,K]  -> shape[2]=M, shape[3]=K
+//   B: [1,1,N,K]  -> shape[2]=N, shape[3]=K   (NOTE: your B_pack is stored as rows=N, cols=K)
+//   C: [1,1,M,N]  -> shape[2]=M, shape[3]=N
+//
+// Strides are in ELEMENTS (not bytes), consistent with init_memref_4d(). 
+//
+static void cpu_ref_mul_mat_f32(
+    const MemRefDescriptor<4> *A_desc,
+    const MemRefDescriptor<4> *B_desc,
+    MemRefDescriptor<4>       *C_desc
+) {
+    if (!A_desc || !B_desc || !C_desc) return;
+    if (!A_desc->data || !B_desc->data || !C_desc->data) return;
+
+    const int64_t M = A_desc->shape[2];
+    const int64_t K = A_desc->shape[3];
+    const int64_t N = B_desc->shape[2];
+
+    if (M <= 0 || N <= 0 || K <= 0) return;
+
+    // Reduction dims must match
+    if (B_desc->shape[3] != K) return;
+
+    // Output dims must match
+    if (C_desc->shape[2] != M) return;
+    if (C_desc->shape[3] != N) return;
+
+    const float *A = (const float *) A_desc->data;
+    const float *B = (const float *) B_desc->data;
+    float       *C = (float       *) C_desc->data;
+
+    // Strides in elements
+    const int64_t a_s2 = A_desc->strides[2];
+    const int64_t a_s3 = A_desc->strides[3];
+    const int64_t b_s2 = B_desc->strides[2];
+    const int64_t b_s3 = B_desc->strides[3];
+    const int64_t c_s2 = C_desc->strides[2];
+    const int64_t c_s3 = C_desc->strides[3];
+
+    const int64_t a_off = A_desc->offset;
+    const int64_t b_off = B_desc->offset;
+    const int64_t c_off = C_desc->offset;
+
+    for (int64_t r = 0; r < M; ++r) {
+        const int64_t a_row = a_off + r * a_s2;
+        const int64_t c_row = c_off + r * c_s2;
+
+        for (int64_t n = 0; n < N; ++n) {
+            const int64_t b_row = b_off + n * b_s2;   // B is [N,K] packed
+
             float acc = 0.0f;
-            for (int k = 0; k < K; ++k) {
-                acc += A[i * lda + k] * B[k * ldb + j];
+            for (int64_t kk = 0; kk < K; ++kk) {
+                acc += A[a_row + kk * a_s3] * B[b_row + kk * b_s3];
             }
-            C[i * ldc + j] = acc;
+            C[c_row + n * c_s3] = acc;
         }
     }
 }
-#endif
+
+#endif // TMU_DEBUG_VALIDATE
 
 
 enum ggml_tsavorite_kernel_mode ggml_tsavorite_kernel_mode_flag = GGML_TSAVORITE_KERNEL_MODE_MLIR;
@@ -846,6 +888,11 @@ static bool is_op_dtype_consistent_with_src(const struct ggml_tensor *op) {
 }
 
 
+#if 0
+static void anoop_test() {
+	return;
+}
+
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     const struct ggml_tensor *a = op->src[0];
     const struct ggml_tensor *b = op->src[1];
@@ -860,7 +907,79 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     // sanity: reduction dims match
     if (b->ne[0] != K) return false;
 
-    return true;
+    if((op->ne[0]  == 2048 && op->ne[1] ==  512))
+	    return true;
+    if((op->ne[0]  == 32003 && op->ne[1] ==  512))
+	    return true;
+    anoop_test();
+
+    return false;
+}
+#endif
+
+static bool mul_mat_supported_size(const struct ggml_tensor *op) {
+    const struct ggml_tensor *a = op->src[0];
+    const struct ggml_tensor *b = op->src[1];
+    if (!a || !b) return false;
+
+    // GGML MUL_MAT:
+    //   K = a->ne[0]
+    //   out = [N = op->ne[0], M = op->ne[1]]
+    const int64_t K = a->ne[0];
+    const int64_t N = op->ne[0];
+    const int64_t M = op->ne[1];
+
+    if (K <= 0 || N <= 0 || M <= 0) return false;
+
+    if ((K % TMU_K_MULTIPLE) != 0) return false;
+
+    // avoid GEMV (you can remove this if you later implement GEMV path)
+    if (M == 1) return false;
+
+    // reduction dims must match
+    if (b->ne[0] != K) return false;
+
+    // (optional but usually correct for ggml mul_mat wiring)
+    // If this blocks valid cases in your build, comment it out.
+    if (a->ne[1] != N) return false;
+
+    // -------------------------------------------------------------------------
+    // Tiny-Llama-v0.3-FP32-1.1B-F32.gguf shapes (from your static-shape list)
+    // Most frequent inference shapes are M=7 with K=2048 and N in {256,2048,5632}
+    // -------------------------------------------------------------------------
+
+    // Common token-batch matmuls (M=7)
+    if (M == 7) {
+        // src0: (2048,  256)  src1: (2048, 7)  result: ( 256, 7)
+        if (K == 2048 && N == 256)  return true;
+
+        // src0: (2048, 2048)  src1: (2048, 7)  result: (2048, 7)
+        if (K == 2048 && N == 2048) return true;
+
+        // src0: (2048, 5632)  src1: (2048, 7)  result: (5632, 7)
+        if (K == 2048 && N == 5632) return true;
+
+        // src0: (5632, 2048)  src1: (5632, 7)  result: (2048, 7)
+        // Depending on how ggml wires A/B, this may appear as K=5632, N=2048, M=7.
+        if (K == 5632 && N == 2048) return true;
+    }
+
+    // Packed multi-dim cases you listed:
+    // Count=22: src0 (256,64,4,1) x src1 (256,7,32,1) => result (64,7,32,1)
+    // Count=22: src0 (64,256,4,1) x src1 (64,7,32,1) => result (256,7,32,1)
+    //
+    // Note: In ggml, op->ne[2], op->ne[3] carry the higher dims.
+    // Only enable these if your TMU path truly supports them.
+    if (M == 7 && op->ne[2] == 32 && op->ne[3] == 1) {
+        // result (64, 7, 32, 1)  with K=256 (from src1 ne[0]=256)
+        if (N == 64  && K == 256) return true;
+
+        // result (256, 7, 32, 1) with K=64
+        if (N == 256 && K == 64)  return true;
+    }
+
+    // Default: not supported (prevents CMA from trying to hold most of the model)
+    return false;
 }
 
 static bool ggml_tsavorite_supports_op(const struct ggml_backend_tsavorite_device_context *ctx_dev,
@@ -1027,65 +1146,6 @@ static inline int64_t map_repeat_i64(int64_t out_idx, int64_t in_dim) {
     return (r < 0) ? (r + in_dim) : r;
 }
 
-static inline void copy_tileC_to_ggml_f32(
-    const float *c_tile,
-    int64_t m_tile,
-    int64_t /*N_unused*/,
-    struct ggml_tensor *node,
-    int64_t m_base,
-    int64_t n0,
-    int64_t od2,
-    int64_t od3
-) {
-    if (!node || !node->data || !c_tile) return;
-
-    // node layout: dim0 = columns (ne[0]), dim1 = rows (ne[1])
-    const int64_t M_cols = node->ne[0] ? node->ne[0] : 1;
-    const int64_t N_rows = node->ne[1] ? node->ne[1] : 1;
-
-    const int64_t nb0 = nb_or_default(node, 0);
-    const int64_t nb1 = nb_or_default(node, 1);
-    const int64_t nb2 = nb_or_default(node, 2);
-    const int64_t nb3 = nb_or_default(node, 3);
-
-    const int64_t D2 = node->ne[2] ? node->ne[2] : 1;
-    const int64_t D3 = node->ne[3] ? node->ne[3] : 1;
-
-    if (od2 < 0 || od2 >= D2) return;
-    if (od3 < 0 || od3 >= D3) return;
-
-    if (m_base >= M_cols) return;
-    const int64_t m_tile_clamped =
-        (m_base + m_tile <= M_cols) ? m_tile : (M_cols - m_base);
-
-    if (n0 >= N_rows) return;
-    const int64_t n_end =
-        ((n0 + TMU_N_BLOCK) < N_rows) ? (n0 + TMU_N_BLOCK) : N_rows;
-
-    char *dst_base = (char *) node->data;
-    const size_t bytes_total = (size_t) ggml_nbytes(node);
-
-    for (int64_t r = 0; r < m_tile_clamped; ++r) {
-        const int64_t m = m_base + r;
-        const float *src_row = c_tile + r * TMU_N_BLOCK;
-
-        for (int64_t n = n0; n < n_end; ++n) {
-            const int64_t local_n = n - n0;
-
-            const int64_t byte_off =
-                m   * nb0 +
-                n   * nb1 +
-                od2 * nb2 +
-                od3 * nb3;
-
-            if (byte_off < 0 ||
-                (size_t) byte_off + sizeof(float) > bytes_total) {
-                continue;
-            }
-            *(float *)(dst_base + byte_off) = src_row[local_n];
-        }
-    }
-}
 
 // ============================================================================
 // ABI WRAPPERS: raw pointers -> MemRefDescriptor<4> -> call MLIR ciface
@@ -1194,13 +1254,26 @@ static inline const tmu_bucket_dispatch *tmu_find_bucket(int k) {
 }
 
 static inline int tmu_decompose_k(int64_t k, int *out, int max_parts) {
+    if (!out || max_parts <= 0) return -1;
+    if (k < 0) return -1;  // defensive: never allow negative K
+
     int n = 0;
+
     for (int i = 0; g_tmu_dispatch[i].k != 0 && n < max_parts; ++i) {
-        while (k >= g_tmu_dispatch[i].k && n < max_parts) {
-            out[n++] = g_tmu_dispatch[i].k;
-            k -= g_tmu_dispatch[i].k;
+        const int bucket = g_tmu_dispatch[i].k;
+
+        // Defensive: bucket must be positive
+        if (bucket <= 0) return -1;
+
+        while (k >= (int64_t) bucket && n < max_parts) {
+            out[n++] = bucket;
+            k -= (int64_t) bucket;
+            // Defensive: k should never go negative due to the loop condition
+            if (k < 0) return -1;
         }
     }
+
+    // Must decompose exactly; otherwise unsupported remainder
     return (k == 0) ? n : -1;
 }
 
@@ -1300,9 +1373,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     const struct ggml_tensor * src0 = node->src[0];
     const struct ggml_tensor * src1 = node->src[1];
 
-    if (src0->type != GGML_TYPE_F32 ||
-        src1->type != GGML_TYPE_F32 ||
-        node->type != GGML_TYPE_F32) {
+    if (src0->type != GGML_TYPE_F32 || src1->type != GGML_TYPE_F32 || node->type != GGML_TYPE_F32) {
         return GGML_STATUS_FAILED;
     }
 
@@ -1316,42 +1387,77 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     // -------------------------------------------------------------------------
     static float *g_C_prev = nullptr;
     static std::once_flag g_prev_once;
-
     auto host_alloc_aligned = [](size_t bytes) -> void * {
         void *p = nullptr;
-        // 64-byte alignment is safe for vector loads; fallback to malloc if needed.
         if (posix_memalign(&p, 64, bytes) != 0) {
             p = malloc(bytes);
         }
         return p;
     };
-
     std::call_once(g_prev_once, [&]() {
         const size_t bytes = (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float);
         g_C_prev = (float *) host_alloc_aligned(bytes);
         TSAVORITE_GGML_ASSERT(g_C_prev);
-        // Optional: initialize to zero once (not required, but keeps debuggability clean)
         memset(g_C_prev, 0, bytes);
     });
 
 #ifdef TMU_DEBUG_VALIDATE
-    // CPU reference tile and probes (allocated once)
-    static float C_ref_full[TMU_M_TILE_MAX * TMU_N_BLOCK];
-    static float *C_probe  = nullptr;
-    static float *C_probe2 = nullptr;
-    static float *C_single = nullptr;
-    static std::once_flag probe_once;
+    // -------------------------------------------------------------------------
+    // PR comment fix #1 + your request:
+    // 1) Make CPU reference helper take MemRefDescriptor-like structs
+    // 2) Actually CALL it here (it was dead previously)
+    // -------------------------------------------------------------------------
+    static void cpu_ref_mul_mat_f32(
+        const MemRefDescriptor<4> *A_desc,
+        const MemRefDescriptor<4> *B_desc,
+        MemRefDescriptor<4>       *C_desc
+    ) {
+        if (!A_desc || !B_desc || !C_desc) return;
+        if (!A_desc->data || !B_desc->data || !C_desc->data) return;
 
-    std::call_once(probe_once, [&]() {
-        const size_t bytes = (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float);
-        // NOTE: These ARE passed to the blob in the probe calls, so they MUST be tsi_alloc.
-        C_probe  = (float *) tsi_alloc(bytes);
-        C_probe2 = (float *) tsi_alloc(bytes);
-        C_single = (float *) tsi_alloc(bytes);
-        TSAVORITE_GGML_ASSERT(C_probe && C_probe2 && C_single);
-    });
+        const int64_t M = A_desc->shape[2];
+        const int64_t K = A_desc->shape[3];
+        const int64_t N = B_desc->shape[2];
 
-    const size_t tile_bytes = (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float);
+        if (M <= 0 || N <= 0 || K <= 0) return;
+        if (B_desc->shape[3] != K) return;
+        if (C_desc->shape[2] != M) return;
+        if (C_desc->shape[3] != N) return;
+
+        const float *A = (const float *) A_desc->data;
+        const float *B = (const float *) B_desc->data;
+        float       *C = (float       *) C_desc->data;
+
+        const int64_t a_s2 = A_desc->strides[2];
+        const int64_t a_s3 = A_desc->strides[3];
+        const int64_t b_s2 = B_desc->strides[2];
+        const int64_t b_s3 = B_desc->strides[3];
+        const int64_t c_s2 = C_desc->strides[2];
+        const int64_t c_s3 = C_desc->strides[3];
+
+        const int64_t a_off = A_desc->offset;
+        const int64_t b_off = B_desc->offset;
+        const int64_t c_off = C_desc->offset;
+
+        for (int64_t r = 0; r < M; ++r) {
+            const int64_t a_row = a_off + r * a_s2;
+            const int64_t c_row = c_off + r * c_s2;
+
+            for (int64_t n = 0; n < N; ++n) {
+                const int64_t b_row = b_off + n * b_s2;   // B packed as [N,K]
+
+                float acc = 0.0f;
+                for (int64_t kk = 0; kk < K; ++kk) {
+                    acc += A[a_row + kk * a_s3] * B[b_row + kk * b_s3];
+                }
+                C[c_row + n * c_s3] = acc;
+            }
+        }
+    }
+
+    // CPU reference buffers: accumulate chunk-by-chunk in packed space
+    static float C_ref_chunk[TMU_M_TILE_MAX * TMU_N_BLOCK];
+    static float C_ref_accum[TMU_M_TILE_MAX * TMU_N_BLOCK];
 #endif
 
     const int64_t K = src0->ne[0];
@@ -1377,11 +1483,12 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     const int64_t c_nb2 = nb_or_default(node, 2);
     const int64_t c_nb3 = nb_or_default(node, 3);
 
-    // --- broadcast dims must come from inputs ---
+    // broadcast dims must come from inputs
     const int64_t A2 = src0->ne[2] ? src0->ne[2] : 1;
     const int64_t A3 = src0->ne[3] ? src0->ne[3] : 1;
     const int64_t B2 = src1->ne[2] ? src1->ne[2] : 1;
     const int64_t B3 = src1->ne[3] ? src1->ne[3] : 1;
+
     const int64_t D2 = (A2 > B2) ? A2 : B2;
     const int64_t D3 = (A3 > B3) ? A3 : B3;
 
@@ -1406,8 +1513,12 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                 for (int64_t n0 = 0; n0 < N; n0 += TMU_N_BLOCK) {
                     const int64_t n_valid = (N - n0 >= TMU_N_BLOCK) ? TMU_N_BLOCK : (N - n0);
 
-                    memset(g_C_tile, 0,
-                           (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+                    memset(g_C_tile, 0, (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+
+#ifdef TMU_DEBUG_VALIDATE
+                    // reset CPU ref accumulator for THIS output tile
+                    memset(C_ref_accum, 0, sizeof(C_ref_accum));
+#endif
 
                     int parts[128];
                     const int np = tmu_decompose_k(K, parts, (int)(sizeof(parts)/sizeof(parts[0])));
@@ -1423,7 +1534,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                         pack_A_tile_f32(g_A_pack, A_base_d23, m0, m_tile, k0, K_chunk, a_nb0, a_nb1);
                         pack_B_tile_f32(g_B_pack, B_base_d23, n0, n_valid, k0, K_chunk, b_nb0, b_nb1);
 
-                        // ---- SAVE PREVIOUS PARTIAL ----
+                        // Save previous partial before calling blob (because blob overwrites)
                         if (pi > 0) {
                             memcpy(g_C_prev, g_C_tile,
                                    (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
@@ -1432,7 +1543,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                         // Run blob
                         bucket->fn(g_A_pack, g_B_pack, g_C_tile);
 
-                        // ---- ACCUMULATE BACK (blob overwrites) ----
+                        // Accumulate back (host-side workaround)
                         if (pi > 0) {
                             const int total = TMU_M_TILE_MAX * TMU_N_BLOCK;
                             for (int i = 0; i < total; ++i) {
@@ -1445,79 +1556,46 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                         ++node->tsi_kernel_runs;
 
 #ifdef TMU_DEBUG_VALIDATE
-                        const bool is_first_tile = (m0 == 0 && n0 == 0 && od2 == 0 && od3 == 0);
+                        // -----------------------------------------------------------------
+                        // CPU reference for THIS K_chunk computed from PACKED tiles
+                        // and accumulated into C_ref_accum, then compared with g_C_tile.
+                        // This makes cpu_ref_mul_mat_f32() actually USED.
+                        // -----------------------------------------------------------------
+                        memset(C_ref_chunk, 0, sizeof(C_ref_chunk));
 
-                        if (is_first_tile && np > 1 && pi > 0) {
-                            // Double-call probe
-                            memset(C_probe, 0, tile_bytes);
-                            bucket->fn(g_A_pack, g_B_pack, C_probe);
-                            memcpy(C_single, C_probe, tile_bytes);
-                            bucket->fn(g_A_pack, g_B_pack, C_probe);
+                        MemRefDescriptor<4> Aref, Bref, Cref;
+                        init_memref_4d(Aref, (void*)g_A_pack, 1, 1, TMU_M_TILE_MAX, (int64_t)K_chunk);
+                        init_memref_4d(Bref, (void*)g_B_pack, 1, 1, TMU_N_BLOCK,   (int64_t)K_chunk);
+                        init_memref_4d(Cref, (void*)C_ref_chunk, 1, 1, TMU_M_TILE_MAX, TMU_N_BLOCK);
 
-                            const float s0 = C_single[0];
-                            const float s1 = C_probe[0];
-                            const float expect = 2.0f * s0;
-                            const float diff = fabsf(s1 - expect);
+                        cpu_ref_mul_mat_f32(&Aref, &Bref, &Cref);
 
-                            fprintf(stderr,
-                                "\nTMU PROBE (pi=%d, K_chunk=%d, k0=%ld): double-call: "
-                                "single=%f second=%f expect=%f diff=%f\n",
-                                pi, K_chunk, (long)k0, s0, s1, expect, diff);
-
-                            // Carry-in probe
-                            for (int i = 0; i < TMU_M_TILE_MAX * TMU_N_BLOCK; ++i) C_probe2[i] = 1.0f;
-
-                            static float A_save[TMU_M_TILE_MAX * 2048];
-                            static float B_save[TMU_N_BLOCK    * 2048];
-
-                            memcpy(A_save, g_A_pack, (size_t)TMU_M_TILE_MAX * (size_t)K_chunk * sizeof(float));
-                            memcpy(B_save, g_B_pack, (size_t)TMU_N_BLOCK    * (size_t)K_chunk * sizeof(float));
-                            memset(g_A_pack, 0, (size_t)TMU_M_TILE_MAX * (size_t)K_chunk * sizeof(float));
-                            memset(g_B_pack, 0, (size_t)TMU_N_BLOCK    * (size_t)K_chunk * sizeof(float));
-
-                            bucket->fn(g_A_pack, g_B_pack, C_probe2);
-
-                            memcpy(g_A_pack, A_save, (size_t)TMU_M_TILE_MAX * (size_t)K_chunk * sizeof(float));
-                            memcpy(g_B_pack, B_save, (size_t)TMU_N_BLOCK    * (size_t)K_chunk * sizeof(float));
-
-                            fprintf(stderr,
-                                "TMU PROBE (pi=%d, K_chunk=%d, k0=%ld): carry-in: "
-                                "C_in=1.0 => C_out[0]=%f (expect ~1.0 if accum)\n",
-                                pi, K_chunk, (long)k0, C_probe2[0]);
-                        }
-
-                        // CPU reference compare up to K_so_far
-                        memset(C_ref_full, 0, sizeof(C_ref_full));
-                        const int64_t K_so_far = k0 + K_chunk;
-
+                        // accumulate CPU reference chunks (only valid region is needed)
                         for (int64_t rr = 0; rr < m_tile; ++rr) {
                             for (int64_t cc = 0; cc < n_valid; ++cc) {
-                                float acc = 0.0f;
-                                for (int64_t kk = 0; kk < K_so_far; ++kk) {
-                                    const float a = *(const float *)(A_base_d23 + (m0 + rr) * a_nb1 + kk * a_nb0);
-                                    const float b = *(const float *)(B_base_d23 + (n0 + cc) * b_nb1 + kk * b_nb0);
-                                    acc += a * b;
-                                }
-                                C_ref_full[rr * TMU_N_BLOCK + cc] = acc;
+                                C_ref_accum[rr * TMU_N_BLOCK + cc] +=
+                                    C_ref_chunk[rr * TMU_N_BLOCK + cc];
                             }
                         }
 
+                        // Compare after each chunk (same tolerance you used before)
                         for (int64_t rr = 0; rr < m_tile; ++rr) {
                             for (int64_t cc = 0; cc < n_valid; ++cc) {
                                 const float tmu_v = g_C_tile[rr * TMU_N_BLOCK + cc];
-                                const float ref_v = C_ref_full[rr * TMU_N_BLOCK + cc];
+                                const float ref_v = C_ref_accum[rr * TMU_N_BLOCK + cc];
                                 if (fabsf(tmu_v - ref_v) > 1e-4f) {
                                     fprintf(stderr,
-                                        "\nTMU MISMATCH (accum)\n"
-                                        "m0=%ld n0=%ld K_so_far=%ld\n"
+                                        "\nTMU MISMATCH (packed-ref)\n"
+                                        "m0=%ld n0=%ld k0=%ld K_chunk=%d pi=%d\n"
                                         "r=%ld c=%ld TMU=%f REF=%f\n",
-                                        (long)m0, (long)n0, (long)K_so_far,
+                                        (long)m0, (long)n0, (long)k0, K_chunk, pi,
                                         (long)rr, (long)cc, tmu_v, ref_v);
                                     abort();
                                 }
                             }
                         }
 #endif
+
                         k0 += K_chunk;
                     }
 
@@ -1527,22 +1605,29 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                         const size_t bytes_total = (size_t) ggml_nbytes(node);
 
                         for (int64_t rr = 0; rr < m_tile; ++rr) {
-                            const int64_t m = m0 + rr;
+                            const int64_t m_idx = m0 + rr;
                             const float *src_row = g_C_tile + rr * TMU_N_BLOCK;
 
                             for (int64_t cc = 0; cc < n_valid; ++cc) {
-                                const int64_t n = n0 + cc;
-                                const int64_t byte_off =
-                                    m  * c_nb0 +
-                                    n  * c_nb1 +
-                                    od2 * c_nb2 +
-                                    od3 * c_nb3;
+                                const int64_t n_idx = n0 + cc;
 
-                                if (byte_off < 0 || (size_t)byte_off + sizeof(float) > bytes_total) continue;
+                                const int64_t byte_off =
+                                    m_idx * c_nb0 +
+                                    n_idx * c_nb1 +
+                                    od2  * c_nb2 +
+                                    od3  * c_nb3;
+
+                                if (byte_off < 0 ||
+                                    (size_t)byte_off + sizeof(float) > bytes_total) {
+                                    continue;
+                                }
                                 *(float *)(dst_base + byte_off) = src_row[cc];
                             }
                         }
                     }
+
+                    // If you decide to USE copy_tileC_to_ggml_f32 instead of inline copy-back:
+                    // copy_tileC_to_ggml_f32(g_C_tile, m_tile, 0, node, m0, n0, od2, od3);
                 }
             }
         }
@@ -1865,7 +1950,6 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
             const int64_t ne13 = src1 ? src1->ne[3] : 1;
         
             // TODO: is this supposed to be ceil instead of floor?
-            //       https://huggingface.co/mosaicml/mpt-7b/blob/main/attention.py#L370
             const uint32_t n_head      = ne02;
             const uint32_t n_head_log2 = 1u << (uint32_t) floor(log2(n_head));
 

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -845,9 +845,6 @@ static bool is_op_dtype_consistent_with_src(const struct ggml_tensor *op) {
   return true;
 }
 
-static void anoop_test() {
-	return;
-}
 
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     const struct ggml_tensor *a = op->src[0];

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -895,10 +895,14 @@ static bool ggml_tsavorite_supports_op(const struct ggml_backend_tsavorite_devic
   case GGML_OP_SOFT_MAX:
 #endif /* GGML_TARGET_POSIX_DEBUG */
     break;
+
+#ifdef GGML_TARGET_POSIX
   case GGML_OP_MUL_MAT:
 	  if (!mul_mat_supported_size(op))
 		  return false;
     break;
+#endif /* GGML_TARGET_POSIX */
+
   case GGML_OP_GLU:
     {
         const ggml_glu_op op_ext = ggml_get_glu_op(op);
@@ -1304,13 +1308,30 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
     ensure_tmu_pack_buffers();
 
-    // --- buffer to save previous partial C between K buckets ---
+    // -------------------------------------------------------------------------
+    // Host-only buffer to save previous partial C between K buckets.
+    // IMPORTANT: This buffer is NOT passed to the TMU blob, so DO NOT use tsi_alloc
+    // (tsi_alloc comes from CMA and is not freed until tsi_finalize).
+    // Allocate once from normal host heap and reuse.
+    // -------------------------------------------------------------------------
     static float *g_C_prev = nullptr;
     static std::once_flag g_prev_once;
-    std::call_once(g_prev_once, []() {
-        g_C_prev = (float *) tsi_alloc(
-            (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+
+    auto host_alloc_aligned = [](size_t bytes) -> void * {
+        void *p = nullptr;
+        // 64-byte alignment is safe for vector loads; fallback to malloc if needed.
+        if (posix_memalign(&p, 64, bytes) != 0) {
+            p = malloc(bytes);
+        }
+        return p;
+    };
+
+    std::call_once(g_prev_once, [&]() {
+        const size_t bytes = (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float);
+        g_C_prev = (float *) host_alloc_aligned(bytes);
         TSAVORITE_GGML_ASSERT(g_C_prev);
+        // Optional: initialize to zero once (not required, but keeps debuggability clean)
+        memset(g_C_prev, 0, bytes);
     });
 
 #ifdef TMU_DEBUG_VALIDATE
@@ -1323,6 +1344,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
     std::call_once(probe_once, [&]() {
         const size_t bytes = (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float);
+        // NOTE: These ARE passed to the blob in the probe calls, so they MUST be tsi_alloc.
         C_probe  = (float *) tsi_alloc(bytes);
         C_probe2 = (float *) tsi_alloc(bytes);
         C_single = (float *) tsi_alloc(bytes);
@@ -1423,10 +1445,10 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                         ++node->tsi_kernel_runs;
 
 #ifdef TMU_DEBUG_VALIDATE
-                        // Optional probes (only for the very first output tile; helps detect overwrite vs accum)
                         const bool is_first_tile = (m0 == 0 && n0 == 0 && od2 == 0 && od3 == 0);
+
                         if (is_first_tile && np > 1 && pi > 0) {
-                            // Double-call probe: same inputs twice should double output if blob accumulates internally
+                            // Double-call probe
                             memset(C_probe, 0, tile_bytes);
                             bucket->fn(g_A_pack, g_B_pack, C_probe);
                             memcpy(C_single, C_probe, tile_bytes);
@@ -1442,11 +1464,12 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                                 "single=%f second=%f expect=%f diff=%f\n",
                                 pi, K_chunk, (long)k0, s0, s1, expect, diff);
 
-                            // Carry-in probe: if blob truly loads PP from C_tile, passing 1.0 should preserve it when A/B are zero
+                            // Carry-in probe
                             for (int i = 0; i < TMU_M_TILE_MAX * TMU_N_BLOCK; ++i) C_probe2[i] = 1.0f;
 
                             static float A_save[TMU_M_TILE_MAX * 2048];
                             static float B_save[TMU_N_BLOCK    * 2048];
+
                             memcpy(A_save, g_A_pack, (size_t)TMU_M_TILE_MAX * (size_t)K_chunk * sizeof(float));
                             memcpy(B_save, g_B_pack, (size_t)TMU_N_BLOCK    * (size_t)K_chunk * sizeof(float));
                             memset(g_A_pack, 0, (size_t)TMU_M_TILE_MAX * (size_t)K_chunk * sizeof(float));
@@ -1463,7 +1486,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                                 pi, K_chunk, (long)k0, C_probe2[0]);
                         }
 
-                        // CPU reference compare up to K_so_far (after host-side accumulation)
+                        // CPU reference compare up to K_so_far
                         memset(C_ref_full, 0, sizeof(C_ref_full));
                         const int64_t K_so_far = k0 + K_chunk;
 
@@ -1495,7 +1518,6 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                             }
                         }
 #endif
-
                         k0 += K_chunk;
                     }
 
@@ -2785,11 +2807,15 @@ static bool ggml_backend_tsavorite_device_offload_op(ggml_backend_dev_t dev,
   case GGML_OP_SOFT_MAX:
 #endif /* GGML_TARGET_POSIX_DEBUG */
     break;
+
+#ifdef GGML_TARGET_POSIX
   case GGML_OP_MUL_MAT:
 	  if (!mul_mat_supported_size(op))
 		  return false;
 
     break;
+#endif /* GGML_TARGET_POSIX */
+
   case GGML_OP_GLU:
     {
         const ggml_glu_op op_ext = ggml_get_glu_op(op);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -31,6 +31,30 @@
 #include "HostShimCAPI.h"
 #include "tsi-rt/utils/Profiler.h"
 
+#ifdef TMU_DEBUG_VALIDATE
+static void cpu_ref_mul_mat_f32(
+        const float * A,
+        const float * B,
+        float * C,
+        int M,
+        int N,
+        int K,
+        int lda,
+        int ldb,
+        int ldc) {
+
+    for (int i = 0; i < M; ++i) {
+        for (int j = 0; j < N; ++j) {
+            float acc = 0.0f;
+            for (int k = 0; k < K; ++k) {
+                acc += A[i * lda + k] * B[k * ldb + j];
+            }
+            C[i * ldc + j] = acc;
+        }
+    }
+}
+#endif
+
 
 enum ggml_tsavorite_kernel_mode ggml_tsavorite_kernel_mode_flag = GGML_TSAVORITE_KERNEL_MODE_MLIR;
 enum ggml_tsavorite_log_type ggml_tsavorite_log_type_val        = GGML_TSAVORITE_LOG_ALL;
@@ -821,14 +845,25 @@ static bool is_op_dtype_consistent_with_src(const struct ggml_tensor *op) {
   return true;
 }
 
+static void anoop_test() {
+	return;
+}
 
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
-   // As a result of FIR-1401, support for K size 2048 is temporarily disabled.
-   //if (op->src[0]->ne[0] == TMU_K_576 || op->src[0]->ne[0] == TMU_K_1536 || op->src[0]->ne[0] == TMU_K_2048)
-   if (op->src[0]->ne[0] == TMU_K_576 || op->src[0]->ne[0] == TMU_K_1536)
-       return true;
-   return false;
+    const struct ggml_tensor *a = op->src[0];
+    const struct ggml_tensor *b = op->src[1];
+    if (!a || !b) return false;
 
+    const int64_t K = a->ne[0];
+    if ((K % TMU_K_MULTIPLE) != 0) return false;
+
+    // avoid GEMV
+    if (b->ne[1] == 1) return false;
+
+    // sanity: reduction dims match
+    if (b->ne[0] != K) return false;
+
+    return true;
 }
 
 static bool ggml_tsavorite_supports_op(const struct ggml_backend_tsavorite_device_context *ctx_dev,
@@ -863,12 +898,10 @@ static bool ggml_tsavorite_supports_op(const struct ggml_backend_tsavorite_devic
   case GGML_OP_SOFT_MAX:
 #endif /* GGML_TARGET_POSIX_DEBUG */
     break;
-#ifdef GGML_TARGET_POSIX_DEBUG
   case GGML_OP_MUL_MAT:
 	  if (!mul_mat_supported_size(op))
 		  return false;
     break;
-#endif /* GGML_TARGET_POSIX_DEBUG */
   case GGML_OP_GLU:
     {
         const ggml_glu_op op_ext = ggml_get_glu_op(op);
@@ -956,192 +989,360 @@ static enum ggml_tsavorite_kernel_type tsi_glu_kernel_type(struct ggml_tensor *n
 
 
 // TMU CODE
-
 // ============================================================================
-// TMU TILE-BLOB APPLICATION SUPPORT (STATIC AOT TILE ABI)
+// SINGLE-PHASE TMU K-TILING (ONE BLOB PER K) + ABI-SAFE WRAPPERS
+// -----------------------------------------------------------------------------
+// Blob semantics assumed:
+//   - Each call reloads PP from C_tile scratchpad
+//   - Runs: PP = A*B + PP across K in this blob
+//   - Last internal op materializes C = A*B + PP
+//   - Stores back to SAME C_tile (scratchpad updated)
 //
-//   A_tile: [1,1,TMU_M_TILE_MAX, TMU_BLOB_K]   (FP32)
-//   B_tile: [1,1,TMU_N_BLOCK,    TMU_BLOB_K]   (FP32, padded to 32 cols)
-//   C_tile: [1,1,TMU_M_TILE_MAX, TMU_N_BLOCK]  (FP32, padded output)
+// IMPORTANT: The MLIR-exported symbols (_mlir_ciface_*_host) expect MemRefDescriptor
+// pointers, NOT raw float pointers. We therefore provide C ABI wrappers
+//   tmu_mul_mat_k{K}(A_raw, B_raw, C_raw)
+// that build MemRefDescriptor<4> and call the MLIR entrypoint safely.
 //
-// Blob loops over all 64 rows and all 32 cols internally, so app must:
+// App responsibilities:
+//   - pack A/B per K_chunk (contiguous stride=K_chunk)
 //   - zero-pad A rows beyond m_tile
-//   - zero-pad B cols beyond n_tile
-//   - copy only valid (m_tile x n_valid) back to node->data
+//   - zero-pad B cols beyond n_valid
+//   - memset(C_tile,0) once per output tile
+//   - call buckets in K decomposition order
+//   - copy valid region from C_tile back to ggml output
 // ============================================================================
 
+#include <mutex>            // for std::once_flag / std::call_once
 
-// Default nb if missing (bytes stride)
 static inline int64_t nb_or_default(const struct ggml_tensor *t, int i) {
     if (t->nb[i] != 0) return t->nb[i];
     if (i == 0) return (int64_t) ggml_type_size(t->type);
     return nb_or_default(t, i - 1) * t->ne[i - 1];
 }
 
-// Broadcast/repeat mapping: out_idx -> in_idx
 static inline int64_t map_repeat_i64(int64_t out_idx, int64_t in_dim) {
     if (in_dim <= 1) return 0;
     int64_t r = out_idx % in_dim;
     return (r < 0) ? (r + in_dim) : r;
 }
 
-// Make a contiguous memref<4> header for our packed tiles.
-// Our packed tiles are plain contiguous FP32 arrays.
-static inline void init_contig_memref_4d(
-    MemRefDescriptor<4> *md,
-    void *data_ptr,
-    int64_t d0, int64_t d1, int64_t d2, int64_t d3
-) {
-    md->base = md->data = data_ptr;
-    md->offset = 0;
-
-    md->shape[0] = d0;
-    md->shape[1] = d1;
-    md->shape[2] = d2;
-    md->shape[3] = d3;
-
-    // row-major contiguous strides in ELEMENTS
-    md->strides[3] = 1;
-    md->strides[2] = d3;
-    md->strides[1] = d2 * d3;
-    md->strides[0] = d1 * d2 * d3;
-}
-
-// Copy from packed C_tile [64][32] into GGML node at (m_base, n0, od2, od3).
-// We copy only valid columns (n_end) and valid rows (m_tile).
 static inline void copy_tileC_to_ggml_f32(
-    const float *c_tile,        // [TMU_M_TILE_MAX][TMU_N_BLOCK]
-    int64_t m_tile,             // <= TMU_M_TILE_MAX
-    int64_t N,                  // actual output N
-    struct ggml_tensor *node,   // output tensor
+    const float *c_tile,
+    int64_t m_tile,
+    int64_t /*N_unused*/,
+    struct ggml_tensor *node,
     int64_t m_base,
     int64_t n0,
     int64_t od2,
     int64_t od3
 ) {
-    const int64_t nb0 = node->nb[0];
-    const int64_t nb1 = node->nb[1];
-    const int64_t nb2 = node->nb[2];
-    const int64_t nb3 = node->nb[3];
+    if (!node || !node->data || !c_tile) return;
+
+    // node layout: dim0 = columns (ne[0]), dim1 = rows (ne[1])
+    const int64_t M_cols = node->ne[0] ? node->ne[0] : 1;
+    const int64_t N_rows = node->ne[1] ? node->ne[1] : 1;
+
+    const int64_t nb0 = nb_or_default(node, 0);
+    const int64_t nb1 = nb_or_default(node, 1);
+    const int64_t nb2 = nb_or_default(node, 2);
+    const int64_t nb3 = nb_or_default(node, 3);
+
+    const int64_t D2 = node->ne[2] ? node->ne[2] : 1;
+    const int64_t D3 = node->ne[3] ? node->ne[3] : 1;
+
+    if (od2 < 0 || od2 >= D2) return;
+    if (od3 < 0 || od3 >= D3) return;
+
+    if (m_base >= M_cols) return;
+    const int64_t m_tile_clamped =
+        (m_base + m_tile <= M_cols) ? m_tile : (M_cols - m_base);
+
+    if (n0 >= N_rows) return;
+    const int64_t n_end =
+        ((n0 + TMU_N_BLOCK) < N_rows) ? (n0 + TMU_N_BLOCK) : N_rows;
+
     char *dst_base = (char *) node->data;
+    const size_t bytes_total = (size_t) ggml_nbytes(node);
 
-    const int64_t n_end = ((n0 + TMU_N_BLOCK) < N) ? (n0 + TMU_N_BLOCK) : N;
-
-    for (int64_t r = 0; r < m_tile; ++r) {
+    for (int64_t r = 0; r < m_tile_clamped; ++r) {
         const int64_t m = m_base + r;
         const float *src_row = c_tile + r * TMU_N_BLOCK;
 
         for (int64_t n = n0; n < n_end; ++n) {
             const int64_t local_n = n - n0;
-            float *dst = (float *)(dst_base + m * nb0 + n * nb1 + od2 * nb2 + od3 * nb3);
-            *dst = src_row[local_n];
+
+            const int64_t byte_off =
+                m   * nb0 +
+                n   * nb1 +
+                od2 * nb2 +
+                od3 * nb3;
+
+            if (byte_off < 0 ||
+                (size_t) byte_off + sizeof(float) > bytes_total) {
+                continue;
+            }
+            *(float *)(dst_base + byte_off) = src_row[local_n];
         }
     }
 }
 
-// -----------------------------------------------------------------------------
-// Persistent packed tiles (header + data) to avoid allocating every tile call.
-// Layout: [MemRefDescriptor<4>][float data...]
-// -----------------------------------------------------------------------------
-static char   *g_tileA_raw = NULL;
-static size_t  g_tileA_cap = 0;
+// ============================================================================
+// ABI WRAPPERS: raw pointers -> MemRefDescriptor<4> -> call MLIR ciface
+// This DEFINES the symbols your .h/.cpp want: tmu_mul_mat_k{K}.
+// ============================================================================
 
-static char   *g_tileB_raw = NULL;
-static size_t  g_tileB_cap = 0;
+static inline void init_memref_4d(MemRefDescriptor<4> &m,
+                                 void *ptr,
+                                 int64_t d0, int64_t d1, int64_t d2, int64_t d3) {
+    m.base   = ptr;
+    m.data   = ptr;
+    m.offset = 0;
 
-static char   *g_tileC_raw = NULL;
-static size_t  g_tileC_cap = 0;
+    m.shape[0] = d0;
+    m.shape[1] = d1;
+    m.shape[2] = d2;
+    m.shape[3] = d3;
 
-static inline MemRefDescriptor<4> *alloc_tile(char **raw, size_t *cap, size_t data_bytes) {
-    const size_t total = sizeof(MemRefDescriptor<4>) + data_bytes;
-    if (*raw && *cap >= total) {
-        return (MemRefDescriptor<4> *)(*raw);
+    // Strides in ELEMENTS (standard MLIR memref convention)
+    m.strides[3] = 1;
+    m.strides[2] = d3;
+    m.strides[1] = d2 * d3;
+    m.strides[0] = d1 * d2 * d3;
+}
+
+
+template<int K>
+static inline void call_tmu_blob(
+    const void *A_tile,
+    const void *B_tile,
+    void *C_tile,
+    void (*fn)(void*, void*, void*)
+) {
+    // Allocate ABI descriptors in tsi_alloc (device-visible) ONCE.
+    static MemRefDescriptor<4> *A = nullptr;
+    static MemRefDescriptor<4> *B = nullptr;
+    static MemRefDescriptor<4> *C = nullptr;
+    static bool inited = false;
+
+    if (!inited) {
+        A = (MemRefDescriptor<4> *)tsi_alloc(sizeof(MemRefDescriptor<4>));
+        B = (MemRefDescriptor<4> *)tsi_alloc(sizeof(MemRefDescriptor<4>));
+        C = (MemRefDescriptor<4> *)tsi_alloc(sizeof(MemRefDescriptor<4>));
+        TSAVORITE_GGML_ASSERT(A && B && C);
+        inited = true;
     }
-    *raw = (char *) tsi_alloc(total);
-    *cap = (*raw) ? total : 0;
-    return (*raw) ? (MemRefDescriptor<4> *)(*raw) : NULL;
+
+    // Fill descriptors (strides in ELEMENTS)
+    init_memref_4d(*A, (void*)A_tile, 1, 1, TMU_M_TILE_MAX, K);
+    init_memref_4d(*B, (void*)B_tile, 1, 1, TMU_N_BLOCK,   K);
+    init_memref_4d(*C, (void*)C_tile, 1, 1, TMU_M_TILE_MAX, TMU_N_BLOCK);
+
+    fn((void*)A, (void*)B, (void*)C);
+}
+
+
+extern "C" void tmu_mul_mat_k32 (const void *A, const void *B, void *C) {
+    call_tmu_blob<32>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k32_host);
+}
+extern "C" void tmu_mul_mat_k64 (const void *A, const void *B, void *C) {
+    call_tmu_blob<64>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k64_host);
+}
+extern "C" void tmu_mul_mat_k128(const void *A, const void *B, void *C) {
+    call_tmu_blob<128>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k128_host);
+}
+extern "C" void tmu_mul_mat_k256(const void *A, const void *B, void *C) {
+    call_tmu_blob<256>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k256_host);
+}
+extern "C" void tmu_mul_mat_k512(const void *A, const void *B, void *C) {
+    call_tmu_blob<512>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k512_host);
+}
+extern "C" void tmu_mul_mat_k1024(const void *A, const void *B, void *C) {
+    call_tmu_blob<1024>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k1024_host);
+}
+extern "C" void tmu_mul_mat_k2048(const void *A, const void *B, void *C) {
+    call_tmu_blob<2048>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k2048_host);
 }
 
 // ============================================================================
-// FINAL TMU runner for STATIC TILE BLOB
-// This Func does tiling + padding + repack.
-// That requires:
-//    persistent tile buffers
-//    packing loops
-//    repack loops
+// DISPATCH (ONE PER K BUCKET) — points to ABI-safe wrappers above
+// ============================================================================
+
+typedef void (*tmu_mul_mat_tile_fn)(const void *A_tile, const void *B_tile, void *C_tile);
+
+struct tmu_bucket_dispatch {
+    int k;
+    tmu_mul_mat_tile_fn fn;
+};
+
+static const tmu_bucket_dispatch g_tmu_dispatch[] = {
+    { 2048, tmu_mul_mat_k2048 },
+    { 1024, tmu_mul_mat_k1024 },
+    {  512, tmu_mul_mat_k512  },
+    {  256, tmu_mul_mat_k256  },
+    {  128, tmu_mul_mat_k128  },
+    {   64, tmu_mul_mat_k64   },
+    {   32, tmu_mul_mat_k32   },
+    {    0, nullptr           }
+};
+
+static inline const tmu_bucket_dispatch *tmu_find_bucket(int k) {
+    for (int i = 0; g_tmu_dispatch[i].k != 0; ++i) {
+        if (g_tmu_dispatch[i].k == k) return &g_tmu_dispatch[i];
+    }
+    return nullptr;
+}
+
+static inline int tmu_decompose_k(int64_t k, int *out, int max_parts) {
+    int n = 0;
+    for (int i = 0; g_tmu_dispatch[i].k != 0 && n < max_parts; ++i) {
+        while (k >= g_tmu_dispatch[i].k && n < max_parts) {
+            out[n++] = g_tmu_dispatch[i].k;
+            k -= g_tmu_dispatch[i].k;
+        }
+    }
+    return (k == 0) ? n : -1;
+}
 
 // ============================================================================
-static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
-    struct ggml_backend_tsavorite_context *ctx,
-    txe_device_s device,
-    struct ggml_tensor *node,
-    enum ggml_tsavorite_kernel_type kernel_type,
-    int kernel_sub_type
+// PACKING HELPERS (FP32)
+// ============================================================================
+
+static inline void pack_A_tile_f32(
+    float *A_pack,             // [TMU_M_TILE_MAX * K_chunk]
+    const char *A_base_d23,     // src0->data already offset for d2/d3
+    int64_t m0,
+    int64_t m_tile,
+    int64_t k0,
+    int64_t K_chunk,
+    int64_t a_nb0,
+    int64_t a_nb1
 ) {
-    // -------------------------------------------------------------------------
-    // 0) Input tensors
-    // -------------------------------------------------------------------------
-    struct ggml_tensor *src0 = node->src[0]; // A
-    struct ggml_tensor *src1 = node->src[1]; // B
-    TSAVORITE_GGML_ASSERT(src0 && src1);
+    memset(A_pack, 0, (size_t)(TMU_M_TILE_MAX * K_chunk) * sizeof(float));
 
-    // This blob is FP32 only (per your blob script)
-    TSAVORITE_GGML_ASSERT(node->type == GGML_TYPE_F32);
-    TSAVORITE_GGML_ASSERT(src0->type == GGML_TYPE_F32);
-    TSAVORITE_GGML_ASSERT(src1->type == GGML_TYPE_F32);
-    TSAVORITE_GGML_ASSERT(kernel_sub_type == DATA_TYPE_F32_INDEX);
+    for (int64_t r = 0; r < m_tile; ++r) {
+        const int64_t m = m0 + r;
+        float *dst = A_pack + r * K_chunk;
 
-    // GGML logical dims for MUL_MAT:
-    // A: [K, M, A2, A3]
-    // B: [K, N, B2, B3]
-    const int64_t K  = src0->ne[0];
-    const int64_t M  = src0->ne[1];
-    const int64_t A2 = src0->ne[2] ? src0->ne[2] : 1;
-    const int64_t A3 = src0->ne[3] ? src0->ne[3] : 1;
+        const char *src_row = A_base_d23 + m * a_nb1 + k0 * a_nb0;
+        for (int64_t kk = 0; kk < K_chunk; ++kk) {
+            dst[kk] = *(const float *)(src_row + kk * a_nb0);
+        }
+    }
+}
 
-    const int64_t N  = src1->ne[1];
-    const int64_t B2 = src1->ne[2] ? src1->ne[2] : 1;
-    const int64_t B3 = src1->ne[3] ? src1->ne[3] : 1;
+static inline void pack_B_tile_f32(
+    float *B_pack,             // [TMU_N_BLOCK * K_chunk]
+    const char *B_base_d23,     // src1->data already offset for d2/d3
+    int64_t n0,
+    int64_t n_valid,
+    int64_t k0,
+    int64_t K_chunk,
+    int64_t b_nb0,
+    int64_t b_nb1
+) {
+    memset(B_pack, 0, (size_t)(TMU_N_BLOCK * K_chunk) * sizeof(float));
 
-    const int64_t D2 = (A2 > B2) ? A2 : B2;
-    const int64_t D3 = (A3 > B3) ? A3 : B3;
+    for (int64_t c = 0; c < n_valid; ++c) {
+        const int64_t n = n0 + c;
+        float *dst = B_pack + c * K_chunk;
 
-    // -------------------------------------------------------------------------
-    // 1) Validate blob constraints (static-AOT tile ABI)
-    // -------------------------------------------------------------------------
-    TSAVORITE_GGML_ASSERT((K % TMU_K_MULTIPLE) == 0);
+        const char *src_col = B_base_d23 + n * b_nb1 + k0 * b_nb0;
+        for (int64_t kk = 0; kk < K_chunk; ++kk) {
+            dst[kk] = *(const float *)(src_col + kk * b_nb0);
+        }
+    }
+}
 
-    // Select which static blob to use based on runtime K
-    auto f2 = (void (*)(void*, void*, void*)) nullptr;
-    int64_t K_blob = 0;
+// ============================================================================
+// REUSABLE BUFFERS — allocated once per process
+// ============================================================================
 
-    if (K == TMU_K_576) {
-        f2 = (void (*)(void*, void*, void*)) _mlir_ciface_txe_mul_mat_tile_f32_k576_host;
-        K_blob = TMU_K_576;
-    } else if (K == TMU_K_1536) {
-        f2 = (void (*)(void*, void*, void*)) _mlir_ciface_txe_mul_mat_tile_f32_k1536_host;
-        K_blob = TMU_K_1536;
-    } else if (K == TMU_K_2048) {
-        f2 = (void (*)(void*, void*, void*)) _mlir_ciface_txe_mul_mat_tile_f32_k2048_host;
-        K_blob = TMU_K_2048;
-    } else {
-        GGML_TSAVORITE_LOG_ERROR("Unsupported TMU static K=%ld (supported: 576,1536)\n", (long)K);
-        return GGML_STATUS_ABORTED;
+static float *g_A_pack = nullptr;   // 64 * 2048
+static float *g_B_pack = nullptr;   // 32 * 2048
+static float *g_C_tile = nullptr;   // 64 * 32
+static int    g_pack_maxK = 0;
+
+static std::once_flag g_tmu_buf_once;
+
+static inline void ensure_tmu_pack_buffers() {
+    std::call_once(g_tmu_buf_once, []() {
+        const int maxK = 2048; // fixed maximum bucket
+
+        g_pack_maxK = maxK;
+
+        g_A_pack = (float *) tsi_alloc((size_t)TMU_M_TILE_MAX * (size_t)maxK * sizeof(float));
+        g_B_pack = (float *) tsi_alloc((size_t)TMU_N_BLOCK     * (size_t)maxK * sizeof(float));
+        g_C_tile = (float *) tsi_alloc((size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+
+        TSAVORITE_GGML_ASSERT(g_A_pack && g_B_pack && g_C_tile);
+    });
+}
+
+// -----------------------------------------------------------------------------
+// TMU MUL_MAT runner (called from ggml_tsavorite_graph_compute)
+// FIXES:
+//  - correct B packing (no memcpy across N)
+//  - meaningful validation (pack correctness + full tile reference)
+//  - increments node->tsi_kernel_runs and device stats for MUL_MAT
+// -----------------------------------------------------------------------------
+static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
+    struct ggml_backend_tsavorite_context * /*ctx*/,
+    txe_device_s device,
+    struct ggml_tensor * node,
+    enum ggml_tsavorite_kernel_type kernel_type,
+    int /*kernel_sub_type*/) {
+
+    if (!node || !node->src[0] || !node->src[1] || !node->data) {
+        return GGML_STATUS_FAILED;
     }
 
-    TSAVORITE_GGML_ASSERT(f2 != nullptr);
-    TSAVORITE_GGML_ASSERT(TMU_M_TILE_MAX == 64);
-    TSAVORITE_GGML_ASSERT(TMU_N_BLOCK == 32);
+    const struct ggml_tensor * src0 = node->src[0];
+    const struct ggml_tensor * src1 = node->src[1];
 
-    // Broadcast legality checks
-    TSAVORITE_GGML_ASSERT((A2 == 1) || ((D2 % A2) == 0));
-    TSAVORITE_GGML_ASSERT((B2 == 1) || ((D2 % B2) == 0));
-    TSAVORITE_GGML_ASSERT((A3 == 1) || ((D3 % A3) == 0));
-    TSAVORITE_GGML_ASSERT((B3 == 1) || ((D3 % B3) == 0));
+    if (src0->type != GGML_TYPE_F32 ||
+        src1->type != GGML_TYPE_F32 ||
+        node->type != GGML_TYPE_F32) {
+        return GGML_STATUS_FAILED;
+    }
 
-    // -------------------------------------------------------------------------
-    // 3) Strides and base pointers for slicing GGML tensors
-    // -------------------------------------------------------------------------
+    ensure_tmu_pack_buffers();
+
+    // --- buffer to save previous partial C between K buckets ---
+    static float *g_C_prev = nullptr;
+    static std::once_flag g_prev_once;
+    std::call_once(g_prev_once, []() {
+        g_C_prev = (float *) tsi_alloc(
+            (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+        TSAVORITE_GGML_ASSERT(g_C_prev);
+    });
+
+#ifdef TMU_DEBUG_VALIDATE
+    // CPU reference tile and probes (allocated once)
+    static float C_ref_full[TMU_M_TILE_MAX * TMU_N_BLOCK];
+    static float *C_probe  = nullptr;
+    static float *C_probe2 = nullptr;
+    static float *C_single = nullptr;
+    static std::once_flag probe_once;
+
+    std::call_once(probe_once, [&]() {
+        const size_t bytes = (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float);
+        C_probe  = (float *) tsi_alloc(bytes);
+        C_probe2 = (float *) tsi_alloc(bytes);
+        C_single = (float *) tsi_alloc(bytes);
+        TSAVORITE_GGML_ASSERT(C_probe && C_probe2 && C_single);
+    });
+
+    const size_t tile_bytes = (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float);
+#endif
+
+    const int64_t K = src0->ne[0];
+    const int64_t M = src0->ne[1];
+    const int64_t N = src1->ne[1];
+
+    if (src1->ne[0] != K) return GGML_STATUS_FAILED;
+    if ((K % TMU_K_MULTIPLE) != 0) return GGML_STATUS_FAILED;
+    if (src1->ne[1] == 1) return GGML_STATUS_FAILED; // avoid GEMV
+
     const int64_t a_nb0 = nb_or_default(src0, 0);
     const int64_t a_nb1 = nb_or_default(src0, 1);
     const int64_t a_nb2 = nb_or_default(src0, 2);
@@ -1152,99 +1353,177 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     const int64_t b_nb2 = nb_or_default(src1, 2);
     const int64_t b_nb3 = nb_or_default(src1, 3);
 
-    TSAVORITE_GGML_ASSERT(a_nb0 == (int64_t)sizeof(float));
-    TSAVORITE_GGML_ASSERT(b_nb0 == (int64_t)sizeof(float));
+    const int64_t c_nb0 = nb_or_default(node, 0);
+    const int64_t c_nb1 = nb_or_default(node, 1);
+    const int64_t c_nb2 = nb_or_default(node, 2);
+    const int64_t c_nb3 = nb_or_default(node, 3);
 
-    // -------------------------------------------------------------------------
-    // 4) Allocate persistent packed tiles (A,B,C) in Tsavorite memory
-    // -------------------------------------------------------------------------
-    const size_t A_bytes = (size_t)TMU_M_TILE_MAX * (size_t)K_blob * sizeof(float);
-    const size_t B_bytes = (size_t)TMU_N_BLOCK    * (size_t)K_blob * sizeof(float);
-    const size_t C_bytes = (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float);
+    // --- broadcast dims must come from inputs ---
+    const int64_t A2 = src0->ne[2] ? src0->ne[2] : 1;
+    const int64_t A3 = src0->ne[3] ? src0->ne[3] : 1;
+    const int64_t B2 = src1->ne[2] ? src1->ne[2] : 1;
+    const int64_t B3 = src1->ne[3] ? src1->ne[3] : 1;
+    const int64_t D2 = (A2 > B2) ? A2 : B2;
+    const int64_t D3 = (A3 > B3) ? A3 : B3;
 
-    MemRefDescriptor<4> *A_hdr = alloc_tile(&g_tileA_raw, &g_tileA_cap, A_bytes);
-    MemRefDescriptor<4> *B_hdr = alloc_tile(&g_tileB_raw, &g_tileB_cap, B_bytes);
-    MemRefDescriptor<4> *C_hdr = alloc_tile(&g_tileC_raw, &g_tileC_cap, C_bytes);
+    if (device) {
+        ++device->stats.op_run_count[kernel_type].total_tensor_count;
+    }
 
-    if (!A_hdr || !B_hdr || !C_hdr) return GGML_STATUS_ALLOC_FAILED;
-
-    float *A_data = (float *)(A_hdr + 1);
-    float *B_data = (float *)(B_hdr + 1);
-    float *C_data = (float *)(C_hdr + 1);
-
-    // Initialize memref headers once (data pointers remain stable)
-    init_contig_memref_4d(A_hdr, A_data, 1, 1, TMU_M_TILE_MAX, K_blob);
-    init_contig_memref_4d(B_hdr, B_data, 1, 1, TMU_N_BLOCK,    K_blob);
-    init_contig_memref_4d(C_hdr, C_data, 1, 1, TMU_M_TILE_MAX, TMU_N_BLOCK);
-
-    // -------------------------------------------------------------------------
-    // 5) Outer loops owned by application:
-    //    broadcast dims + m_base + n0
-    // -------------------------------------------------------------------------
     for (int64_t od3 = 0; od3 < D3; ++od3) {
-        const int64_t ad3 = map_repeat_i64(od3, A3);
-        const int64_t bd3 = map_repeat_i64(od3, B3);
+        const int64_t a_d3 = map_repeat_i64(od3, A3);
+        const int64_t b_d3 = map_repeat_i64(od3, B3);
 
         for (int64_t od2 = 0; od2 < D2; ++od2) {
-            const int64_t ad2 = map_repeat_i64(od2, A2);
-            const int64_t bd2 = map_repeat_i64(od2, B2);
+            const int64_t a_d2 = map_repeat_i64(od2, A2);
+            const int64_t b_d2 = map_repeat_i64(od2, B2);
 
-            // Base pointers for this broadcast plane
-            const char *a_plane = (const char *)src0->data + ad2 * a_nb2 + ad3 * a_nb3;
-            const char *b_plane = (const char *)src1->data + bd2 * b_nb2 + bd3 * b_nb3;
+            const char *A_base_d23 = (const char *) src0->data + a_d2 * a_nb2 + a_d3 * a_nb3;
+            const char *B_base_d23 = (const char *) src1->data + b_d2 * b_nb2 + b_d3 * b_nb3;
 
-            // Tile over M
-            for (int64_t m_base = 0; m_base < M; m_base += TMU_M_TILE_MAX) {
-                const int64_t m_tile = ((M - m_base) > TMU_M_TILE_MAX) ? TMU_M_TILE_MAX : (M - m_base);
+            for (int64_t m0 = 0; m0 < M; m0 += TMU_M_TILE_MAX) {
+                const int64_t m_tile = (M - m0 > TMU_M_TILE_MAX) ? TMU_M_TILE_MAX : (M - m0);
 
-                // Tile over N in blocks of 32
                 for (int64_t n0 = 0; n0 < N; n0 += TMU_N_BLOCK) {
-                    const int64_t n_end = ((n0 + TMU_N_BLOCK) < N) ? (n0 + TMU_N_BLOCK) : N;
-                    const int64_t n_tile = n_end - n0; // <= 32
+                    const int64_t n_valid = (N - n0 >= TMU_N_BLOCK) ? TMU_N_BLOCK : (N - n0);
 
-                    // ---------------------------------------------------------
-                    // Pack/pad A_tile: [64][K]
-                    // Only fill m_tile rows; rest remain zeros.
-                    // ---------------------------------------------------------
-                    memset(A_data, 0, A_bytes);
-                    for (int64_t r = 0; r < m_tile; ++r) {
-                        const char *src_row = a_plane + (m_base + r) * a_nb1; // k=0
-                        memcpy((char *)(A_data + r * K_blob),
-                               src_row,
-                               (size_t)K_blob * sizeof(float));
+                    memset(g_C_tile, 0,
+                           (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+
+                    int parts[128];
+                    const int np = tmu_decompose_k(K, parts, (int)(sizeof(parts)/sizeof(parts[0])));
+                    if (np < 0) return GGML_STATUS_FAILED;
+
+                    int64_t k0 = 0;
+
+                    for (int pi = 0; pi < np; ++pi) {
+                        const int K_chunk = parts[pi];
+                        const tmu_bucket_dispatch *bucket = tmu_find_bucket(K_chunk);
+                        if (!bucket || !bucket->fn) return GGML_STATUS_FAILED;
+
+                        pack_A_tile_f32(g_A_pack, A_base_d23, m0, m_tile, k0, K_chunk, a_nb0, a_nb1);
+                        pack_B_tile_f32(g_B_pack, B_base_d23, n0, n_valid, k0, K_chunk, b_nb0, b_nb1);
+
+                        // ---- SAVE PREVIOUS PARTIAL ----
+                        if (pi > 0) {
+                            memcpy(g_C_prev, g_C_tile,
+                                   (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+                        }
+
+                        // Run blob
+                        bucket->fn(g_A_pack, g_B_pack, g_C_tile);
+
+                        // ---- ACCUMULATE BACK (blob overwrites) ----
+                        if (pi > 0) {
+                            const int total = TMU_M_TILE_MAX * TMU_N_BLOCK;
+                            for (int i = 0; i < total; ++i) {
+                                g_C_tile[i] += g_C_prev[i];
+                            }
+                        }
+
+                        // Stats per kernel call
+                        if (device) ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
+                        ++node->tsi_kernel_runs;
+
+#ifdef TMU_DEBUG_VALIDATE
+                        // Optional probes (only for the very first output tile; helps detect overwrite vs accum)
+                        const bool is_first_tile = (m0 == 0 && n0 == 0 && od2 == 0 && od3 == 0);
+                        if (is_first_tile && np > 1 && pi > 0) {
+                            // Double-call probe: same inputs twice should double output if blob accumulates internally
+                            memset(C_probe, 0, tile_bytes);
+                            bucket->fn(g_A_pack, g_B_pack, C_probe);
+                            memcpy(C_single, C_probe, tile_bytes);
+                            bucket->fn(g_A_pack, g_B_pack, C_probe);
+
+                            const float s0 = C_single[0];
+                            const float s1 = C_probe[0];
+                            const float expect = 2.0f * s0;
+                            const float diff = fabsf(s1 - expect);
+
+                            fprintf(stderr,
+                                "\nTMU PROBE (pi=%d, K_chunk=%d, k0=%ld): double-call: "
+                                "single=%f second=%f expect=%f diff=%f\n",
+                                pi, K_chunk, (long)k0, s0, s1, expect, diff);
+
+                            // Carry-in probe: if blob truly loads PP from C_tile, passing 1.0 should preserve it when A/B are zero
+                            for (int i = 0; i < TMU_M_TILE_MAX * TMU_N_BLOCK; ++i) C_probe2[i] = 1.0f;
+
+                            static float A_save[TMU_M_TILE_MAX * 2048];
+                            static float B_save[TMU_N_BLOCK    * 2048];
+                            memcpy(A_save, g_A_pack, (size_t)TMU_M_TILE_MAX * (size_t)K_chunk * sizeof(float));
+                            memcpy(B_save, g_B_pack, (size_t)TMU_N_BLOCK    * (size_t)K_chunk * sizeof(float));
+                            memset(g_A_pack, 0, (size_t)TMU_M_TILE_MAX * (size_t)K_chunk * sizeof(float));
+                            memset(g_B_pack, 0, (size_t)TMU_N_BLOCK    * (size_t)K_chunk * sizeof(float));
+
+                            bucket->fn(g_A_pack, g_B_pack, C_probe2);
+
+                            memcpy(g_A_pack, A_save, (size_t)TMU_M_TILE_MAX * (size_t)K_chunk * sizeof(float));
+                            memcpy(g_B_pack, B_save, (size_t)TMU_N_BLOCK    * (size_t)K_chunk * sizeof(float));
+
+                            fprintf(stderr,
+                                "TMU PROBE (pi=%d, K_chunk=%d, k0=%ld): carry-in: "
+                                "C_in=1.0 => C_out[0]=%f (expect ~1.0 if accum)\n",
+                                pi, K_chunk, (long)k0, C_probe2[0]);
+                        }
+
+                        // CPU reference compare up to K_so_far (after host-side accumulation)
+                        memset(C_ref_full, 0, sizeof(C_ref_full));
+                        const int64_t K_so_far = k0 + K_chunk;
+
+                        for (int64_t rr = 0; rr < m_tile; ++rr) {
+                            for (int64_t cc = 0; cc < n_valid; ++cc) {
+                                float acc = 0.0f;
+                                for (int64_t kk = 0; kk < K_so_far; ++kk) {
+                                    const float a = *(const float *)(A_base_d23 + (m0 + rr) * a_nb1 + kk * a_nb0);
+                                    const float b = *(const float *)(B_base_d23 + (n0 + cc) * b_nb1 + kk * b_nb0);
+                                    acc += a * b;
+                                }
+                                C_ref_full[rr * TMU_N_BLOCK + cc] = acc;
+                            }
+                        }
+
+                        for (int64_t rr = 0; rr < m_tile; ++rr) {
+                            for (int64_t cc = 0; cc < n_valid; ++cc) {
+                                const float tmu_v = g_C_tile[rr * TMU_N_BLOCK + cc];
+                                const float ref_v = C_ref_full[rr * TMU_N_BLOCK + cc];
+                                if (fabsf(tmu_v - ref_v) > 1e-4f) {
+                                    fprintf(stderr,
+                                        "\nTMU MISMATCH (accum)\n"
+                                        "m0=%ld n0=%ld K_so_far=%ld\n"
+                                        "r=%ld c=%ld TMU=%f REF=%f\n",
+                                        (long)m0, (long)n0, (long)K_so_far,
+                                        (long)rr, (long)cc, tmu_v, ref_v);
+                                    abort();
+                                }
+                            }
+                        }
+#endif
+
+                        k0 += K_chunk;
                     }
 
-                    // ---------------------------------------------------------
-                    // Pack/pad B_tile: [32][K]
-                    // Only fill n_tile columns; rest remain zeros.
-                    // Each column in GGML B is contiguous across K and strided by nb1 in N.
-                    // ---------------------------------------------------------
-                    memset(B_data, 0, B_bytes);
-                    for (int64_t ccol = 0; ccol < n_tile; ++ccol) {
-                        const int64_t col = n0 + ccol;
-                        const char *src_col = b_plane + col * b_nb1; // k=0
-                        memcpy((char *)(B_data + ccol * K_blob),
-                               src_col,
-                               (size_t)K_blob * sizeof(float));
+                    // Copy tile back to ggml output
+                    {
+                        char *dst_base = (char *) node->data;
+                        const size_t bytes_total = (size_t) ggml_nbytes(node);
+
+                        for (int64_t rr = 0; rr < m_tile; ++rr) {
+                            const int64_t m = m0 + rr;
+                            const float *src_row = g_C_tile + rr * TMU_N_BLOCK;
+
+                            for (int64_t cc = 0; cc < n_valid; ++cc) {
+                                const int64_t n = n0 + cc;
+                                const int64_t byte_off =
+                                    m  * c_nb0 +
+                                    n  * c_nb1 +
+                                    od2 * c_nb2 +
+                                    od3 * c_nb3;
+
+                                if (byte_off < 0 || (size_t)byte_off + sizeof(float) > bytes_total) continue;
+                                *(float *)(dst_base + byte_off) = src_row[cc];
+                            }
+                        }
                     }
-
-                    // Clear output tile
-                    memset(C_data, 0, C_bytes);
-
-                    // ---------------------------------------------------------
-                    // Run blob once for this tile
-                    // ---------------------------------------------------------
-                    f2((void *)A_hdr, (void *)B_hdr, (void *)C_hdr);
-
-                    ++device->stats.op_run_count[GGML_TSAVORITE_KERNEL_TYPE_MUL_MAT].num_of_kernel_call;
-                    ++node->tsi_kernel_runs;
-
-                    // ---------------------------------------------------------
-                    // Repack tile output into GGML node->data
-                    // C_data is [64][32], but only [m_tile][n_tile] is valid.
-                    // copy_tileC_to_ggml_f32() automatically truncates to N.
-                    // ---------------------------------------------------------
-                    copy_tileC_to_ggml_f32(C_data, m_tile, N, node, m_base, n0, od2, od3);
                 }
             }
         }
@@ -1252,8 +1531,6 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
     return GGML_STATUS_SUCCESS;
 }
-
-
 
 // nodes are intermediate which has multiple src tensors & operation
 // Here we create multiple thread
@@ -2476,6 +2753,8 @@ static bool ggml_backend_tsavorite_device_supports_buft(ggml_backend_dev_t dev,
   GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
   GGML_TSAVORITE_LOG_INFO("End %s\n", __func__);
   return buft->iface.get_name == ggml_backend_tsavorite_buffer_type_get_name;
+  //return strcmp(buft->iface.get_name(buft), "tsavorite") == 0;
+
 
   TSI_UNUSED(dev);
 }
@@ -2509,13 +2788,11 @@ static bool ggml_backend_tsavorite_device_offload_op(ggml_backend_dev_t dev,
   case GGML_OP_SOFT_MAX:
 #endif /* GGML_TARGET_POSIX_DEBUG */
     break;
-#ifdef GGML_TARGET_POSIX_DEBUG
   case GGML_OP_MUL_MAT:
 	  if (!mul_mat_supported_size(op))
 		  return false;
 
     break;
-#endif /* GGML_TARGET_POSIX_DEBUG */
   case GGML_OP_GLU:
     {
         const ggml_glu_op op_ext = ggml_get_glu_op(op);

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -2,9 +2,16 @@
 # Safe to source: does not leak -e/-u into the interactive shell.
 #
 # Build modes:
-#   Release build:  source tsi-pkg-build.sh release
-#   Debug build:    source tsi-pkg-build.sh debug
-#   Default build:  source tsi-pkg-build.sh
+#   Release build:   source tsi-pkg-build.sh release
+#   Debug build:     source tsi-pkg-build.sh debug
+#                   (enables GGML_PERF_DETAIL)
+#   Debug build:     source tsi-pkg-build.sh debug-detail
+#                   (enables GGML_PERF_DETAIL + TMU blob validation)
+#   Default build:   source tsi-pkg-build.sh
+#
+# Optional flags:
+#   git-submodule-pull   : run "git submodule update --recursive --init" (default OFF)
+#   enable_coverage      : adds -DENABLE_COVERAGE=ON
 
 log_error(){ echo "ERROR: $*" >&2; }
 log_info(){  echo "INFO:  $*"; }
@@ -51,18 +58,43 @@ select_arch() {
 }
 
 parse_args() {
-  BUILD_TYPE="${1:-}"
-  MLIR_COMPILER_DIR_IN="${2:-${MLIR_COMPILER_DIR:-}}"
-  TOOLBOX_DIR_IN="${3:-${TOOLBOX_DIR:-}}"
+  # Defaults come from env (same semantics as your backup)
+  BUILD_TYPE=""
+  MLIR_COMPILER_DIR_IN="${MLIR_COMPILER_DIR:-}"
+  TOOLBOX_DIR_IN="${TOOLBOX_DIR:-}"
 
   ENABLE_COVERAGE_FLAG=""
+  GIT_SUBMODULE_PULL=0
+
+  # Robust parsing so: source tsi-pkg-build.sh debug git-submodule-pull
+  # does NOT treat "git-submodule-pull" as MLIR_COMPILER_DIR.
   local a
   for a in "$@"; do
-    if [ "$(tolower "$a")" = "enable_coverage" ]; then
-      ENABLE_COVERAGE_FLAG="-DENABLE_COVERAGE=ON"
-      log_info "enable_coverage detected"
-      break
-    fi
+    case "$(tolower "$a")" in
+      release|debug|debug-detail)
+        # first recognized build-type wins
+        if [ -z "${BUILD_TYPE}" ]; then
+          BUILD_TYPE="$a"
+        fi
+        ;;
+      enable_coverage)
+        ENABLE_COVERAGE_FLAG="-DENABLE_COVERAGE=ON"
+        log_info "enable_coverage detected"
+        ;;
+      git-submodule-pull)
+        GIT_SUBMODULE_PULL=1
+        log_info "git-submodule-pull detected (will update submodules)"
+        ;;
+      *)
+        # If user provides explicit paths, accept them in order:
+        # MLIR_COMPILER_DIR then TOOLBOX_DIR (only if not already set explicitly)
+        if [ -z "${MLIR_COMPILER_DIR_IN}" ]; then
+          MLIR_COMPILER_DIR_IN="$a"
+        elif [ -z "${TOOLBOX_DIR_IN}" ]; then
+          TOOLBOX_DIR_IN="$a"
+        fi
+        ;;
+    esac
   done
 }
 
@@ -104,6 +136,17 @@ setup_python() {
   log_info "creating python virtual env"
   __OLD_VIRTUAL_ENV="${VIRTUAL_ENV:-}"
 
+  # If venv already exists, just activate and return
+  if [ -d "blob-creation" ] && [ -f "blob-creation/bin/activate" ]; then
+    log_info "blob-creation virtual env already exists; activating"
+    # shellcheck disable=SC1091
+    run bash -c 'source blob-creation/bin/activate && python -V >/dev/null' || return 1
+    # shellcheck disable=SC1091
+    source blob-creation/bin/activate || return 1
+    return 0
+  fi
+
+  # Otherwise create it and install deps
   run /proj/local/Python-3.11.12/bin/python3 -m venv blob-creation || return 1
   # shellcheck disable=SC1091
   run bash -c 'source blob-creation/bin/activate && python -V >/dev/null' || return 1
@@ -141,13 +184,20 @@ build_posix() {
   local common="-DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DGGML_NATIVE=ON -DGGML_AMX_TILE=OFF -DGGML_AMX_INT8=OFF -DGGML_AMX_BF16=OFF -DGGML_AVX512_BF16=OFF -DGGML_AVX_VNNI=OFF"
   local cflags_base="-DGGML_TARGET_POSIX -DGGML_TSAVORITE -mno-amx-tile -mno-amx-int8 -mno-amx-bf16 -mno-avx512bf16 -mno-avxvnni"
   local perf="-DGGML_PERF"
+  local tmu_debug=""
+
   [ "$bt" = "release" ] && perf="-DGGML_PERF_RELEASE"
-  [ "$bt" = "debug" ]   && perf="-DGGML_PERF_DETAIL"
+  [ "$bt" = "debug" ] && perf="-DGGML_PERF_DETAIL"
+  if [ "$bt" = "debug-detail" ]; then
+    perf="-DGGML_PERF_DETAIL"
+    tmu_debug="-DTMU_DEBUG_VALIDATE"
+    log_info "TMU_DEBUG_VALIDATE ENABLED (debug-detail build)"
+  fi
 
   run cmake -B build-posix ${common} \
     -DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}" \
-    -DCMAKE_C_FLAGS="${perf} ${cflags_base}" \
-    -DCMAKE_CXX_FLAGS="${perf} ${cflags_base}" \
+    -DCMAKE_C_FLAGS="${perf} ${tmu_debug} ${cflags_base}" \
+    -DCMAKE_CXX_FLAGS="${perf} ${tmu_debug} ${cflags_base}" \
     ${ENABLE_COVERAGE_FLAG} || return 1
 
   run cmake --build build-posix --config Release || return 1
@@ -179,7 +229,8 @@ build_fpga() {
   local ARM_TOOLCHAIN_FILE="${TOOLBOX_DIR}/lib/cmake/toolchains/arm.cmake"
   local perf="-DGGML_PERF"
   [ "$bt" = "release" ] && perf="-DGGML_PERF_RELEASE"
-  [ "$bt" = "debug" ]   && perf="-DGGML_PERF_DETAIL"
+  [ "$bt" = "debug" ] && perf="-DGGML_PERF_DETAIL"
+  [ "$bt" = "debug-detail" ] && perf="-DGGML_PERF_DETAIL"
 
   run cmake -B build-fpga \
     -DCMAKE_TOOLCHAIN_FILE="${ARM_TOOLCHAIN_FILE}" \
@@ -246,7 +297,12 @@ main() {
   parse_args "$@"
   resolve_paths "$arch" || return $?
 
-  run git submodule update --recursive --init || return 1
+  # Optional submodule update (default OFF)
+  if [ "${GIT_SUBMODULE_PULL}" -eq 1 ]; then
+    run git submodule update --recursive --init || return 1
+  else
+    log_info "Skipping git submodule update (default). Use git-submodule-pull to enable."
+  fi
 
   cd ggml-tsi-kernel/ || return 1
   setup_toolchain || return 1


### PR DESCRIPTION
able to build and test at posix
Currently K-tiling only enable for POSIX

-ggml/libggml-base.so
tsi-ggml/libggml-cpu.so
tsi-ggml/libggml.so
tsi-ggml/libggml-tsavorite.so
tsi-ggml/libllama.so
tsi-ggml/llama-cli
tsi-ggml/simple-backend-tsi
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 




TINY LLAMA

Tiny Llama also i am able to validate with some Some Tensors
but its taking too much time (85 tensors needed) 7088 time Blob Call
MUL_MAT          OPU           85            7088         404379950        4757411.18
 
 

[akapoor@wspd0 llama.cpp]$    ./build-posix/bin/llama-cli   -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf   --device tSavorite    -p "my cat's name is"   -c 2048   -b 128   --n-predict 4   --temp 0.0 --top-k 50 --top-p 0.9   --repeat-penalty 1.5 --repeat-last-n 5   --no-warmup  
my cat's name is Luna.
 
 
 
llama_perf_sampler_print:    sampling time =       9.52 ms /    11 runs   (    0.87 ms per token,  1154.98 tokens per second)
llama_perf_context_print:        load time =  406196.70 ms
llama_perf_context_print: prompt eval time =  405684.14 ms /     7 tokens (57954.88 ms per token,     0.02 tokens per second)
llama_perf_context_print:        eval time =    1346.72 ms /     3 runs   (  448.91 ms per token,     2.23 tokens per second)
llama_perf_context_print:       total time =  407554.03 ms /    10 tokens
 
=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          308             560            630094           2045.76
  MUL              OPU          315             573            373985           1187.25
  RMS_NORM         OPU          315             315            268424            852.14
  MUL_MAT          CPU         5164               0           7441887           1441.11
  MUL_MAT          OPU           85            7088         404379950        4757411.18
  CONT             CPU         1170               0             62730             53.62
  RESHAPE          CPU         1751               0               846              0.48
  VIEW             CPU         2604               0               344              0.13
  PERMUTE          CPU         1986               0               366              0.18
  TRANSPOSE        CPU          459               0               130              0.28
  GET_ROWS         CPU           50               0               253              5.06
  SET_ROWS         CPU         1047               0              1059              1.01
  SOFT_MAX         CPU          559               0             80140            143.36
  ROPE             CPU         1150               0              7871              6.84
  GLU              OPU          154             280            423588           2750.57
 
OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    19.7740   19.7740      7.5380  [4.85e-03%] [Thread] tsi::runtime::TsavRTPosix::initialize
    1    12.0790   12.0790      0.2950  └─ [2.96e-03%] tsi::runtime::TsavRTPosix::initializeQueues
    1     9.7260    9.7260      9.7260    └─ [2.39e-03%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     1.9040    1.9040      1.9040    └─ [4.67e-04%] tsi::runtime::TsavRTPosix::requestTXEDevice
    1     0.1540    0.1540      0.1470    └─ [3.78e-05%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0070    0.0070      0.0070      └─ [1.72e-06%] tsi::runtime::executeWithTimeout
    1     0.1570    0.1570      0.1570  └─ [3.85e-05%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
8348  1392.7760    0.1668    327.2860  [3.42e-01%] [Thread] tsi::runtime::TsavRTPosix::loadBlob
16696  1061.5280    0.0636   1061.5280  └─ [2.60e-01%] tsi::runtime::executeWithTimeout
8348     3.9620  4.75e-04      3.9620  └─ [9.72e-04%] LOAD_BLOB Command Execution
    8     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2148009600[0x800...
8348     0.0000    0.0000      0.0000  └─ [0.00e+00%] TXE 0 Idle
  232     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2148011136[0x800...
    1     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2148012672[0x800...
8107     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2148014208[0x800...
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
8348  1230.0870    0.1474    653.1910  [3.02e-01%] [Thread] tsi::runtime::TsavRTPosix::unloadBlob
16696   566.0590    0.0339    566.0590  └─ [1.39e-01%] tsi::runtime::executeWithTimeout
8348    10.8370    0.0013     10.8370  └─ [2.66e-03%] UNLOAD_BLOB Command Execution
    8     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2148009600[0x8...
8348     0.0000    0.0000      0.0000  └─ [0.00e+00%] TXE 0 Idle
  232     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2148011136[0x8...
    1     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2148012672[0x8...
8107     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2148014208[0x8...
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     4.9540    4.9540      4.5500  [1.22e-03%] [Thread] tsi::runtime::TsavRT::finalize
    1     0.3950    0.3950      0.0590  └─ [9.69e-05%] tsi::runtime::TsavRTPosix::detachFromTXEDevice
    1     0.3360    0.3360      0.0730    └─ [8.24e-05%] tsi::runtime::TsavRT::executeSyncCommand
    1     0.2210    0.2210      0.2210      └─ [5.42e-05%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     0.0420    0.0420      0.0380      └─ [1.03e-05%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0040    0.0040      0.0040        └─ [9.81e-07%] tsi::runtime::executeWithTimeout
    2     0.0090    0.0045      0.0090  └─ [2.21e-06%] tsi::runtime::TsavRT::deallocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
8350   4.00e+05   47.8960    214.3000  [98.12%] [Thread] tsi::runtime::TsavRT::processResponses
8350   4.00e+05   47.8703    4.00e+05  └─ [98.06%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     0.0740    0.0740      0.0450  [1.82e-05%] [Thread] OPU 
    1     0.0290    0.0290      0.0290  └─ [7.11e-06%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
8348   160.5880    0.0192    148.7310  [3.94e-02%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
8348    11.8570    0.0014     11.8570  └─ [2.91e-03%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
8363    34.7680    0.0042     34.7680  [8.53e-03%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
8348    37.3620    0.0045     37.3620  [9.17e-03%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
8348   4.00e+05   47.9529    4.00e+05  [98.21%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
8348    26.8590    0.0032     26.8590  [6.59e-03%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    -   4.08e+05    0.0000    4.08e+05  [100.00%] TOTAL
========================================================================================================================
 
Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.9972
------------------------------------------------------------------------------------------------------------------------













[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$   ./build-posix/bin/llama-cli   -m /proj/rel/sw/ggml/models/smolVLM-256M.gguf   --device tSavorite    -p "my cat's name is"   -c 2048   -b 128   --n-predict 4   --temp 0.0 --top-k 50 --top-p 0.9   --repeat-penalty 1.5 --repeat-last-n 5   --no-warmup   </dev/null
Failed to generate tool call example: Value is not callable: null at row 1, column 72:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                                                       ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 13:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
            ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 1:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

User: my cat's name is
Assistant: My cat's name
> EOF by user




llama_perf_sampler_print:    sampling time =      15.92 ms /    17 runs   (    0.94 ms per token,  1067.71 tokens per second)
llama_perf_context_print:        load time =   48957.90 ms
llama_perf_context_print: prompt eval time =   47940.72 ms /    13 tokens ( 3687.75 ms per token,     0.27 tokens per second)
llama_perf_context_print:        eval time =     722.90 ms /     3 runs   (  240.97 ms per token,     4.15 tokens per second)
llama_perf_context_print:       total time =   49939.29 ms /    16 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          660            1356            831359           1259.63
  MUL              OPU          671            1379            851660           1269.24
  RMS_NORM         OPU          671             671            463079            690.13
  MUL_MAT          CPU        11387               0           2112732            185.54
  MUL_MAT          OPU          117            3846          46379524         396406.19
  CONT             CPU         2526               0            100917             39.95
  RESHAPE          CPU         3588               0               965              0.27
  VIEW             CPU         5741               0               710              0.12
  PERMUTE          CPU         4374               0               569              0.13
  TRANSPOSE        CPU         1050               0               148              0.14
  GET_ROWS         CPU           90               0              1578             17.53
  SET_ROWS         CPU         2447               0              1919              0.78
  SOFT_MAX         CPU         1268               0             57616             45.44
  ROPE             CPU         2580               0             11468              4.44
  GLU              OPU          330             678            596340           1807.09

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    34.3340   34.3340      7.5930  [6.86e-02%] [Thread] tsi::runtime::TsavRTPosix::initialize
    1    26.6120   26.6120      3.1180  └─ [5.32e-02%] tsi::runtime::TsavRTPosix::initializeQueues
    1    21.3660   21.3660     21.3660    └─ [4.27e-02%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     1.9730    1.9730      1.9730    └─ [3.94e-03%] tsi::runtime::TsavRTPosix::requestTXEDevice
    1     0.1550    0.1550      0.0930    └─ [3.10e-04%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0620    0.0620      0.0620      └─ [1.24e-04%] tsi::runtime::executeWithTimeout
    1     0.1290    0.1290      0.1290  └─ [2.58e-04%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 6658   842.6930    0.1266    213.6180  [ 1.68%] [Thread] tsi::runtime::TsavRTPosix::loadBlob
13316   627.2360    0.0471    627.2360  └─ [ 1.25%] tsi::runtime::executeWithTimeout
 6658     1.8390  2.76e-04      1.8390  └─ [3.67e-03%] LOAD_BLOB Command Execution
   14     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2701133440[0xa10...
 6658     0.0000    0.0000      0.0000  └─ [0.00e+00%] TXE 0 Idle
    1     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2701134976[0xa10...
  153     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2701136512[0xa10...
 6490     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=2 (LOAD_BLOB), blob_args=[2701138048[0xa10...
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 6658  1076.8510    0.1617    312.4070  [ 2.15%] [Thread] tsi::runtime::TsavRTPosix::unloadBlob
13316   760.6490    0.0571    760.6490  └─ [ 1.52%] tsi::runtime::executeWithTimeout
 6658     3.7950  5.70e-04      3.7950  └─ [7.58e-03%] UNLOAD_BLOB Command Execution
   14     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2701133440[0xa...
 6658     0.0000    0.0000      0.0000  └─ [0.00e+00%] TXE 0 Idle
    1     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2701134976[0xa...
  153     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2701136512[0xa...
 6490     0.0000    0.0000      0.0000  └─ [0.00e+00%] Command{command=3 (UNLOAD_BLOB), blob_args=[2701138048[0xa...
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1    34.5720   34.5720     34.0400  [6.91e-02%] [Thread] tsi::runtime::TsavRT::finalize
    1     0.5230    0.5230      0.0510  └─ [1.05e-03%] tsi::runtime::TsavRTPosix::detachFromTXEDevice
    1     0.4720    0.4720      0.0510    └─ [9.43e-04%] tsi::runtime::TsavRT::executeSyncCommand
    1     0.3780    0.3780      0.3780      └─ [7.55e-04%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     0.0430    0.0430      0.0400      └─ [8.59e-05%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0030    0.0030      0.0030        └─ [5.99e-06%] tsi::runtime::executeWithTimeout
    2     0.0090    0.0045      0.0090  └─ [1.80e-05%] tsi::runtime::TsavRT::deallocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 6660 45462.0690    6.8261     80.4490  [90.84%] [Thread] tsi::runtime::TsavRT::processResponses
 6660 45381.6200    6.8141  45381.6200  └─ [90.68%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     0.0930    0.0930      0.0530  [1.86e-04%] [Thread] OPU 
    1     0.0400    0.0400      0.0400  └─ [7.99e-05%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 6658   118.4850    0.0178    108.8500  [2.37e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
 6658     9.6350    0.0014      9.6350  └─ [1.93e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 6677    14.9990    0.0022     14.9990  [3.00e-02%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 6658    27.5610    0.0041     27.5610  [5.51e-02%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 6658 45642.4250    6.8553  45642.4250  [91.20%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 6658    12.1330    0.0018     12.1330  [2.42e-02%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    - 50044.9220    0.0000  50044.9220  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.9979
------------------------------------------------------------------------------------------------------------------------

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 





