### PR TITLE
@FIR-1628 - llama.cpp: Disable larger TMU blobs due to SDK‑2.10 regre…

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -1237,9 +1237,9 @@ static const tmu_bucket_dispatch g_tmu_dispatch[] = {
     { 1024, tmu_mul_mat_k1024 },
     {  512, tmu_mul_mat_k512  },
     {  256, tmu_mul_mat_k256  },
-#endif
     {  128, tmu_mul_mat_k128  },
     {   64, tmu_mul_mat_k64   },
+#endif
     {   32, tmu_mul_mat_k32   },
     {    0, nullptr           }
 };


### PR DESCRIPTION
Log
############
Ashish Trivedi u can see below working log with 2.10 after disabling larger blob
packer@tsisim:/usr/bin/tsi/bin$ sudo LD_LIBRARY_PATH=/tsi/tsi-sw/sdk/sdk-r.0.2.10/toolbox/build/install-fpga/lib:/tsi/tsi-sw/sdk/sdk-r.0.2.10/tsisim/runtime/lib:/opt/tsi/current/lib:/opt/tsi/current/bin/aot-tests/lib ./run_llama_cli.sh 

[2026-03-28 06:45:02.659] [info] </proj/pd3/work/nusman/git-runners/sdk-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:261> Device buffer file /dev/udmabuf3 does not exist (or not accessible), stopping initialization of further device buffers

Failed to generate tool call example: Value is not callable: null at row 1, column 72:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>

                                                                       ^

