### PR TITLE
@FIR-1498 - llama.cpp: tsi-pkg-build.sh enhancement

### DIFF
--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -2,45 +2,68 @@
 # ==============================================================================
 # tsi-pkg-build.sh  (source-safe)
 #
-# Key behaviors (read this once):
-# 1) Submodules:
-#    - If ggml-tsi-kernel/ is missing => ALWAYS runs "git submodule update --init --recursive"
-#      (even if .tsi_submodules_initialized exists and even without git-submodule-pull).
-#    - First time in a fresh checkout => auto init submodules and drop marker file.
-#    - Later runs => submodule update is optional via: git-submodule-pull
+# USAGE (source is recommended)
+# ============================
 #
-# 2) Clean rebuild:
-#    - build-posix => rm -rf ./build-posix before configuring/building
-#    - build-fpga  => rm -rf ./build-fpga  before configuring/building
-#    - default build (posix+fpga+package) cleans both.
-#    - Disable cleaning with: incremental
+#   source tsi-pkg-build.sh [build-mode] [flags...] [MLIR_COMPILER_DIR] [TOOLBOX_DIR]
 #
-# 3) Blobs:
-#    - Explicit blob flags:
-#        build-posix-blobs | build-fpga-blobs | build-all-blobs
-#    - overwrite-venv deletes ggml-tsi-kernel/blob-creation and recreates it
-#      (does NOT build blobs by itself).
-#    - git-submodule-pull additionally forces: overwrite-venv + build-all-blobs.
+# Build modes (optional):
+#   release | debug | debug-detail
+#     - release      : GGML_PERF_RELEASE
+#     - debug        : GGML_PERF_DETAIL
+#     - debug-detail : GGML_PERF_DETAIL + TMU_DEBUG_VALIDATE
 #
-# 4) IMPORTANT POSIX LINK FIX:
-#    - POSIX build needs generated host objects that define _mlir_ciface_txe_*_host.
-#    - If those host objects are missing, this script AUTO builds POSIX blobs
-#      (equivalent to build-posix-blobs) unless you pass: no-auto-blobs
+# Submodules:
+#   - First run in a fresh repo checkout: auto "git submodule update --init --recursive"
+#   - Later runs: submodule update is OPTIONAL unless you pass:
+#       git-submodule-pull
+#   - If ggml-tsi-kernel is missing, script forces submodule init even without the flag.
 #
-# 5) IMPORTANT FPGA LINK FIX (your new failure):
-#    - FPGA build also links against generated host objects (cross-linker sees _mlir_ciface_*_host).
-#    - If FPGA host objects are missing, this script AUTO builds FPGA blobs
-#      (equivalent to build-fpga-blobs) unless you pass: no-auto-blobs
+# Blob build (OFF by default):
+#   build-fpga-blobs     : build blobs in ggml-tsi-kernel/fpga-kernel only
+#   build-posix-blobs    : build blobs in ggml-tsi-kernel/posix-kernel only
+#   build-all-blobs      : build blobs for both fpga+posix kernels
 #
-# Build modes:
-#    release | debug | debug-detail
+# Auto blob safeguards (ON by default):
+#   - If you deleted ggml-tsi-kernel (rm -rf) or host objects are missing:
+#       * POSIX build auto-builds POSIX blobs if required for link
+#       * FPGA build auto-builds FPGA blobs if required for link
+#   Disable both with:
+#       no-auto-blobs
 #
-# Build selection flags:
-#    build-posix | build-fpga | package
-#    (default: build-posix + build-fpga + package)
+# Python virtual env:
+#   overwrite-venv       : delete blob-creation venv and recreate it (installs deps)
+#                          NOTE: this alone does NOT build blobs unless blob flag is also set.
+#   git-submodule-pull   : ALSO forces overwrite-venv AND build-all-blobs (as requested)
 #
-# Cleanup flags:
-#    clean | clean-all
+# Build selection:
+#   Default (no build-selection flags): build-posix + build-fpga + package
+#   build-posix          : only build posix C/C++
+#   build-fpga           : only build fpga target
+#   package              : only package fpga bundle (requires fpga already built)
+#   (You can combine them: e.g. build-posix build-fpga)
+#
+# Incremental build:
+#   incremental          : do not rm -rf build dirs (both llama.cpp + kernels)
+#
+# Cleanup:
+#   clean                : rm -rf build-posix build-fpga (llama.cpp) and kernel build dirs in ggml-tsi-kernel
+#   clean-all            : clean + remove python venv blob-creation
+#
+# Coverage:
+#   enable_coverage      : adds -DENABLE_COVERAGE=ON
+#
+# Help:
+#   help | -h | --help
+#
+# Examples:
+#   source tsi-pkg-build.sh debug-detail
+#   source tsi-pkg-build.sh debug git-submodule-pull
+#   source tsi-pkg-build.sh debug build-all-blobs overwrite-venv
+#   source tsi-pkg-build.sh release build-posix
+#   source tsi-pkg-build.sh debug build-fpga package
+#   source tsi-pkg-build.sh debug build-fpga no-auto-blobs build-fpga-blobs
+#
 # ==============================================================================
 
 log_error(){ echo "ERROR: $*" >&2; }
@@ -66,7 +89,9 @@ cleanup() {
   trap - RETURN EXIT 2>/dev/null || true
 }
 
-usage() { sed -n '1,200p' "$0" 2>/dev/null | sed 's/^# \{0,1\}//'; }
+usage() {
+  sed -n '1,220p' "$0" 2>/dev/null | sed 's/^# \{0,1\}//'
+}
 
 select_arch() {
   local m; m="$(uname -m)"
@@ -84,6 +109,7 @@ MARKER_FILE=".tsi_submodules_initialized"
 SUBMODULE_DIR="ggml-tsi-kernel"
 
 submodule_self_heal_if_needed() {
+  # If the path exists but is not a proper submodule checkout and is non-empty, wipe it.
   if [ -e "${SUBMODULE_DIR}" ]; then
     if [ ! -d "${SUBMODULE_DIR}/.git" ] && [ -n "$(ls -A "${SUBMODULE_DIR}" 2>/dev/null || true)" ]; then
       log_info "${SUBMODULE_DIR} exists and is non-empty (stale). Cleaning to allow submodule clone."
@@ -96,18 +122,21 @@ submodule_self_heal_if_needed() {
 }
 
 ensure_submodules() {
-  local want_update="$1"
+  local want_update="$1"   # 0/1 from user flag
   local force=0
 
+  # If submodule directory missing, ALWAYS force init.
   if [ ! -d "${SUBMODULE_DIR}" ]; then
     log_info "${SUBMODULE_DIR} missing; forcing submodule init"
     force=1
   fi
 
+  # If marker missing, treat as first-time repo.
   if [ ! -f "${MARKER_FILE}" ]; then
     force=1
   fi
 
+  # User asked explicitly.
   if [ "${want_update}" -eq 1 ]; then
     force=1
   fi
@@ -134,54 +163,108 @@ parse_args() {
   TOOLBOX_DIR_IN="${TOOLBOX_DIR:-}"
   ENABLE_COVERAGE_FLAG=""
 
+  # submodules
   GIT_SUBMODULE_PULL=0
 
+  # blobs
   DO_BLOB_FPGA=0
   DO_BLOB_POSIX=0
 
+  # python venv
   OVERWRITE_VENV=0
 
+  # build selection (default: posix+fpga+package)
   DO_BUILD_POSIX=1
   DO_BUILD_FPGA=1
   DO_PACKAGE_FPGA=1
   __USER_BUILD_SELECT=0
 
+  # cleanup
   DO_CLEAN=0
   DO_CLEAN_ALL=0
 
+  # cleaning build dirs before build (default ON)
   DO_CLEAN_BUILD_DIRS=1
   INCREMENTAL=0
 
+  # auto blobs (default ON; applies to POSIX+FPGA host object link safety)
   AUTO_BLOBS=1
 
   local a
   for a in "$@"; do
     case "$(tolower "$a")" in
-      help|-h|--help) usage; if [ "$__TSI_SOURCED" -eq 1 ]; then return 0; else exit 0; fi ;;
-      release|debug|debug-detail) [ -z "${BUILD_TYPE}" ] && BUILD_TYPE="$a" ;;
-      enable_coverage) ENABLE_COVERAGE_FLAG="-DENABLE_COVERAGE=ON"; log_info "enable_coverage detected" ;;
-      git-submodule-pull) GIT_SUBMODULE_PULL=1; log_info "git-submodule-pull detected" ;;
-      build-fpga-blobs) DO_BLOB_FPGA=1; log_info "build-fpga-blobs detected" ;;
-      build-posix-blobs) DO_BLOB_POSIX=1; log_info "build-posix-blobs detected" ;;
-      build-all-blobs) DO_BLOB_FPGA=1; DO_BLOB_POSIX=1; log_info "build-all-blobs detected" ;;
-      overwrite-venv) OVERWRITE_VENV=1; log_info "overwrite-venv detected" ;;
-      no-auto-blobs) AUTO_BLOBS=0; log_info "no-auto-blobs detected" ;;
-      incremental) INCREMENTAL=1; DO_CLEAN_BUILD_DIRS=0; log_info "incremental build selected (no rm -rf build dirs)" ;;
+      help|-h|--help)
+        usage
+        if [ "$__TSI_SOURCED" -eq 1 ]; then return 0; else exit 0; fi
+        ;;
+      release|debug|debug-detail)
+        [ -z "${BUILD_TYPE}" ] && BUILD_TYPE="$a"
+        ;;
+      enable_coverage)
+        ENABLE_COVERAGE_FLAG="-DENABLE_COVERAGE=ON"
+        log_info "enable_coverage detected"
+        ;;
+      git-submodule-pull)
+        GIT_SUBMODULE_PULL=1
+        log_info "git-submodule-pull detected"
+        ;;
+      build-fpga-blobs)
+        DO_BLOB_FPGA=1
+        log_info "build-fpga-blobs detected"
+        ;;
+      build-posix-blobs)
+        DO_BLOB_POSIX=1
+        log_info "build-posix-blobs detected"
+        ;;
+      build-all-blobs)
+        DO_BLOB_FPGA=1
+        DO_BLOB_POSIX=1
+        log_info "build-all-blobs detected"
+        ;;
+      overwrite-venv)
+        OVERWRITE_VENV=1
+        log_info "overwrite-venv detected"
+        ;;
+      no-auto-blobs)
+        AUTO_BLOBS=0
+        log_info "no-auto-blobs detected"
+        ;;
+      incremental)
+        INCREMENTAL=1
+        DO_CLEAN_BUILD_DIRS=0
+        log_info "incremental build selected (no rm -rf build dirs)"
+        ;;
       build-posix|posix)
-        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0; __USER_BUILD_SELECT=1; fi
-        DO_BUILD_POSIX=1; log_info "build-posix selected"
+        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then
+          DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0; __USER_BUILD_SELECT=1
+        fi
+        DO_BUILD_POSIX=1
+        log_info "build-posix selected"
         ;;
       build-fpga|fpga)
-        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0; __USER_BUILD_SELECT=1; fi
-        DO_BUILD_FPGA=1; log_info "build-fpga selected"
+        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then
+          DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0; __USER_BUILD_SELECT=1
+        fi
+        DO_BUILD_FPGA=1
+        log_info "build-fpga selected"
         ;;
       package|bundle)
-        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0; __USER_BUILD_SELECT=1; fi
-        DO_PACKAGE_FPGA=1; log_info "package selected"
+        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then
+          DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0; __USER_BUILD_SELECT=1
+        fi
+        DO_PACKAGE_FPGA=1
+        log_info "package selected"
         ;;
-      clean) DO_CLEAN=1; log_info "clean selected" ;;
-      clean-all) DO_CLEAN_ALL=1; log_info "clean-all selected" ;;
+      clean)
+        DO_CLEAN=1
+        log_info "clean selected"
+        ;;
+      clean-all)
+        DO_CLEAN_ALL=1
+        log_info "clean-all selected"
+        ;;
       *)
+        # positional paths
         if [ -z "${MLIR_COMPILER_DIR_IN}" ]; then
           MLIR_COMPILER_DIR_IN="$a"
         elif [ -z "${TOOLBOX_DIR_IN}" ]; then