{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>

                                         ^

{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>

                                         ^

{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

at row 1, column 13:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>

            ^

{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

at row 1, column 1:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>

^

{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 
is not mentioned in the
 
 
llama_perf_sampler_print:    sampling time =     184.55 ms /     9 runs   (   20.51 ms per token,    48.77 tokens per second)

llama_perf_context_print:        load time = 1203063.92 ms

llama_perf_context_print: prompt eval time = 1183695.85 ms /     4 tokens (295923.96 ms per token,     0.00 tokens per second)

llama_perf_context_print:        eval time =   14160.10 ms /     4 runs   ( 3540.02 ms per token,     0.28 tokens per second)

llama_perf_context_print:       total time = 1217445.40 ms /     8 tokens
 
=== GGML Perf Summary ===

  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us

  ADD              OPU          660             834           9762820          14792.15

  MUL              OPU          671             848          10267700          15302.09

  RMS_NORM         OPU          671             671          10089110          15035.93

  MUL_MAT          CPU        11440               0          17300830           1512.31

  MUL_MAT          OPU          117           42444        1173182284       10027199.01

  CONT             CPU         2611               0            620857            237.79

  RESHAPE          CPU         3922               0             16282              4.15

  VIEW             CPU         6513               0             11437              1.76

  PERMUTE          CPU         5180               0             11113              2.15

  TRANSPOSE        CPU         1277               0              2493              1.95

  GET_ROWS         CPU           93               0              1708             18.37

  SET_ROWS         CPU         2612               0             39889             15.27

  SOFT_MAX         CPU         1313               0            330148            251.45

  ROPE             CPU         2610               0             82581             31.64

  GLU              OPU          330             417           7653962          23193.82

[2026-03-28 07:05:21.172975] 1063:1063 [warning] TsavRTFPGA TsavRTFPGA.cpp:498: FPGA runtime does not support dynamic device detachment.

[2026-03-28 07:05:21.210049] 1063:1063 [ info] TsavRTFPGA TsavRTFPGA.cpp:222: Releasing TXE instance 0
 
OPU Profiling Results:

------------------------------------------------------------------------------------------------------------------------

Calls  Total(ms)    T/call    Self(ms)  Function

------------------------------------------------------------------------------------------------------------------------

    1   951.4640  951.4640    934.7510  [7.81e-02%] [Thread] tsi::runtime::TsavRTFPGA::initialize

    1     5.7910    5.7910      5.7910  └─ [4.75e-04%] tsi::runtime::TsavRTFPGA::initializeQueues

    1     4.4510    4.4510      3.4870  └─ [3.65e-04%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand

    2     0.9640    0.4820      0.9640    └─ [7.91e-05%] tsi::runtime::executeWithTimeout

    1     3.4970    3.4970      3.4970  └─ [2.87e-04%] tsi::runtime::TsavRTFPGA::initializeRuntimeSpace

    1     2.9740    2.9740      2.9740  └─ [2.44e-04%] tsi::runtime::TsavRT::initialize

------------------------------------------------------------------------------------------------------------------------

[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)

------------------------------------------------------------------------------------------------------------------------

43942   1.11e+06   25.1678    1.10e+06  [90.75%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion

42444  2761.4320    0.0651   2761.4320  └─ [2.27e-01%] [ txe_mul_mat_tile_f32_k32 ]

43942  1170.1527    0.0266   1170.1527  └─ [9.60e-02%] TXE 0 Idle

  482    24.0803    0.0500     24.0803  └─ [1.98e-03%] [ txe_mult ]

  474    23.6787    0.0500     23.6787  └─ [1.94e-03%] [ txe_add ]

  305    19.0141    0.0623     19.0141  └─ [1.56e-03%] [ txe_rms_norm ]

  237    16.5001    0.0696     16.5001  └─ [1.35e-03%] [ txe_swiglu ]

------------------------------------------------------------------------------------------------------------------------

[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)

------------------------------------------------------------------------------------------------------------------------

    1    55.2760   55.2760     15.6530  [4.54e-03%] [Thread] tsi::runtime::TsavRTFPGA::finalize

    1    34.2490   34.2490     34.2490  └─ [2.81e-03%] tsi::runtime::TsavRT::finalize

    1     5.3740    5.3740      5.3740  └─ [4.41e-04%] tsi::runtime::TsavRTFPGA::releaseTxes

------------------------------------------------------------------------------------------------------------------------

[Thread] OPU  (cumulative over all threads)

------------------------------------------------------------------------------------------------------------------------

    1     1.3850    1.3850      1.1390  [1.14e-04%] [Thread] OPU 

    1     0.2460    0.2460      0.2460  └─ [2.02e-05%] tsi::runtime::TsavRT::allocate

------------------------------------------------------------------------------------------------------------------------

[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)

------------------------------------------------------------------------------------------------------------------------

43942 10381.8010    0.2363   8898.6250  [8.52e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList

43942  1483.1760    0.0338   1483.1760  └─ [1.22e-01%] tsi::runtime::executeWithTimeout

------------------------------------------------------------------------------------------------------------------------

[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)

------------------------------------------------------------------------------------------------------------------------

43942   1.08e+06   24.6578   4698.0310  [88.91%] [Thread] tsi::runtime::TsavRT::processResponses

43942   1.08e+06   24.5509    1.08e+06  └─ [88.53%] tsi::runtime::executeWithTimeout

------------------------------------------------------------------------------------------------------------------------

[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)

------------------------------------------------------------------------------------------------------------------------

43954   859.6260    0.0196    859.6260  [7.05e-02%] [Thread] tsi::runtime::TsavRT::allocate

------------------------------------------------------------------------------------------------------------------------

[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)

------------------------------------------------------------------------------------------------------------------------

43942 50779.8790    1.1556  50779.8790  [ 4.17%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob

------------------------------------------------------------------------------------------------------------------------

[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)

------------------------------------------------------------------------------------------------------------------------

43942  3798.1000    0.0864   3798.1000  [3.12e-01%] [Thread] tsi::runtime::TsavRT::addCommandToList

------------------------------------------------------------------------------------------------------------------------

[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)

------------------------------------------------------------------------------------------------------------------------

43942  6182.0940    0.1407   6182.0940  [5.07e-01%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob

------------------------------------------------------------------------------------------------------------------------

[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)

------------------------------------------------------------------------------------------------------------------------

43942   986.0860    0.0224    986.0860  [8.09e-02%] [Thread] tsi::runtime::TsavRT::deallocate

========================================================================================================================

    -   1.22e+06    0.0000    1.22e+06  [100.00%] TOTAL

========================================================================================================================
 
Counter Metrics:

------------------------------------------------------------------------------------------------------------------------

Metric                                    Min            Max            Avg

------------------------------------------------------------------------------------------------------------------------

Queue_0_Occupancy                      0.0000         1.0000         0.9980

------------------------------------------------------------------------------------------------------------------------
 
packer@tsisim:/usr/bin/tsi/bin$ 

 
Anoop Kapoor while we can chase issue with runtime/supv code maybe we can go with smaller size blobs for now and raise a PR for it. I can do a new ollama release that works for me as well, it unblocks everything as well enables TMU.
 
that was it, after making the change to only use K=32 even ollama is working. Once you raise PR and I integrate it I can do another ollama release with TMU enabled as well for Karrar to use. 
Mar 28 15:11:28 qemuarm64 ollama[480]: llama_kv_cache: size =   90.00 MiB (  4096 cells,  30 layers,  1/1 seqs), K (f16):   45.00 MiB, V (f16):   45.00 MiB

Mar 28 15:11:29 qemuarm64 ollama[480]: llama_context:  tsavorite compute buffer size =   213.16 MiB

Mar 28 15:11:29 qemuarm64 ollama[480]: llama_context:        CPU compute buffer size =    84.13 MiB

Mar 28 15:11:29 qemuarm64 ollama[480]: llama_context: graph nodes  = 1086

Mar 28 15:11:29 qemuarm64 ollama[480]: llama_context: graph splits = 216 (with bs=512), 244 (with bs=1)

Mar 28 15:11:29 qemuarm64 ollama[480]: time=2026-03-28T15:11:29.498Z level=INFO source=server.go:1312 msg="llama runner started in 5.82 seconds"

Mar 28 15:11:29 qemuarm64 ollama[480]: time=2026-03-28T15:11:29.500Z level=INFO source=sched.go:485 msg="loaded runners" count=1

Mar 28 15:11:29 qemuarm64 ollama[480]: time=2026-03-28T15:11:29.501Z level=INFO source=server.go:1274 msg="waiting for llama runner to start responding"

Mar 28 15:11:29 qemuarm64 ollama[480]: time=2026-03-28T15:11:29.512Z level=INFO source=server.go:1312 msg="llama runner started in 5.84 seconds"

Mar 28 15:32:17 qemuarm64 ollama[480]: [2026-03-28 15:32:17.172012] 554:558 [warning] TsavRTFPGA TsavRTFPGA.cpp:498: FPGA runtime does not support dynamic device detachment.

Mar 28 15:32:17 qemuarm64 ollama[480]: [2026-03-28 15:32:17.198538] 554:558 [ info] TsavRTFPGA TsavRTFPGA.cpp:222: Releasing TXE instance 0

Mar 28 15:32:17 qemuarm64 ollama[554]: OPU Profiling Results:

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: Calls  Total(ms)    T/call    Self(ms)  Function

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]:     1    51.1310   51.1310     34.5480  [4.08e-03%] [Thread] tsi::runtime::TsavRTFPGA::initialize

Mar 28 15:32:17 qemuarm64 ollama[554]:     1     9.0150    9.0150      9.0150  └─ [7.19e-04%] tsi::runtime::TsavRTFPGA::initializeQueues

Mar 28 15:32:17 qemuarm64 ollama[554]:     1     3.2010    3.2010      2.0330  └─ [2.55e-04%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand

Mar 28 15:32:17 qemuarm64 ollama[554]:     2     1.1680    0.5840      1.1680    └─ [9.32e-05%] tsi::runtime::executeWithTimeout

Mar 28 15:32:17 qemuarm64 ollama[554]:     1     2.2120    2.2120      2.2120  └─ [1.76e-04%] tsi::runtime::TsavRTFPGA::initializeRuntimeSpace

Mar 28 15:32:17 qemuarm64 ollama[554]:     1     2.1550    2.1550      2.1550  └─ [1.72e-04%] tsi::runtime::TsavRT::initialize

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: 46068   1.21e+06   26.3262    1.21e+06  [96.76%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion

Mar 28 15:32:17 qemuarm64 ollama[554]: 42444  2757.8776    0.0650   2757.8776  └─ [2.20e-01%] [ txe_mul_mat_tile_f32_k32 ]

Mar 28 15:32:17 qemuarm64 ollama[554]: 46068   393.8941    0.0086    393.8941  └─ [3.14e-02%] TXE 0 Idle

Mar 28 15:32:17 qemuarm64 ollama[554]:  1456    72.7419    0.0500     72.7419  └─ [5.80e-03%] [ txe_mult ]

Mar 28 15:32:17 qemuarm64 ollama[554]:  1432    71.5396    0.0500     71.5396  └─ [5.71e-03%] [ txe_add ]

Mar 28 15:32:17 qemuarm64 ollama[554]:   716    49.8396    0.0696     49.8396  └─ [3.98e-03%] [ txe_swiglu ]

Mar 28 15:32:17 qemuarm64 ollama[554]:    20     1.1053    0.0553      1.1053  └─ [8.82e-05%] [ txe_rms_norm ]

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: [Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]:     1    44.3100   44.3100     13.3950  [3.54e-03%] [Thread] tsi::runtime::TsavRTFPGA::finalize

Mar 28 15:32:17 qemuarm64 ollama[554]:     1    24.6680   24.6680     24.6680  └─ [1.97e-03%] tsi::runtime::TsavRT::finalize

Mar 28 15:32:17 qemuarm64 ollama[554]:     1     6.2470    6.2470      6.2470  └─ [4.98e-04%] tsi::runtime::TsavRTFPGA::releaseTxes

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: [Thread] OPU  (cumulative over all threads)

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]:     2     3.0340    1.5170      1.2980  [2.42e-04%] [Thread] OPU

Mar 28 15:32:17 qemuarm64 ollama[554]:     2     1.7360    0.8680      1.7360  └─ [1.39e-04%] tsi::runtime::TsavRT::allocate

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: [Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: 46068  4532.6920    0.0984   4328.4380  [3.62e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList

Mar 28 15:32:17 qemuarm64 ollama[554]: 46068   204.2540    0.0044    204.2540  └─ [1.63e-02%] tsi::runtime::executeWithTimeout

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: [Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: 46068   1.21e+06   26.2240   1521.4450  [96.38%] [Thread] tsi::runtime::TsavRT::processResponses

Mar 28 15:32:17 qemuarm64 ollama[554]: 46068   1.21e+06   26.1909    1.21e+06  └─ [96.26%] tsi::runtime::executeWithTimeout

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: [Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: 46076   364.4410    0.0079    364.4410  [2.91e-02%] [Thread] tsi::runtime::TsavRT::allocate

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: [Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: 46068 15326.9820    0.3327  15326.9820  [ 1.22%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: [Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: 46068  1736.4970    0.0377   1736.4970  [1.39e-01%] [Thread] tsi::runtime::TsavRT::addCommandToList

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: [Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: 46068  1180.1760    0.0256   1180.1760  [9.42e-02%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: [Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: 46068   363.8190    0.0079    363.8190  [2.90e-02%] [Thread] tsi::runtime::TsavRT::deallocate

Mar 28 15:32:17 qemuarm64 ollama[554]: ========================================================================================================================

Mar 28 15:32:17 qemuarm64 ollama[554]:     -   1.25e+06    0.0000    1.25e+06  [100.00%] TOTAL

Mar 28 15:32:17 qemuarm64 ollama[554]: ========================================================================================================================

Mar 28 15:32:17 qemuarm64 ollama[554]: Counter Metrics:

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: Metric                                    Min            Max            Avg

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[554]: Queue_0_Occupancy                      0.0000         1.0000         0.9997

Mar 28 15:32:17 qemuarm64 ollama[554]: ------------------------------------------------------------------------------------------------------------------------

Mar 28 15:32:17 qemuarm64 ollama[480]: [GIN] 2026/03/28 - 15:32:17 | 200 |        20m54s |       127.0.0.1 | POST     "/api/generate"

Mar 28 15:37:17 qemuarm64 ollama[480]: time=2026-03-28T15:37:17.232Z level=WARN source=server.go:1757 msg="llama server stopped" pid=554
 
 
 
 