@@ -191,12 +274,16 @@ parse_args() {
     esac
   done
 
+  # git-submodule-pull ALSO deletes+recreates venv and builds all blobs.
   if [ "${GIT_SUBMODULE_PULL}" -eq 1 ]; then
     OVERWRITE_VENV=1
     DO_BLOB_FPGA=1
     DO_BLOB_POSIX=1
     log_info "git-submodule-pull => forcing overwrite-venv + build-all-blobs"
   fi
+
+  # Default build type if none provided
+  [ -n "${BUILD_TYPE}" ] || BUILD_TYPE="debug"
 }
 
 resolve_paths() {
@@ -275,12 +362,14 @@ setup_python() {
 # Blob presence + build helpers
 # -------------------------
 posix_host_objs_present() {
+  # host.o provides _mlir_ciface_txe_*_host for POSIX link
   [ -d "posix-kernel/build-posix" ] || return 1
   find "posix-kernel/build-posix" -name "host.o" -print -quit 2>/dev/null | grep -q . || return 1
   return 0
 }
 
 fpga_host_objs_present() {
+  # host.o provides _mlir_ciface_txe_*_host for ARM cross-link too
   [ -d "fpga-kernel/build-fpga" ] || return 1
   find "fpga-kernel/build-fpga" -name "host.o" -print -quit 2>/dev/null | grep -q . || return 1
   return 0
@@ -289,6 +378,7 @@ fpga_host_objs_present() {
 build_fpga_blobs() {
   log_info "BLOB: building FPGA kernels/blobs"
   cd fpga-kernel || return 1
+  # ensure cmake config exists (create-all-kernels.sh may depend on it)
   run cmake -B build-fpga -DTOOLBOX_DIR="${TOOLBOX_DIR}" -DCOMPILER_INSTALL_DIR="${MLIR_COMPILER_DIR}" || return 1
   run ./create-all-kernels.sh || return 1
   cd .. || return 1
@@ -304,7 +394,7 @@ build_posix_blobs() {
 }
 
 # -------------------------
-# POSIX build
+# POSIX build (clean rebuild by default)
 # -------------------------
 build_posix() {
   log_info "building llama.cpp/ggml for posix"
@@ -362,7 +452,7 @@ EOL
 }
 
 # -------------------------
-# FPGA build
+# FPGA build (clean rebuild by default)
 # -------------------------
 build_fpga() {
   log_info "building llama.cpp/ggml for fpga"
@@ -474,14 +564,16 @@ main() {
   resolve_paths "$arch" || return $?
   setup_toolchain || return 1
 
+  # Ensure submodule exists (fixes your "rm -rf ggml-tsi-kernel/" case)
   ensure_submodules "${GIT_SUBMODULE_PULL}" || return 1
 
+  # Decide if we need python:
   local need_python=0
   if [ "${OVERWRITE_VENV}" -eq 1 ] || [ "${DO_BLOB_FPGA}" -eq 1 ] || [ "${DO_BLOB_POSIX}" -eq 1 ]; then
     need_python=1
   fi
 
-  # AUTO blobs when required for link (unless disabled)
+  # AUTO host-object driven blob builds (POSIX + FPGA)
   local auto_posix_blob=0
   local auto_fpga_blob=0
 
@@ -523,6 +615,7 @@ main() {
     cd .. || return 1
   fi
 
+  # Build llama.cpp outputs (posix first, then fpga, then package)
   if [ "${DO_BUILD_POSIX}" -eq 1 ]; then
     build_posix || return 1
     wrap_glibc_bins || return 1

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1,64 +1,51 @@
 #!/usr/bin/env bash
-# Safe to source: does not leak -e/-u into the interactive shell.
+# ==============================================================================
+# tsi-pkg-build.sh  (source-safe)
 #
-# ============================
-# USAGE (source is recommended)
-# ============================
+# Key behaviors (read this once):
+# 1) Submodules:
+#    - If ggml-tsi-kernel/ is missing => ALWAYS runs "git submodule update --init --recursive"
+#      (even if .tsi_submodules_initialized exists and even without git-submodule-pull).
+#    - First time in a fresh checkout => auto init submodules and drop marker file.
+#    - Later runs => submodule update is optional via: git-submodule-pull
 #
-#   source tsi-pkg-build.sh [build-mode] [flags...] [MLIR_COMPILER_DIR] [TOOLBOX_DIR]
+# 2) Clean rebuild:
+#    - build-posix => rm -rf ./build-posix before configuring/building
+#    - build-fpga  => rm -rf ./build-fpga  before configuring/building
+#    - default build (posix+fpga+package) cleans both.
+#    - Disable cleaning with: incremental
 #
-# Build modes (optional):
-#   release | debug | debug-detail
-#     - release      : GGML_PERF_RELEASE
-#     - debug        : GGML_PERF_DETAIL
-#     - debug-detail : GGML_PERF_DETAIL + TMU_DEBUG_VALIDATE
+# 3) Blobs:
+#    - Explicit blob flags:
+#        build-posix-blobs | build-fpga-blobs | build-all-blobs
+#    - overwrite-venv deletes ggml-tsi-kernel/blob-creation and recreates it
+#      (does NOT build blobs by itself).
+#    - git-submodule-pull additionally forces: overwrite-venv + build-all-blobs.
 #
-# Submodules:
-#   - First run in a fresh repo checkout: auto "git submodule update --init --recursive"
-#   - Later runs: submodule update is OPTIONAL unless you pass:
-#       git-submodule-pull
-#   - If ggml-tsi-kernel is missing, script forces submodule init even without the flag.
+# 4) IMPORTANT POSIX LINK FIX:
+#    - POSIX build needs generated host objects that define _mlir_ciface_txe_*_host.
+#    - If those host objects are missing, this script AUTO builds POSIX blobs
+#      (equivalent to build-posix-blobs) unless you pass: no-auto-blobs
 #
-# Blob build (OFF by default):
-#   build-fpga-blobs     : build blobs in ggml-tsi-kernel/fpga-kernel only
-#   build-posix-blobs    : build blobs in ggml-tsi-kernel/posix-kernel only
-#   build-all-blobs      : build blobs for both fpga+posix kernels
+# 5) IMPORTANT FPGA LINK FIX (your new failure):
+#    - FPGA build also links against generated host objects (cross-linker sees _mlir_ciface_*_host).
+#    - If FPGA host objects are missing, this script AUTO builds FPGA blobs
+#      (equivalent to build-fpga-blobs) unless you pass: no-auto-blobs
 #
-# Python virtual env:
-#   overwrite-venv       : delete blob-creation venv and recreate it (installs deps)
-#                          NOTE: this alone does NOT build blobs unless blob flag is also set.
-#   git-submodule-pull   : ALSO forces overwrite-venv AND build-all-blobs (as requested)
+# Build modes:
+#    release | debug | debug-detail
 #
-# Build selection:
-#   Default (no build-selection flags): build-posix + build-fpga + package
-#   build-posix          : only build posix C/C++
-#   build-fpga           : only build fpga target
-#   package              : only package fpga bundle (requires fpga already built)
-#   (You can combine them: e.g. build-posix build-fpga)
+# Build selection flags:
+#    build-posix | build-fpga | package
+#    (default: build-posix + build-fpga + package)
 #
-# Cleanup:
-#   clean                : rm -rf build-posix build-fpga (llama.cpp) and kernel build dirs in ggml-tsi-kernel
-#   clean-all            : clean + remove python venv blob-creation
-#
-# Coverage:
-#   enable_coverage      : adds -DENABLE_COVERAGE=ON
-#
-# Help:
-#   help | -h | --help
-#
-# Examples:
-#   source tsi-pkg-build.sh debug-detail
-#   source tsi-pkg-build.sh debug git-submodule-pull
-#   source tsi-pkg-build.sh debug build-all-blobs overwrite-venv
-#   source tsi-pkg-build.sh release build-posix
-#   source tsi-pkg-build.sh debug build-fpga package
-#   source tsi-pkg-build.sh clean
-#
+# Cleanup flags:
+#    clean | clean-all
+# ==============================================================================
 
 log_error(){ echo "ERROR: $*" >&2; }
 log_info(){  echo "INFO:  $*"; }
 
-# detect sourced vs executed
 __TSI_SOURCED=0
 (return 0 2>/dev/null) && __TSI_SOURCED=1 || true
 __TSI_OLD_SET="$(set +o)"
@@ -74,25 +61,12 @@ die() {
 }
 
 cleanup() {
-  # leave/restore venv
-  if [ -n "${__OLD_VIRTUAL_ENV:-}" ] && [ -f "${__OLD_VIRTUAL_ENV}/bin/activate" ]; then
-    # shellcheck disable=SC1091
-    source "${__OLD_VIRTUAL_ENV}/bin/activate" >/dev/null 2>&1 || true
-  else
-    type deactivate >/dev/null 2>&1 && deactivate || true
-  fi
-
-  # restore caller shell behavior
   eval "${__TSI_OLD_SET}" >/dev/null 2>&1 || true
   stty sane 2>/dev/null || true
-
-  # don't leak traps into parent shell
   trap - RETURN EXIT 2>/dev/null || true
 }
 
-usage() {
-  sed -n '1,120p' "$0" 2>/dev/null | sed 's/^# \{0,1\}//'
-}
+usage() { sed -n '1,200p' "$0" 2>/dev/null | sed 's/^# \{0,1\}//'; }
 
 select_arch() {
   local m; m="$(uname -m)"
@@ -104,54 +78,49 @@ select_arch() {
 }
 
 # -------------------------
-# Submodule init/update logic
+# Submodule logic (robust)
 # -------------------------
-submodule_marker_file() { echo ".tsi_submodules_initialized"; }
-
-is_first_time_repo() { [ ! -f "$(submodule_marker_file)" ]; }
-mark_repo_initialized() { : > "$(submodule_marker_file)" || true; }
+MARKER_FILE=".tsi_submodules_initialized"
+SUBMODULE_DIR="ggml-tsi-kernel"
 
 submodule_self_heal_if_needed() {
-  # Fix stale/bad state for ggml-tsi-kernel specifically:
-  # directory exists and non-empty but not a proper submodule checkout.
-  if [ -e "ggml-tsi-kernel" ]; then
-    if [ ! -d "ggml-tsi-kernel/.git" ] && [ -n "$(ls -A ggml-tsi-kernel 2>/dev/null || true)" ]; then
-      log_info "ggml-tsi-kernel exists and is non-empty; cleaning stale submodule state"
-      run git submodule deinit -f -- ggml-tsi-kernel || true
-      run rm -rf ggml-tsi-kernel || return 1
-      run rm -rf .git/modules/ggml-tsi-kernel || return 1
+  if [ -e "${SUBMODULE_DIR}" ]; then
+    if [ ! -d "${SUBMODULE_DIR}/.git" ] && [ -n "$(ls -A "${SUBMODULE_DIR}" 2>/dev/null || true)" ]; then
+      log_info "${SUBMODULE_DIR} exists and is non-empty (stale). Cleaning to allow submodule clone."
+      run git submodule deinit -f -- "${SUBMODULE_DIR}" || true
+      run rm -rf "${SUBMODULE_DIR}" || return 1
+      run rm -rf ".git/modules/${SUBMODULE_DIR}" || return 1
     fi
   fi
   return 0
 }
 
 ensure_submodules() {
-  # want_update: 0/1 (user flag)
   local want_update="$1"
-  local first_time=0
-  is_first_time_repo && first_time=1 || true
+  local force=0
 
-  # If submodule directory is missing, we must init regardless of optional policy.
-  if [ ! -d "ggml-tsi-kernel" ]; then
-    log_info "ggml-tsi-kernel missing; forcing submodule init"
-    want_update=1
+  if [ ! -d "${SUBMODULE_DIR}" ]; then
+    log_info "${SUBMODULE_DIR} missing; forcing submodule init"
+    force=1
   fi
 
-  if [ "$first_time" -eq 1 ]; then
-    log_info "First-time repo setup detected; initializing submodules automatically"
-    want_update=1
+  if [ ! -f "${MARKER_FILE}" ]; then
+    force=1
   fi
 
-  if [ "$want_update" -eq 1 ]; then
+  if [ "${want_update}" -eq 1 ]; then
+    force=1
+  fi
+
+  if [ "${force}" -eq 1 ]; then
     submodule_self_heal_if_needed || return 1
-    run git submodule update --recursive --init || return 1
-    if [ "$first_time" -eq 1 ]; then
-      mark_repo_initialized
-      log_info "Submodules initialized; future runs will skip by default (use git-submodule-pull to force update)."
-    fi
+    run git submodule update --init --recursive || die "git submodule update failed"
+    : > "${MARKER_FILE}" || true
   else
-    log_info "Skipping git submodule update (already initialized). Use git-submodule-pull to enable."
+    log_info "Skipping git submodule update (already initialized). Use git-submodule-pull to refresh."
   fi
+
+  [ -d "${SUBMODULE_DIR}" ] || die "${SUBMODULE_DIR} still missing after submodule init"
   return 0
 }
 
@@ -159,102 +128,60 @@ ensure_submodules() {
 # Args/flags
 # -------------------------
 parse_args() {
-  # Defaults from env
   BUILD_TYPE=""
+
   MLIR_COMPILER_DIR_IN="${MLIR_COMPILER_DIR:-}"
   TOOLBOX_DIR_IN="${TOOLBOX_DIR:-}"
-
   ENABLE_COVERAGE_FLAG=""
 
-  # Submodules
   GIT_SUBMODULE_PULL=0
 
-  # Blobs (default OFF)
   DO_BLOB_FPGA=0
   DO_BLOB_POSIX=0
 
-  # Python venv
   OVERWRITE_VENV=0
 
-  # Build selection (default: posix+fpga+package)
   DO_BUILD_POSIX=1
   DO_BUILD_FPGA=1
   DO_PACKAGE_FPGA=1
   __USER_BUILD_SELECT=0
 
-  # Cleanup
   DO_CLEAN=0
   DO_CLEAN_ALL=0
+
+  DO_CLEAN_BUILD_DIRS=1
+  INCREMENTAL=0
+
+  AUTO_BLOBS=1
 
   local a
   for a in "$@"; do
     case "$(tolower "$a")" in
-      help|-h|--help)
-        usage
-        if [ "$__TSI_SOURCED" -eq 1 ]; then return 0; else exit 0; fi
-        ;;
-      release|debug|debug-detail)
-        [ -z "${BUILD_TYPE}" ] && BUILD_TYPE="$a"
-        ;;
-      enable_coverage)
-        ENABLE_COVERAGE_FLAG="-DENABLE_COVERAGE=ON"
-        log_info "enable_coverage detected"
-        ;;
-      git-submodule-pull)
-        GIT_SUBMODULE_PULL=1
-        log_info "git-submodule-pull detected (will update submodules)"
-        ;;
-      build-fpga-blobs)
-        DO_BLOB_FPGA=1
-        log_info "build-fpga-blobs detected"
-        ;;
-      build-posix-blobs)
-        DO_BLOB_POSIX=1
-        log_info "build-posix-blobs detected"
-        ;;
-      build-all-blobs)
-        DO_BLOB_FPGA=1
-        DO_BLOB_POSIX=1
-        log_info "build-all-blobs detected"
-        ;;
-      overwrite-venv)
-        OVERWRITE_VENV=1
-        log_info "overwrite-venv detected"
-        ;;
+      help|-h|--help) usage; if [ "$__TSI_SOURCED" -eq 1 ]; then return 0; else exit 0; fi ;;
+      release|debug|debug-detail) [ -z "${BUILD_TYPE}" ] && BUILD_TYPE="$a" ;;
+      enable_coverage) ENABLE_COVERAGE_FLAG="-DENABLE_COVERAGE=ON"; log_info "enable_coverage detected" ;;
+      git-submodule-pull) GIT_SUBMODULE_PULL=1; log_info "git-submodule-pull detected" ;;
+      build-fpga-blobs) DO_BLOB_FPGA=1; log_info "build-fpga-blobs detected" ;;
+      build-posix-blobs) DO_BLOB_POSIX=1; log_info "build-posix-blobs detected" ;;
+      build-all-blobs) DO_BLOB_FPGA=1; DO_BLOB_POSIX=1; log_info "build-all-blobs detected" ;;
+      overwrite-venv) OVERWRITE_VENV=1; log_info "overwrite-venv detected" ;;
+      no-auto-blobs) AUTO_BLOBS=0; log_info "no-auto-blobs detected" ;;
+      incremental) INCREMENTAL=1; DO_CLEAN_BUILD_DIRS=0; log_info "incremental build selected (no rm -rf build dirs)" ;;
       build-posix|posix)
-        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then
-          DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0
-          __USER_BUILD_SELECT=1
-        fi
-        DO_BUILD_POSIX=1
-        log_info "build-posix selected"
+        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0; __USER_BUILD_SELECT=1; fi
+        DO_BUILD_POSIX=1; log_info "build-posix selected"
         ;;
       build-fpga|fpga)
-        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then
-          DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0
-          __USER_BUILD_SELECT=1
-        fi
-        DO_BUILD_FPGA=1
-        log_info "build-fpga selected"
+        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0; __USER_BUILD_SELECT=1; fi
+        DO_BUILD_FPGA=1; log_info "build-fpga selected"
         ;;
       package|bundle)
-        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then
-          DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0
-          __USER_BUILD_SELECT=1
-        fi
-        DO_PACKAGE_FPGA=1
-        log_info "package selected"
+        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0; __USER_BUILD_SELECT=1; fi
+        DO_PACKAGE_FPGA=1; log_info "package selected"
         ;;
-      clean)
-        DO_CLEAN=1
-        log_info "clean selected"
-        ;;
-      clean-all)
-        DO_CLEAN_ALL=1
-        log_info "clean-all selected"
-        ;;
+      clean) DO_CLEAN=1; log_info "clean selected" ;;
+      clean-all) DO_CLEAN_ALL=1; log_info "clean-all selected" ;;
       *)
-        # positional paths (only if not already set)
         if [ -z "${MLIR_COMPILER_DIR_IN}" ]; then
           MLIR_COMPILER_DIR_IN="$a"
         elif [ -z "${TOOLBOX_DIR_IN}" ]; then
@@ -264,7 +191,6 @@ parse_args() {
     esac
   done
 
-  # Required behavior: git-submodule-pull ALSO deletes+recreates venv and builds all blobs.
   if [ "${GIT_SUBMODULE_PULL}" -eq 1 ]; then
     OVERWRITE_VENV=1
     DO_BLOB_FPGA=1
@@ -279,13 +205,11 @@ resolve_paths() {
   if [ -z "${MLIR_COMPILER_DIR_IN}" ]; then
     MLIR_SDK_VERSION="${MLIR_SDK_VERSION:-/proj/rel/sw/sdk-r.0.2.5/${arch}}"
     MLIR_COMPILER_DIR_IN="${MLIR_SDK_VERSION}/compiler"
-    log_info "Using default MLIR_COMPILER_DIR: ${MLIR_COMPILER_DIR_IN}"
   fi
 
   if [ -z "${TOOLBOX_DIR_IN}" ]; then
     MLIR_SDK_VERSION="${MLIR_SDK_VERSION:-$(dirname "${MLIR_COMPILER_DIR_IN}")}"
     TOOLBOX_DIR_IN="${MLIR_SDK_VERSION}/toolbox/build/install-fpga"
-    log_info "Using default TOOLBOX_DIR: ${TOOLBOX_DIR_IN}"
   fi
 
   MLIR_COMPILER_DIR="$(absdir "${MLIR_COMPILER_DIR_IN}")" || die "MLIR_COMPILER_DIR not found: ${MLIR_COMPILER_DIR_IN}"
@@ -308,10 +232,9 @@ setup_toolchain() {
 }
 
 # -------------------------
-# Python env (only when requested)
+# Python venv (only when needed)
 # -------------------------
 setup_python() {
-  log_info "python venv: ensuring blob-creation exists"
   __OLD_VIRTUAL_ENV="${VIRTUAL_ENV:-}"
 
   if [ "${OVERWRITE_VENV}" -eq 1 ] && [ -d "blob-creation" ]; then
@@ -319,19 +242,14 @@ setup_python() {
     rm -rf blob-creation || return 1
   fi
 
-  # If venv exists, activate
   if [ -d "blob-creation" ] && [ -f "blob-creation/bin/activate" ]; then
-    log_info "blob-creation virtual env already exists; activating"
-    # shellcheck disable=SC1091
     run bash -c 'source blob-creation/bin/activate && python -V >/dev/null' || return 1
     # shellcheck disable=SC1091
     source blob-creation/bin/activate || return 1
     return 0
   fi
 
-  # Otherwise create + install deps
   run /proj/local/Python-3.11.12/bin/python3 -m venv blob-creation || return 1
-  # shellcheck disable=SC1091
   run bash -c 'source blob-creation/bin/activate && python -V >/dev/null' || return 1
   # shellcheck disable=SC1091
   source blob-creation/bin/activate || return 1
@@ -354,28 +272,48 @@ setup_python() {
 }
 
 # -------------------------
-# Blob build steps (explicit only)
+# Blob presence + build helpers
 # -------------------------
+posix_host_objs_present() {
+  [ -d "posix-kernel/build-posix" ] || return 1
+  find "posix-kernel/build-posix" -name "host.o" -print -quit 2>/dev/null | grep -q . || return 1
+  return 0
+}
+
+fpga_host_objs_present() {
+  [ -d "fpga-kernel/build-fpga" ] || return 1
+  find "fpga-kernel/build-fpga" -name "host.o" -print -quit 2>/dev/null | grep -q . || return 1
+  return 0
+}
+
 build_fpga_blobs() {
-  log_info "BLOB: creating fpga kernels/blobs"
-  # In ggml-tsi-kernel/fpga-kernel
+  log_info "BLOB: building FPGA kernels/blobs"
+  cd fpga-kernel || return 1
   run cmake -B build-fpga -DTOOLBOX_DIR="${TOOLBOX_DIR}" -DCOMPILER_INSTALL_DIR="${MLIR_COMPILER_DIR}" || return 1
   run ./create-all-kernels.sh || return 1
+  cd .. || return 1
   return 0
 }
 
 build_posix_blobs() {
-  log_info "BLOB: creating posix kernels/blobs"
-  # In ggml-tsi-kernel/posix-kernel
+  log_info "BLOB: building POSIX kernels/blobs"
+  cd posix-kernel || return 1
   run ./create-all-kernels.sh || return 1
+  cd .. || return 1
   return 0
 }
 
 # -------------------------
-# Build and package (llama.cpp root)
+# POSIX build
 # -------------------------
 build_posix() {
   log_info "building llama.cpp/ggml for posix"
+
+  if [ "${DO_CLEAN_BUILD_DIRS}" -eq 1 ]; then
+    log_info "clean rebuild: rm -rf ./build-posix"
+    rm -rf build-posix || return 1
+  fi
+
   local bt; bt="$(tolower "${BUILD_TYPE}")"
   local common="-DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DGGML_NATIVE=ON -DGGML_AMX_TILE=OFF -DGGML_AMX_INT8=OFF -DGGML_AMX_BF16=OFF -DGGML_AVX512_BF16=OFF -DGGML_AVX_VNNI=OFF"
   local cflags_base="-DGGML_TARGET_POSIX -DGGML_TSAVORITE -mno-amx-tile -mno-amx-int8 -mno-amx-bf16 -mno-avx512bf16 -mno-avxvnni"
@@ -423,8 +361,17 @@ EOL
   return 0
 }
 
+# -------------------------
+# FPGA build
+# -------------------------
 build_fpga() {
   log_info "building llama.cpp/ggml for fpga"
+
+  if [ "${DO_CLEAN_BUILD_DIRS}" -eq 1 ]; then
+    log_info "clean rebuild: rm -rf ./build-fpga"
+    rm -rf build-fpga || return 1
+  fi
+
   local bt; bt="$(tolower "${BUILD_TYPE}")"
   local ARM_TOOLCHAIN_FILE="${TOOLBOX_DIR}/lib/cmake/toolchains/arm.cmake"
   local perf="-DGGML_PERF"
@@ -452,7 +399,6 @@ bundle_fpga() {
   local TSI_BLOB_INSTALL_DIR
   TSI_BLOB_INSTALL_DIR="$(pwd)/${GGML_TSI_INSTALL_DIR}/fpga-kernel/build-fpga"
 
-  # Sanity checks: package requires built fpga binaries
   [ -f "build-fpga/bin/llama-cli" ] || die "package requested but build-fpga/bin/llama-cli not found. Run with build-fpga first."
 
   mkdir -p "${TSI_GGML_BUNDLE_INSTALL_DIR}"
@@ -474,9 +420,7 @@ EOL
   sed -i "s|__TSI_BLOB_INSTALL_DIR__|${TSI_BLOB_INSTALL_DIR}|g" "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh"
   chmod +x "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh" || return 1
 
-  # These are repo-provided fpga blobs directory (not the generated per-kernel build dirs)
   cp "${GGML_TSI_INSTALL_DIR}/fpga/blobs" "${TSI_GGML_BUNDLE_INSTALL_DIR}/" -r || return 1
-
   cp build-fpga/bin/llama-cli "${TSI_GGML_BUNDLE_INSTALL_DIR}/" || return 1
   cp build-fpga/bin/libggml*.so "${TSI_GGML_BUNDLE_INSTALL_DIR}/" || return 1
   cp build-fpga/bin/libllama*.so "${TSI_GGML_BUNDLE_INSTALL_DIR}/" || return 1
@@ -486,7 +430,6 @@ EOL
 
   if [ "$(tolower "$BUILD_TYPE")" = "release" ]; then
     cp "${TSI_GGML_BUNDLE_INSTALL_DIR}-${TSI_GGML_VERSION}.tz" "${TSI_GGML_RELEASE_DIR}/" || return 1
-
     local LATEST_TZ="${TSI_GGML_BUNDLE_INSTALL_DIR}-${TSI_GGML_VERSION}.tz"
     local LATEST_FULL_PATH="${TSI_GGML_RELEASE_DIR}/$(basename "$LATEST_TZ")"
     rm -f "${TSI_GGML_RELEASE_DIR}/tsi-ggml-aws-latest.tz" "${TSI_GGML_RELEASE_DIR}/tsi-ggml-latest.tz"
@@ -503,18 +446,18 @@ EOL
 do_clean() {
   log_info "clean: removing build directories"
   rm -rf build-posix build-fpga 2>/dev/null || true
-  if [ -d ggml-tsi-kernel ]; then
-    rm -rf ggml-tsi-kernel/fpga-kernel/build-fpga 2>/dev/null || true
-    rm -rf ggml-tsi-kernel/posix-kernel/build-posix 2>/dev/null || true
+  if [ -d "${SUBMODULE_DIR}" ]; then
+    rm -rf "${SUBMODULE_DIR}/fpga-kernel/build-fpga" 2>/dev/null || true
+    rm -rf "${SUBMODULE_DIR}/posix-kernel/build-posix" 2>/dev/null || true
   fi
   return 0
 }
 
 do_clean_all() {
   do_clean || return 1
-  if [ -d ggml-tsi-kernel/blob-creation ]; then
+  if [ -d "${SUBMODULE_DIR}/blob-creation" ]; then
     log_info "clean-all: removing python venv blob-creation"
-    rm -rf ggml-tsi-kernel/blob-creation || true
+    rm -rf "${SUBMODULE_DIR}/blob-creation" || true
   fi
   return 0
 }
@@ -525,56 +468,61 @@ main() {
   local arch; arch="$(select_arch)" || return $?
   parse_args "$@"
 
-  # Cleanup-only mode: do cleanup and exit early
-  if [ "${DO_CLEAN_ALL}" -eq 1 ]; then
-    do_clean_all
-    return 0
-  fi
-  if [ "${DO_CLEAN}" -eq 1 ]; then
-    do_clean
-    return 0
-  fi
+  if [ "${DO_CLEAN_ALL}" -eq 1 ]; then do_clean_all; return 0; fi
+  if [ "${DO_CLEAN}" -eq 1 ]; then do_clean; return 0; fi
 
   resolve_paths "$arch" || return $?
+  setup_toolchain || return 1
 
-  # First run auto-inits; later optional unless git-submodule-pull is provided
   ensure_submodules "${GIT_SUBMODULE_PULL}" || return 1
 
-  # Blob/venv work happens in ggml-tsi-kernel only when requested
   local need_python=0
   if [ "${OVERWRITE_VENV}" -eq 1 ] || [ "${DO_BLOB_FPGA}" -eq 1 ] || [ "${DO_BLOB_POSIX}" -eq 1 ]; then
     need_python=1
   fi
 
+  # AUTO blobs when required for link (unless disabled)
+  local auto_posix_blob=0
+  local auto_fpga_blob=0
+
+  if [ "${AUTO_BLOBS}" -eq 1 ]; then
+    cd "${SUBMODULE_DIR}" || return 1
+
+    if [ "${DO_BUILD_POSIX}" -eq 1 ]; then
+      if ! posix_host_objs_present; then
+        auto_posix_blob=1
+        log_info "POSIX host objects missing => auto-building POSIX blobs to avoid undefined _mlir_ciface_*_host"
+        need_python=1
+        DO_BLOB_POSIX=1
+      fi
+    fi
+
+    if [ "${DO_BUILD_FPGA}" -eq 1 ]; then
+      if ! fpga_host_objs_present; then
+        auto_fpga_blob=1
+        log_info "FPGA host objects missing => auto-building FPGA blobs to avoid undefined _mlir_ciface_*_host"
+        need_python=1
+        DO_BLOB_FPGA=1
+      fi
+    fi
+
+    cd .. || return 1
+  fi
+
+  # Do submodule-side work (python + blobs) only if required
   if [ "${need_python}" -eq 1 ] || [ "${DO_BLOB_FPGA}" -eq 1 ] || [ "${DO_BLOB_POSIX}" -eq 1 ]; then
-    cd ggml-tsi-kernel/ || die "ggml-tsi-kernel not found (submodule). Try git-submodule-pull."
+    cd "${SUBMODULE_DIR}" || die "cannot enter ggml-tsi-kernel"
 
-    setup_toolchain || return 1
-
-    # Only set up python env when requested (overwrite or blob build)
     if [ "${need_python}" -eq 1 ]; then
       setup_python || return 1
     fi
 
-    # Build blobs ONLY when explicitly requested
-    if [ "${DO_BLOB_FPGA}" -eq 1 ]; then
-      cd fpga-kernel || return 1
-      build_fpga_blobs || return 1
-      cd .. || return 1
-    fi
-
-    if [ "${DO_BLOB_POSIX}" -eq 1 ]; then
-      cd posix-kernel || return 1
-      build_posix_blobs || return 1
-      cd .. || return 1
-    fi
+    if [ "${DO_BLOB_FPGA}" -eq 1 ]; then build_fpga_blobs || return 1; fi
+    if [ "${DO_BLOB_POSIX}" -eq 1 ]; then build_posix_blobs || return 1; fi
 
     cd .. || return 1
-  else
-    setup_toolchain || return 1
   fi
 
-  # Build selection in llama.cpp root
   if [ "${DO_BUILD_POSIX}" -eq 1 ]; then
     build_posix || return 1
     wrap_glibc_bins || return 1
@@ -588,10 +536,16 @@ main() {
     bundle_fpga || return 1
   fi
 
+  if [ "${auto_posix_blob}" -eq 1 ]; then
+    log_info "NOTE: POSIX blobs were auto-built because they are required for linking _mlir_ciface_*_host."
+  fi
+  if [ "${auto_fpga_blob}" -eq 1 ]; then
+    log_info "NOTE: FPGA blobs were auto-built because they are required for linking _mlir_ciface_*_host."
+  fi
+
   return 0
 }
 
-# Ensure cleanup runs even on errors; do not leak trap in sourced shell
 if [ "$__TSI_SOURCED" -eq 1 ]; then
   trap cleanup RETURN
 else

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1,17 +1,59 @@
 #!/usr/bin/env bash
 # Safe to source: does not leak -e/-u into the interactive shell.
 #
-# Build modes:
-#   Release build:   source tsi-pkg-build.sh release
-#   Debug build:     source tsi-pkg-build.sh debug
-#                   (enables GGML_PERF_DETAIL)
-#   Debug build:     source tsi-pkg-build.sh debug-detail
-#                   (enables GGML_PERF_DETAIL + TMU blob validation)
-#   Default build:   source tsi-pkg-build.sh
+# ============================
+# USAGE (source is recommended)
+# ============================
 #
-# Optional flags:
-#   git-submodule-pull   : run "git submodule update --recursive --init" (default OFF)
+#   source tsi-pkg-build.sh [build-mode] [flags...] [MLIR_COMPILER_DIR] [TOOLBOX_DIR]
+#
+# Build modes (optional):
+#   release | debug | debug-detail
+#     - release      : GGML_PERF_RELEASE
+#     - debug        : GGML_PERF_DETAIL
+#     - debug-detail : GGML_PERF_DETAIL + TMU_DEBUG_VALIDATE
+#
+# Submodules:
+#   - First run in a fresh repo checkout: auto "git submodule update --init --recursive"
+#   - Later runs: submodule update is OPTIONAL unless you pass:
+#       git-submodule-pull
+#   - If ggml-tsi-kernel is missing, script forces submodule init even without the flag.
+#
+# Blob build (OFF by default):
+#   build-fpga-blobs     : build blobs in ggml-tsi-kernel/fpga-kernel only
+#   build-posix-blobs    : build blobs in ggml-tsi-kernel/posix-kernel only
+#   build-all-blobs      : build blobs for both fpga+posix kernels
+#
+# Python virtual env:
+#   overwrite-venv       : delete blob-creation venv and recreate it (installs deps)
+#                          NOTE: this alone does NOT build blobs unless blob flag is also set.
+#   git-submodule-pull   : ALSO forces overwrite-venv AND build-all-blobs (as requested)
+#
+# Build selection:
+#   Default (no build-selection flags): build-posix + build-fpga + package
+#   build-posix          : only build posix C/C++
+#   build-fpga           : only build fpga target
+#   package              : only package fpga bundle (requires fpga already built)
+#   (You can combine them: e.g. build-posix build-fpga)
+#
+# Cleanup:
+#   clean                : rm -rf build-posix build-fpga (llama.cpp) and kernel build dirs in ggml-tsi-kernel
+#   clean-all            : clean + remove python venv blob-creation
+#
+# Coverage:
 #   enable_coverage      : adds -DENABLE_COVERAGE=ON
+#
+# Help:
+#   help | -h | --help
+#
+# Examples:
+#   source tsi-pkg-build.sh debug-detail
+#   source tsi-pkg-build.sh debug git-submodule-pull
+#   source tsi-pkg-build.sh debug build-all-blobs overwrite-venv
+#   source tsi-pkg-build.sh release build-posix
+#   source tsi-pkg-build.sh debug build-fpga package
+#   source tsi-pkg-build.sh clean
+#
 
 log_error(){ echo "ERROR: $*" >&2; }
 log_info(){  echo "INFO:  $*"; }
@@ -48,6 +90,10 @@ cleanup() {
   trap - RETURN EXIT 2>/dev/null || true
 }
 
+usage() {
+  sed -n '1,120p' "$0" 2>/dev/null | sed 's/^# \{0,1\}//'
+}
+
 select_arch() {
   local m; m="$(uname -m)"
   case "$m" in
@@ -57,25 +103,98 @@ select_arch() {
   esac
 }
 
+# -------------------------
+# Submodule init/update logic
+# -------------------------
+submodule_marker_file() { echo ".tsi_submodules_initialized"; }
+
+is_first_time_repo() { [ ! -f "$(submodule_marker_file)" ]; }
+mark_repo_initialized() { : > "$(submodule_marker_file)" || true; }
+
+submodule_self_heal_if_needed() {
+  # Fix stale/bad state for ggml-tsi-kernel specifically:
+  # directory exists and non-empty but not a proper submodule checkout.
+  if [ -e "ggml-tsi-kernel" ]; then
+    if [ ! -d "ggml-tsi-kernel/.git" ] && [ -n "$(ls -A ggml-tsi-kernel 2>/dev/null || true)" ]; then
+      log_info "ggml-tsi-kernel exists and is non-empty; cleaning stale submodule state"
+      run git submodule deinit -f -- ggml-tsi-kernel || true
+      run rm -rf ggml-tsi-kernel || return 1
+      run rm -rf .git/modules/ggml-tsi-kernel || return 1
+    fi
+  fi
+  return 0
+}
+
+ensure_submodules() {
+  # want_update: 0/1 (user flag)
+  local want_update="$1"
+  local first_time=0
+  is_first_time_repo && first_time=1 || true
+
+  # If submodule directory is missing, we must init regardless of optional policy.
+  if [ ! -d "ggml-tsi-kernel" ]; then
+    log_info "ggml-tsi-kernel missing; forcing submodule init"
+    want_update=1
+  fi
+
+  if [ "$first_time" -eq 1 ]; then
+    log_info "First-time repo setup detected; initializing submodules automatically"
+    want_update=1
+  fi
+
+  if [ "$want_update" -eq 1 ]; then
+    submodule_self_heal_if_needed || return 1
+    run git submodule update --recursive --init || return 1
+    if [ "$first_time" -eq 1 ]; then
+      mark_repo_initialized
+      log_info "Submodules initialized; future runs will skip by default (use git-submodule-pull to force update)."
+    fi
+  else
+    log_info "Skipping git submodule update (already initialized). Use git-submodule-pull to enable."
+  fi
+  return 0
+}
+
+# -------------------------
+# Args/flags
+# -------------------------
 parse_args() {
-  # Defaults come from env (same semantics as your backup)
+  # Defaults from env
   BUILD_TYPE=""
   MLIR_COMPILER_DIR_IN="${MLIR_COMPILER_DIR:-}"
   TOOLBOX_DIR_IN="${TOOLBOX_DIR:-}"
 
   ENABLE_COVERAGE_FLAG=""
+
+  # Submodules
   GIT_SUBMODULE_PULL=0
 
-  # Robust parsing so: source tsi-pkg-build.sh debug git-submodule-pull
-  # does NOT treat "git-submodule-pull" as MLIR_COMPILER_DIR.
+  # Blobs (default OFF)
+  DO_BLOB_FPGA=0
+  DO_BLOB_POSIX=0
+
+  # Python venv
+  OVERWRITE_VENV=0
+
+  # Build selection (default: posix+fpga+package)
+  DO_BUILD_POSIX=1
+  DO_BUILD_FPGA=1
+  DO_PACKAGE_FPGA=1
+  __USER_BUILD_SELECT=0
+
+  # Cleanup
+  DO_CLEAN=0
+  DO_CLEAN_ALL=0
+
   local a
   for a in "$@"; do
     case "$(tolower "$a")" in
+      help|-h|--help)
+        usage
+        if [ "$__TSI_SOURCED" -eq 1 ]; then return 0; else exit 0; fi
+        ;;
       release|debug|debug-detail)
-        # first recognized build-type wins
-        if [ -z "${BUILD_TYPE}" ]; then
-          BUILD_TYPE="$a"
-        fi
+        [ -z "${BUILD_TYPE}" ] && BUILD_TYPE="$a"
         ;;
       enable_coverage)
         ENABLE_COVERAGE_FLAG="-DENABLE_COVERAGE=ON"
@@ -85,9 +204,57 @@ parse_args() {
         GIT_SUBMODULE_PULL=1
         log_info "git-submodule-pull detected (will update submodules)"
         ;;
+      build-fpga-blobs)
+        DO_BLOB_FPGA=1
+        log_info "build-fpga-blobs detected"
+        ;;
+      build-posix-blobs)
+        DO_BLOB_POSIX=1
+        log_info "build-posix-blobs detected"
+        ;;
+      build-all-blobs)
+        DO_BLOB_FPGA=1
+        DO_BLOB_POSIX=1
+        log_info "build-all-blobs detected"
+        ;;
+      overwrite-venv)
+        OVERWRITE_VENV=1
+        log_info "overwrite-venv detected"
+        ;;
+      build-posix|posix)
+        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then
+          DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0
+          __USER_BUILD_SELECT=1
+        fi
+        DO_BUILD_POSIX=1
+        log_info "build-posix selected"
+        ;;
+      build-fpga|fpga)
+        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then
+          DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0
+          __USER_BUILD_SELECT=1
+        fi
+        DO_BUILD_FPGA=1
+        log_info "build-fpga selected"
+        ;;
+      package|bundle)
+        if [ "$__USER_BUILD_SELECT" -eq 0 ]; then
+          DO_BUILD_POSIX=0; DO_BUILD_FPGA=0; DO_PACKAGE_FPGA=0
+          __USER_BUILD_SELECT=1
+        fi
+        DO_PACKAGE_FPGA=1
+        log_info "package selected"
+        ;;
+      clean)
+        DO_CLEAN=1
+        log_info "clean selected"
+        ;;
+      clean-all)
+        DO_CLEAN_ALL=1
+        log_info "clean-all selected"
+        ;;
       *)
-        # If user provides explicit paths, accept them in order:
-        # MLIR_COMPILER_DIR then TOOLBOX_DIR (only if not already set explicitly)
+        # positional paths (only if not already set)
         if [ -z "${MLIR_COMPILER_DIR_IN}" ]; then
           MLIR_COMPILER_DIR_IN="$a"
         elif [ -z "${TOOLBOX_DIR_IN}" ]; then
@@ -96,6 +263,14 @@ parse_args() {
         ;;
     esac
   done
+
+  # Required behavior: git-submodule-pull ALSO deletes+recreates venv and builds all blobs.
+  if [ "${GIT_SUBMODULE_PULL}" -eq 1 ]; then
+    OVERWRITE_VENV=1
+    DO_BLOB_FPGA=1
+    DO_BLOB_POSIX=1
+    log_info "git-submodule-pull => forcing overwrite-venv + build-all-blobs"
+  fi
 }
 
 resolve_paths() {
@@ -132,11 +307,19 @@ setup_toolchain() {
   export LD_LIBRARY_PATH="/proj/local/gcc-13.3.0/lib64:${LD_LIBRARY_PATH:-}"
 }
 
+# -------------------------
+# Python env (only when requested)
+# -------------------------
 setup_python() {
-  log_info "creating python virtual env"
+  log_info "python venv: ensuring blob-creation exists"
   __OLD_VIRTUAL_ENV="${VIRTUAL_ENV:-}"
 
-  # If venv already exists, just activate and return
+  if [ "${OVERWRITE_VENV}" -eq 1 ] && [ -d "blob-creation" ]; then
+    log_info "overwrite-venv: removing existing blob-creation venv"
+    rm -rf blob-creation || return 1
+  fi
+
+  # If venv exists, activate
   if [ -d "blob-creation" ] && [ -f "blob-creation/bin/activate" ]; then
     log_info "blob-creation virtual env already exists; activating"
     # shellcheck disable=SC1091
@@ -146,7 +329,7 @@ setup_python() {
     return 0
   fi
 
-  # Otherwise create it and install deps
+  # Otherwise create + install deps
   run /proj/local/Python-3.11.12/bin/python3 -m venv blob-creation || return 1
   # shellcheck disable=SC1091
   run bash -c 'source blob-creation/bin/activate && python -V >/dev/null' || return 1
@@ -165,19 +348,32 @@ setup_python() {
   else
     log_info "WARNING: mlir_external_packages wheel not found in ${MLIR_COMPILER_DIR}/python/"
   fi
+
   run pip install onnxruntime-training || return 1
+  return 0
 }
 
-build_kernels() {
-  log_info "creating fpga kernel"
+# -------------------------
+# Blob build steps (explicit only)
+# -------------------------
+build_fpga_blobs() {
+  log_info "BLOB: creating fpga kernels/blobs"
+  # In ggml-tsi-kernel/fpga-kernel
   run cmake -B build-fpga -DTOOLBOX_DIR="${TOOLBOX_DIR}" -DCOMPILER_INSTALL_DIR="${MLIR_COMPILER_DIR}" || return 1
   run ./create-all-kernels.sh || return 1
-
-  log_info "creating posix kernel"
-  cd ../posix-kernel/ || return 1
-  run ./create-all-kernels.sh || return 1
+  return 0
 }
 
+build_posix_blobs() {
+  log_info "BLOB: creating posix kernels/blobs"
+  # In ggml-tsi-kernel/posix-kernel
+  run ./create-all-kernels.sh || return 1
+  return 0
+}
+
+# -------------------------
+# Build and package (llama.cpp root)
+# -------------------------
 build_posix() {
   log_info "building llama.cpp/ggml for posix"
   local bt; bt="$(tolower "${BUILD_TYPE}")"
@@ -201,12 +397,14 @@ build_posix() {
     ${ENABLE_COVERAGE_FLAG} || return 1
 
   run cmake --build build-posix --config Release || return 1
+  return 0
 }
 
 wrap_glibc_bins() {
   log_info "fixing GLIBC compatibility for TSI binaries"
 
-  mv build-posix/bin/simple-backend-tsi build-posix/bin/simple-backend-tsi-original || return 1
+  [ -f build-posix/bin/simple-backend-tsi ] || return 0
+  [ -f build-posix/bin/simple-backend-tsi-original ] || mv build-posix/bin/simple-backend-tsi build-posix/bin/simple-backend-tsi-original || return 1
   cat > build-posix/bin/simple-backend-tsi <<'EOL'
 #!/bin/bash
 export LD_LIBRARY_PATH="/proj/local/gcc-13.3.0/lib64:$LD_LIBRARY_PATH"
@@ -214,13 +412,15 @@ exec "$(dirname "$0")/simple-backend-tsi-original" "$@"
 EOL
   chmod +x build-posix/bin/simple-backend-tsi || return 1
 
-  mv build-posix/bin/llama-cli build-posix/bin/llama-cli-original || return 1
+  [ -f build-posix/bin/llama-cli ] || return 0
+  [ -f build-posix/bin/llama-cli-original ] || mv build-posix/bin/llama-cli build-posix/bin/llama-cli-original || return 1
   cat > build-posix/bin/llama-cli <<'EOL'
 #!/bin/bash
 export LD_LIBRARY_PATH="/proj/local/gcc-13.3.0/lib64:$LD_LIBRARY_PATH"
 exec "$(dirname "$0")/llama-cli-original" "$@"
 EOL
   chmod +x build-posix/bin/llama-cli || return 1
+  return 0
 }
 
 build_fpga() {
@@ -240,6 +440,7 @@ build_fpga() {
     ${ENABLE_COVERAGE_FLAG} || return 1
 
   run cmake --build build-fpga --config Release || return 1
+  return 0
 }
 
 bundle_fpga() {
@@ -251,10 +452,12 @@ bundle_fpga() {
   local TSI_BLOB_INSTALL_DIR
   TSI_BLOB_INSTALL_DIR="$(pwd)/${GGML_TSI_INSTALL_DIR}/fpga-kernel/build-fpga"
 
+  # Sanity checks: package requires built fpga binaries
+  [ -f "build-fpga/bin/llama-cli" ] || die "package requested but build-fpga/bin/llama-cli not found. Run with build-fpga first."
+
   mkdir -p "${TSI_GGML_BUNDLE_INSTALL_DIR}"
   rm -f "${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh"
 
-  # Generate script without expansion, then substitute blob dir (avoids heredoc/quoting bugs)
   cat > "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh" <<'EOL'
 #!/bin/bash
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)
@@ -271,7 +474,9 @@ EOL
   sed -i "s|__TSI_BLOB_INSTALL_DIR__|${TSI_BLOB_INSTALL_DIR}|g" "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh"
   chmod +x "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh" || return 1
 
+  # These are repo-provided fpga blobs directory (not the generated per-kernel build dirs)
   cp "${GGML_TSI_INSTALL_DIR}/fpga/blobs" "${TSI_GGML_BUNDLE_INSTALL_DIR}/" -r || return 1
+
   cp build-fpga/bin/llama-cli "${TSI_GGML_BUNDLE_INSTALL_DIR}/" || return 1
   cp build-fpga/bin/libggml*.so "${TSI_GGML_BUNDLE_INSTALL_DIR}/" || return 1
   cp build-fpga/bin/libllama*.so "${TSI_GGML_BUNDLE_INSTALL_DIR}/" || return 1
@@ -289,33 +494,100 @@ EOL
     ln -s "${LATEST_FULL_PATH}" "${TSI_GGML_RELEASE_DIR}/tsi-ggml-latest.tz"
     log_info "Symlinks updated to point to $(basename "$LATEST_FULL_PATH")"
   fi
+  return 0
+}
+
+# -------------------------
+# Cleanup
+# -------------------------
+do_clean() {
+  log_info "clean: removing build directories"
+  rm -rf build-posix build-fpga 2>/dev/null || true
+  if [ -d ggml-tsi-kernel ]; then
+    rm -rf ggml-tsi-kernel/fpga-kernel/build-fpga 2>/dev/null || true
+    rm -rf ggml-tsi-kernel/posix-kernel/build-posix 2>/dev/null || true
+  fi
+  return 0
+}
+
+do_clean_all() {
+  do_clean || return 1
+  if [ -d ggml-tsi-kernel/blob-creation ]; then
+    log_info "clean-all: removing python venv blob-creation"
+    rm -rf ggml-tsi-kernel/blob-creation || true
+  fi
+  return 0
 }
 
 main() {
   set -o pipefail
+
   local arch; arch="$(select_arch)" || return $?
   parse_args "$@"
-  resolve_paths "$arch" || return $?
 
-  # Optional submodule update (default OFF)
-  if [ "${GIT_SUBMODULE_PULL}" -eq 1 ]; then
-    run git submodule update --recursive --init || return 1
-  else
-    log_info "Skipping git submodule update (default). Use git-submodule-pull to enable."
+  # Cleanup-only mode: do cleanup and exit early
+  if [ "${DO_CLEAN_ALL}" -eq 1 ]; then
+    do_clean_all
+    return 0
+  fi
+  if [ "${DO_CLEAN}" -eq 1 ]; then
+    do_clean
+    return 0
   fi
 
-  cd ggml-tsi-kernel/ || return 1
-  setup_toolchain || return 1
-  setup_python || return 1
+  resolve_paths "$arch" || return $?
 
-  cd fpga-kernel || return 1
-  build_kernels || return 1
+  # First run auto-inits; later optional unless git-submodule-pull is provided
+  ensure_submodules "${GIT_SUBMODULE_PULL}" || return 1
 
-  cd ../../ || return 1
-  build_posix || return 1
-  wrap_glibc_bins || return 1
-  build_fpga || return 1
-  bundle_fpga || return 1
+  # Blob/venv work happens in ggml-tsi-kernel only when requested
+  local need_python=0
+  if [ "${OVERWRITE_VENV}" -eq 1 ] || [ "${DO_BLOB_FPGA}" -eq 1 ] || [ "${DO_BLOB_POSIX}" -eq 1 ]; then
+    need_python=1
+  fi
+
+  if [ "${need_python}" -eq 1 ] || [ "${DO_BLOB_FPGA}" -eq 1 ] || [ "${DO_BLOB_POSIX}" -eq 1 ]; then
+    cd ggml-tsi-kernel/ || die "ggml-tsi-kernel not found (submodule). Try git-submodule-pull."
+
+    setup_toolchain || return 1
+
+    # Only set up python env when requested (overwrite or blob build)
+    if [ "${need_python}" -eq 1 ]; then
+      setup_python || return 1
+    fi
+
+    # Build blobs ONLY when explicitly requested
+    if [ "${DO_BLOB_FPGA}" -eq 1 ]; then
+      cd fpga-kernel || return 1
+      build_fpga_blobs || return 1
+      cd .. || return 1
+    fi
+
+    if [ "${DO_BLOB_POSIX}" -eq 1 ]; then
+      cd posix-kernel || return 1
+      build_posix_blobs || return 1
+      cd .. || return 1
+    fi
+
+    cd .. || return 1
+  else
+    setup_toolchain || return 1
+  fi
+
+  # Build selection in llama.cpp root
+  if [ "${DO_BUILD_POSIX}" -eq 1 ]; then
+    build_posix || return 1
+    wrap_glibc_bins || return 1
+  fi
+
+  if [ "${DO_BUILD_FPGA}" -eq 1 ]; then
+    build_fpga || return 1
+  fi
+
+  if [ "${DO_PACKAGE_FPGA}" -eq 1 ]; then
+    bundle_fpga || return 1
+  fi
+
   return 0
 }
 

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -56,14 +56,6 @@
 # Help:
 #   help | -h | --help
 #
-# Examples:
-#   source tsi-pkg-build.sh debug-detail
-#   source tsi-pkg-build.sh debug git-submodule-pull
-#   source tsi-pkg-build.sh debug build-all-blobs overwrite-venv
-#   source tsi-pkg-build.sh release build-posix
-#   source tsi-pkg-build.sh debug build-fpga package
-#   source tsi-pkg-build.sh debug build-fpga no-auto-blobs build-fpga-blobs
-#
 # ==============================================================================
 
 log_error(){ echo "ERROR: $*" >&2; }
@@ -72,7 +64,11 @@ log_info(){  echo "INFO:  $*"; }
 __TSI_SOURCED=0
 (return 0 2>/dev/null) && __TSI_SOURCED=1 || true
 __TSI_OLD_SET="$(set +o)"
+
+# --- VENV TRACKING (FIX) ---
+# If script activates blob-creation venv, we must restore previous env when sourced.
 __OLD_VIRTUAL_ENV=""
+__TSI_CHANGED_VENV=0
 
 run() { "$@"; local rc=$?; [ $rc -eq 0 ] || log_error "cmd failed ($rc): $*"; return $rc; }
 absdir() { (cd "$1" 2>/dev/null && pwd); }
@@ -84,6 +80,26 @@ die() {
 }
 
 cleanup() {
+  # --- VENV RESTORE (FIX) ---
+  # If we changed the venv, undo it. This runs on RETURN (sourced) or EXIT (executed).
+  if [ "${__TSI_CHANGED_VENV:-0}" -eq 1 ]; then
+    # deactivate exists only if we successfully sourced an activate script.
+    if declare -F deactivate >/dev/null 2>&1; then
+      deactivate >/dev/null 2>&1 || true
+    else
+      # Fallback: if deactivate isn't defined, at least unset VIRTUAL_ENV.
+      # (PATH restoration without deactivate is risky, so keep it minimal.)
+      unset VIRTUAL_ENV 2>/dev/null || true
+    fi
+
+    # If user was in a previous venv before we activated blob-creation, restore it.
+    if [ -n "${__OLD_VIRTUAL_ENV}" ] && [ -f "${__OLD_VIRTUAL_ENV}/bin/activate" ]; then
+      # shellcheck disable=SC1090
+      source "${__OLD_VIRTUAL_ENV}/bin/activate" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  # restore caller shell behavior
   eval "${__TSI_OLD_SET}" >/dev/null 2>&1 || true
   stty sane 2>/dev/null || true
   trap - RETURN EXIT 2>/dev/null || true
@@ -322,6 +338,7 @@ setup_toolchain() {
 # Python venv (only when needed)
 # -------------------------
 setup_python() {
+  # Save the caller's current VIRTUAL_ENV (if any). This allows restore.
   __OLD_VIRTUAL_ENV="${VIRTUAL_ENV:-}"
 
   if [ "${OVERWRITE_VENV}" -eq 1 ] && [ -d "blob-creation" ]; then
@@ -333,6 +350,8 @@ setup_python() {
     run bash -c 'source blob-creation/bin/activate && python -V >/dev/null' || return 1
     # shellcheck disable=SC1091
     source blob-creation/bin/activate || return 1
+    # Mark changed only if we actually switched envs
+    [ "${VIRTUAL_ENV:-}" != "${__OLD_VIRTUAL_ENV:-}" ] && __TSI_CHANGED_VENV=1 || true
     return 0
   fi
 
@@ -340,6 +359,7 @@ setup_python() {
   run bash -c 'source blob-creation/bin/activate && python -V >/dev/null' || return 1
   # shellcheck disable=SC1091
   source blob-creation/bin/activate || return 1
+  [ "${VIRTUAL_ENV:-}" != "${__OLD_VIRTUAL_ENV:-}" ] && __TSI_CHANGED_VENV=1 || true
 
   log_info "installing mlir and python dependencies"
   run pip install --upgrade pip || return 1
@@ -362,14 +382,12 @@ setup_python() {
 # Blob presence + build helpers
 # -------------------------
 posix_host_objs_present() {
-  # host.o provides _mlir_ciface_txe_*_host for POSIX link
   [ -d "posix-kernel/build-posix" ] || return 1
   find "posix-kernel/build-posix" -name "host.o" -print -quit 2>/dev/null | grep -q . || return 1
   return 0
 }
 
 fpga_host_objs_present() {
-  # host.o provides _mlir_ciface_txe_*_host for ARM cross-link too
   [ -d "fpga-kernel/build-fpga" ] || return 1
   find "fpga-kernel/build-fpga" -name "host.o" -print -quit 2>/dev/null | grep -q . || return 1
   return 0
@@ -378,7 +396,6 @@ fpga_host_objs_present() {
 build_fpga_blobs() {
   log_info "BLOB: building FPGA kernels/blobs"
   cd fpga-kernel || return 1
-  # ensure cmake config exists (create-all-kernels.sh may depend on it)
   run cmake -B build-fpga -DTOOLBOX_DIR="${TOOLBOX_DIR}" -DCOMPILER_INSTALL_DIR="${MLIR_COMPILER_DIR}" || return 1
   run ./create-all-kernels.sh || return 1
   cd .. || return 1
@@ -531,7 +548,7 @@ EOL
 }
 
 # -------------------------
-# Cleanup
+# Cleanup commands
 # -------------------------
 do_clean() {
   log_info "clean: removing build directories"
@@ -564,16 +581,13 @@ main() {
   resolve_paths "$arch" || return $?
   setup_toolchain || return 1
 
-  # Ensure submodule exists (fixes your "rm -rf ggml-tsi-kernel/" case)
   ensure_submodules "${GIT_SUBMODULE_PULL}" || return 1
 
-  # Decide if we need python:
   local need_python=0
   if [ "${OVERWRITE_VENV}" -eq 1 ] || [ "${DO_BLOB_FPGA}" -eq 1 ] || [ "${DO_BLOB_POSIX}" -eq 1 ]; then
     need_python=1
   fi
 
-  # AUTO host-object driven blob builds (POSIX + FPGA)
   local auto_posix_blob=0
   local auto_fpga_blob=0
 
@@ -601,7 +615,6 @@ main() {
     cd .. || return 1
   fi
 
-  # Do submodule-side work (python + blobs) only if required
   if [ "${need_python}" -eq 1 ] || [ "${DO_BLOB_FPGA}" -eq 1 ] || [ "${DO_BLOB_POSIX}" -eq 1 ]; then
     cd "${SUBMODULE_DIR}" || die "cannot enter ggml-tsi-kernel"
 
@@ -615,7 +628,6 @@ main() {
     cd .. || return 1
   fi
 
-  # Build llama.cpp outputs (posix first, then fpga, then package)
   if [ "${DO_BUILD_POSIX}" -eq 1 ]; then
     build_posix || return 1
     wrap_glibc_bins || return 1


### PR DESCRIPTION

Added following Enhancement
USAGE (source is recommended)
# ============================
#
#   source tsi-pkg-build.sh [build-mode] [flags...] [MLIR_COMPILER_DIR] [TOOLBOX_DIR]
#
# Build modes (optional):
#   release | debug | debug-detail
#     - release      : GGML_PERF_RELEASE
#     - debug        : GGML_PERF_DETAIL
#     - debug-detail : GGML_PERF_DETAIL + TMU_DEBUG_VALIDATE
#
# Submodules:
#   - First run in a fresh repo checkout: auto "git submodule update --init --recursive"
#   - Later runs: submodule update is OPTIONAL unless you pass:
#       git-submodule-pull
#   - If ggml-tsi-kernel is missing, script forces submodule init even without the flag.
#
# Blob build (OFF by default):
#   build-fpga-blobs     : build blobs in ggml-tsi-kernel/fpga-kernel only
#   build-posix-blobs    : build blobs in ggml-tsi-kernel/posix-kernel only
#   build-all-blobs      : build blobs for both fpga+posix kernels
#
# Auto blob safeguards (ON by default):
#   - If you deleted ggml-tsi-kernel (rm -rf) or host objects are missing:
#       * POSIX build auto-builds POSIX blobs if required for link
#       * FPGA build auto-builds FPGA blobs if required for link
#   Disable both with:
#       no-auto-blobs
#
# Python virtual env:
#   overwrite-venv       : delete blob-creation venv and recreate it (installs deps)
#                          NOTE: this alone does NOT build blobs unless blob flag is also set.
#   git-submodule-pull   : ALSO forces overwrite-venv AND build-all-blobs (as requested)
#
# Build selection:
#   Default (no build-selection flags): build-posix + build-fpga + package
#   build-posix          : only build posix C/C++
#   build-fpga           : only build fpga target
#   package              : only package fpga bundle (requires fpga already built)
#   (You can combine them: e.g. build-posix build-fpga)
#
# Incremental build:
#   incremental          : do not rm -rf build dirs (both llama.cpp + kernels)
#
# Cleanup:
#   clean                : rm -rf build-posix build-fpga (llama.cpp) and kernel build dirs in ggml-tsi-kernel
#   clean-all            : clean + remove python venv blob-creation
#
# Coverage:
#   enable_coverage      : adds -DENABLE_COVERAGE=ON
#
# Help:
#   help | -h | --help
#