### PR TITLE
@FIR-1605- Multi-TXE Support: USE CASE 2

### DIFF
--- a/ggml/include/ggml-tsavorite.h
+++ b/ggml/include/ggml-tsavorite.h
@@ -327,8 +327,6 @@ extern void _mlir_ciface_txe_rms_norm_16_host(void *a, void *res, void *buf);
 
 extern void ggml_tsi_log_tensor_data(tensor_log log_data);
 
-#define NUM_OF_TXES 2
-
 // GGML supports tensors with a maximum rank of 4
 #define MEM_REF_DESCRIPTOR_RANK 4
 #define TSI_TVU_MEM_ALIGN 128

--- a/ggml/include/ggml-tsavorite.h
+++ b/ggml/include/ggml-tsavorite.h
@@ -327,7 +327,7 @@ extern void _mlir_ciface_txe_rms_norm_16_host(void *a, void *res, void *buf);
 
 extern void ggml_tsi_log_tensor_data(tensor_log log_data);
 
-#define NUM_OF_TXES 1
+#define NUM_OF_TXES 2
 
 // GGML supports tensors with a maximum rank of 4
 #define MEM_REF_DESCRIPTOR_RANK 4

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -37,12 +37,19 @@
 
 #include <thread>
 #include <vector>
+#include  <mutex>
+#include <condition_variable>
 
 
 using namespace tsi::runtime;
 
 
 std::vector<std::thread> workers;
+static std::mutex device_mutex;
+static std::condition_variable device_cv;
+
+// device availability table
+static bool device_free[NUM_OF_TXES] = { true, true };
 
 static bool multi_thread_enable = false;
 
@@ -125,40 +132,47 @@ bool runtime_initialized = false;
 uint64_t num_of_op;
 
 
-static TSI_DeviceIdType deviceId_1 = 0, deviceId_2 = 1;
-static void *loadResult_add, *loadResult_mult, *loadResult_rms_norm;
-static BlobDescriptor *blobDescriptor_add, *blobDescriptor_mult, *blobDescriptor_rms_norm;
+//static TSI_DeviceIdType deviceId_1 = 0, deviceId_2 = 1;
+
+static void *loadResult_add[NUM_OF_TXES], *loadResult_mult[NUM_OF_TXES], *loadResult_rms_norm[NUM_OF_TXES];
+static BlobDescriptor *blobDescriptor_add[NUM_OF_TXES], *blobDescriptor_mult[NUM_OF_TXES], *blobDescriptor_rms_norm[NUM_OF_TXES];
 
 void tsi_load_all_blobs() {
-  loadResult_add = tsi_load_blob(
-      deviceId_1,
+
+for (int i=0; i < NUM_OF_TXES; ++i) {
+printf("\n ANOOP Loading Blobs \n");
+  loadResult_add[i] = tsi_load_blob(
+      i,
       "txe_add",
       ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"));
 
-  blobDescriptor_add = static_cast<BlobDescriptor *>(loadResult_add);
+  blobDescriptor_add[i] = static_cast<BlobDescriptor *>(loadResult_add[i]);
 
-  loadResult_mult = tsi_load_blob(
-      deviceId_1,
+  loadResult_mult[i] = tsi_load_blob(
+      i,
       "txe_mult",
       ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"));
 
-  blobDescriptor_mult = static_cast<BlobDescriptor *>(loadResult_mult);
-  
-  loadResult_rms_norm = tsi_load_blob(
-      deviceId_2,
+  blobDescriptor_mult[i] = static_cast<BlobDescriptor *>(loadResult_mult[i]);
+
+  loadResult_rms_norm[i] = tsi_load_blob(
+      i,
       "txe_rms_norm",
       ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"));
 
-  blobDescriptor_rms_norm = static_cast<BlobDescriptor *>(loadResult_rms_norm);
+  blobDescriptor_rms_norm[i] = static_cast<BlobDescriptor *>(loadResult_rms_norm[i]);
+
+}
 
   return;
 }
 
 static void tsi_unload_all_blobs() {
-  tsi_unload_blob(blobDescriptor_add);
-  tsi_unload_blob(blobDescriptor_mult);
-  tsi_unload_blob(blobDescriptor_rms_norm);
-
+for (int i=0; i < NUM_OF_TXES; ++i) {
+  tsi_unload_blob(blobDescriptor_add[i]);
+  tsi_unload_blob(blobDescriptor_mult[i]);
+  tsi_unload_blob(blobDescriptor_rms_norm[i]);
+}
   return;
 }
 
@@ -168,8 +182,7 @@ static void ensure_tsi_runtime_initialized() {
     std::string mainProfilerName = "OPU ";
     tsirt::utils::TSIProfiler::initialize();
     // TSI Run time Initalization
-    //tsi_initialize(NUM_OF_TXES, NULL);
-    tsi_initialize(2, NULL);
+    tsi_initialize(NUM_OF_TXES, NULL);
 
     tsi_load_all_blobs();
 
@@ -558,29 +571,67 @@ static void _mlir_ciface_txe_mult_test (void *src0, void *src1, void *res)
 // Total = 3 args * 3 int64 = 9 int64 = 72 bytes.)
 
 
-static uint32_t anoop_add_test=0;
+// ============================================================
+// DEVICE ACQUIRE / RELEASE
+// ============================================================
 
+static inline int acquire_device_blocking() {
+    std::unique_lock<std::mutex> lock(device_mutex);
 
-static void _mlir_ciface_txe_add_host_internal(void *a, void *b, void *res) {
-  //TSI_DeviceIdType deviceId = 0;
+    device_cv.wait(lock, [] {
+        for (int i = 0; i < NUM_OF_TXES; ++i)
+            if (device_free[i])
+                return true;
+        return false;
+    });
+
+    for (int i = 0; i < NUM_OF_TXES; ++i) {
+        if (device_free[i]) {
+            device_free[i] = false;
+            return i;
+        }
+    }
+    return -1;
+}
+
+static inline void release_device(int deviceId) {
+    std::lock_guard<std::mutex> lock(device_mutex);
+    device_free[deviceId] = true;
+    device_cv.notify_one();
+}
+
+// ============================================================
+// FINAL JOIN — CALL AT END OF ggml_tsavorite_graph_compute()
+// ============================================================
+
+static inline void join_all_workers() {
+    for (auto &t : workers) {
+        if (t.joinable())
+            t.join();
+    }
+    workers.clear();
+
+    {
+        std::lock_guard<std::mutex> lock(device_mutex);
+        for (int i = 0; i < NUM_OF_TXES; ++i)
+            device_free[i] = true;
+    }
+    device_cv.notify_all();
+}
+
+static void tsi_blob_execution_internal(void *commandList) {
+  // Enqueue & run
+  tsi_finalize_command_list(commandList);
+  tsi_wait(commandList);
+  return;
+}
+
+static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI_DeviceIdType deviceId) {
   constexpr int64_t kPackedArgsI64  = 9;
   constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
 
-  ++anoop_add_test;
-  //if (anoop_add_test <= 2)
-    printf("\n Called _mlir_ciface_txe_add_host_new %d \n", anoop_add_test);
-
-#if 0
-  void *loadResult_add = tsi_load_blob(
-      deviceId,
-      "txe_add",
-      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"));
-
-  BlobDescriptor *blobDescriptor_add = static_cast<BlobDescriptor *>(loadResult_add);
-#endif
-
   // Create the command list for the blob execute command
-  void *commandList = tsi_create_command_list(deviceId_1);
+  void *commandList = tsi_create_command_list(deviceId);
 
   // Allocate packed args buffer in shared DRAM
   void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
@@ -619,52 +670,37 @@ static void _mlir_ciface_txe_add_host_internal(void *a, void *b, void *res) {
 
   const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
 
-  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add, /*packedArgs*/ packedHandle);
+  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add[deviceId], /*packedArgs*/ packedHandle);
   tsi_add_command_to_list(commandList, blobExecuteCmd);
 
-  // Enqueue & run
-  tsi_finalize_command_list(commandList);
-  tsi_wait(commandList);
-
-#if 0
-  tsi_unload_blob(blobDescriptor_add);
-#endif
-  return;
+  return commandList;
 }
 
 static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
-   if(multi_thread_enable) {
-      printf("\n ANOP we are calling thread for ADD \n");
-      workers.emplace_back(_mlir_ciface_txe_add_host_internal, a, b, res);
-   } else {
-       _mlir_ciface_txe_add_host_internal(a, b, res);
-   }
-   return;
+    if (!multi_thread_enable) {
+       void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, 0);
+        tsi_blob_execution_internal(commandList);
+        return;
+    }
+
+    int deviceId = acquire_device_blocking();
+printf("\n ANOOP ADD device ID %d", deviceId);
+
+    workers.emplace_back([=]() {
+        void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, deviceId);
+        tsi_blob_execution_internal(commandList);
+        release_device(deviceId);
+        printf("\n ANOOP Release ADD device ID %d", deviceId);
+    });
 }
 
-static uint32_t anoop_mult_test=0;
 
-
-static void _mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res) {
-  //TSI_DeviceIdType deviceId = 0;
+static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TSI_DeviceIdType deviceId) {
   constexpr int64_t kPackedArgsI64  = 9;
   constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
 
-  ++anoop_mult_test;
-  //if (anoop_mult_test <= 2)
-    printf("\n Called _mlir_ciface_txe_mult_host_new %d \n", anoop_mult_test);
-
-#if 0
-  void *loadResult_mult = tsi_load_blob(
-      deviceId,
-      "txe_mult",
-      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"));
-
-  BlobDescriptor *blobDescriptor_mult = static_cast<BlobDescriptor *>(loadResult_mult);
-#endif
-
   // Create the command list for the blob execute command
-  void *commandList = tsi_create_command_list(deviceId_1);
+  void *commandList = tsi_create_command_list(deviceId);
 
   // Allocate packed args buffer in shared DRAM
   void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
@@ -703,53 +739,37 @@ static void _mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res) {
 
   const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
 
-  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult, /*packedArgs*/ packedHandle);
+  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult[deviceId], /*packedArgs*/ packedHandle);
   tsi_add_command_to_list(commandList, blobExecuteCmd);
 
-  // Enqueue & run
-  tsi_finalize_command_list(commandList);
-  tsi_wait(commandList);
-
-#if 0
-  tsi_unload_blob(blobDescriptor_mult);
-#endif
-  return;
+  return commandList;
 }
 
 static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
-   if(multi_thread_enable) {
-      printf("\n ANOP we are calling thread for MULT \n");
-      workers.emplace_back(_mlir_ciface_txe_mult_host_internal, a, b, res);
-   } else {
-       _mlir_ciface_txe_mult_host_internal(a, b, res);
-   }
-   return;
+    if (!multi_thread_enable) {
+        void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, 1);
+        tsi_blob_execution_internal(commandList);
+        return;
+    }
+
+    int deviceId = acquire_device_blocking();
+
+printf("\n ANOOP MUL device ID %d", deviceId);
+    workers.emplace_back([=]() {
+        void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, deviceId);
+        tsi_blob_execution_internal(commandList);
+        release_device(deviceId);
+        printf("\n ANOOP Release MUL device ID %d", deviceId);
+    });
 }
 
 
-static uint32_t anoop_rms_norm_test=0;
-
-
-static void _mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf) {
-  //TSI_DeviceIdType deviceId = 1;
+static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf, TSI_DeviceIdType deviceId) {
   constexpr int64_t kPackedArgsI64  = 20;
   constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
 
-  ++anoop_rms_norm_test;
-  //if (anoop_rms_norm_test <= 2)
-    printf("\n Called _mlir_ciface_txe_rms_norm_host_new %d \n", anoop_rms_norm_test);
-
-#if 0
-  void *loadResult_rms_norm = tsi_load_blob(
-      deviceId,
-      "txe_rms_norm",
-      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"));
-
-  BlobDescriptor *blobDescriptor_rms_norm = static_cast<BlobDescriptor *>(loadResult_rms_norm);
-#endif
-
   // Create the command list for the blob execute command
-  void *commandList = tsi_create_command_list(deviceId_2);
+  void *commandList = tsi_create_command_list(deviceId);
 
   // Allocate packed args buffer in shared DRAM
   void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
@@ -800,30 +820,28 @@ static void _mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf)
 
   const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
 
-  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm, /*packedArgs*/ packedHandle);
+  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm[deviceId], /*packedArgs*/ packedHandle);
   tsi_add_command_to_list(commandList, blobExecuteCmd);
-
-  // Enqueue & run
-  tsi_finalize_command_list(commandList);
-  tsi_wait(commandList);
-
-#if 0
-  tsi_unload_blob(blobDescriptor_rms_norm);
-#endif
-  return;
+  return commandList;
 }
 
 static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
-   if(multi_thread_enable) {
-      printf("\n ANOP we are calling thread for RMS NORM \n");
-      workers.emplace_back(_mlir_ciface_txe_rms_norm_host_internal, a, b, buf);
-   } else {
-       _mlir_ciface_txe_rms_norm_host_internal(a, b, buf);
-   }
-   return;
+    if (!multi_thread_enable) {
+        void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, 0);
+        tsi_blob_execution_internal(commandList);
+        return;
+    }
+
+    int deviceId = acquire_device_blocking();
+printf("\n ANOOP RMS_NORM device ID %d", deviceId);
+
+    workers.emplace_back([=]() {
+        void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, deviceId);
+        tsi_blob_execution_internal(commandList);
+        release_device(deviceId);
+       printf("\n ANOOP RMS_NORM Releasing device ID %d", deviceId);
+    });
 }
-
-
 
 
 static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_type kernel_type) {
@@ -2046,31 +2064,20 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
   enum ggml_tsavorite_input_tensors_count num_of_input_tensors;
   tensor_log log_data;
 
-bool skip_multi_threading = false;
-    if (cgraph->n_nodes == 2) {
-          printf("\n ANOOP graph nodes %d \n",cgraph->n_nodes);
-          for (int i = 0; i < cgraph->n_nodes; i++) {
-             node = cgraph->nodes[i];
-             if (node->op == GGML_OP_UNARY) {
-                enum ggml_unary_op subop = ggml_get_unary_op(node);
-                printf ("     OPS:  UNARY(%s)\n", ggml_unary_op_name(subop));
-             } else {
-                printf ("     OPS:  (%s)\n", ggml_op_name(node->op));
+
+multi_thread_enable = false;
+if (cgraph->n_nodes == 2) {
+             node = cgraph->nodes[0];
+             if (node->op == GGML_OP_MUL)  {
+                 multi_thread_enable = true;
+                 printf("\n ANOOP Multi-thread-enable for MUL GRAPH EXECUTIOn going to start");
              }
-             if (node->op == GGML_OP_ADD) 
-                skip_multi_threading = true;
-          }
-          
-    }
-    if (cgraph->n_nodes == 2 && !skip_multi_threading) {
-        multi_thread_enable = true;
-       anoop_test();
-    } else {
-        multi_thread_enable = false;
-    }
-
-
-//multi_thread_enable = false;
+             node = cgraph->nodes[1];
+             if (node->op == GGML_OP_MUL)  {
+                 multi_thread_enable = true;
+                 printf("\n ANOOP Multi-thread-enable for MUL GRAPH EXECUTIOn going to start");
+             }
+}
 
   for (int i = 0; i < cgraph->n_nodes; i++) {
      int32_t kernel_sub_type=-1;
@@ -2551,15 +2558,11 @@ bool skip_multi_threading = false;
 #endif /* GGML_PERF-related flags */
   } /* this is main for loop */
 
-if (cgraph->n_nodes == 2) {
-printf("\n ANOOP WE are joinin the thread\n");
-// join back to main thread
-    for (auto &t : workers) {
-        t.join();
-    }
-    workers.clear();
-    anoop_test();
-}
+  if (multi_thread_enable) {
+    printf("\n ANOOP Multi-thread-enable for MUL GRAPH EXECUTIOn Completed");
+    join_all_workers();
+   }
+  anoop_test();
 
 
   // This this need to implement correctly when we have mixture of CPU and accelerator operation

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -18,8 +18,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <limits.h>
-#include <libgen.h>
 #include <string.h>
 
 #include "ggml-tsavorite.h"
@@ -244,10 +242,13 @@ static void ensure_tsi_runtime_initialized() {
     #else
         num_of_txes = NUM_OF_TXES;
         multi_thread_enable = false;
-        tsi_load_all_blobs();
     #endif /* GGML_TARGET_POSIX */
     tsi_initialize(num_of_txes, NULL);
 
+    if (multi_thread_enable) {
+        // Temporarily disabled; will be enabled in the next release to avoid collateral impact
+        tsi_load_all_blobs();
+    }
     device_free = (bool *)malloc(num_of_txes * sizeof(bool));
     if (!device_free) {
         fprintf(stderr, "Failed to allocate device_free\n");
@@ -1225,7 +1226,10 @@ static void ggml_tsavorite_free(struct ggml_backend_tsavorite_context *ctx) {
       sleep(2);
       runtime_initialized = false;
       #ifndef GGML_TARGET_POSIX
-         tsi_unload_all_blobs();
+          if (multi_thread_enable) {
+              // Temporarily disabled; will be enabled in the next release to avoid collateral impact
+              tsi_unload_all_blobs();
+          }
       #endif /* !GGML_TARGET_POSIX */
       if(device_free) {
           free(device_free);
@@ -1249,7 +1253,10 @@ tsi_cleanup() {
         return;
     runtime_initialized = false;
     #ifndef GGML_TARGET_POSIX
-       tsi_unload_all_blobs();
+          if (multi_thread_enable) {
+              // Temporarily disabled; will be enabled in the next release to avoid collateral impact
+              tsi_unload_all_blobs();
+          }
     #endif /* !GGML_TARGET_POSIX */
     if(device_free) {
         free(device_free);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -1470,6 +1470,9 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     // If this blocks valid cases in your build, comment it out.
     if (a->ne[1] != N) return false;
 
+    // Disable MAT_MUL offloading to Tsavorite for the Tiny‑Llama‑v0.3‑FP32‑1.1B model
+    return false;
+
     // -------------------------------------------------------------------------
     // Tiny-Llama-v0.3-FP32-1.1B-F32.gguf shapes (from your static-shape list)
     // Most frequent inference shapes are M=7 with K=2048 and N in {256,2048,5632}

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -54,9 +54,11 @@ static std::condition_variable device_cv;
 
 
 // This will also go in deployment file
-#define NUM_OF_TXES 1
-// device availability table
-static bool device_free[NUM_OF_TXES] = { true, true };
+#define NUM_OF_TXES 2
+static uint32_t num_of_txes =  NUM_OF_TXES;
+
+
+static bool *device_free = NULL;
 static bool multi_thread_enable = false;
 
 
@@ -234,16 +236,28 @@ static void ensure_tsi_runtime_initialized() {
   if (!runtime_initialized) {
     std::string mainProfilerName = "OPU ";
     tsirt::utils::TSIProfiler::initialize();
+
     // TSI Run time Initalization
     #ifdef GGML_TARGET_POSIX
-        tsi_initialize(1, NULL);
+        num_of_txes = 1;
         multi_thread_enable = false;
     #else
-        tsi_initialize(NUM_OF_TXES, NULL);
+        num_of_txes = NUM_OF_TXES;
         multi_thread_enable = false;
         tsi_load_all_blobs();
     #endif /* GGML_TARGET_POSIX */
+    tsi_initialize(num_of_txes, NULL);
 
+    device_free = (bool *)malloc(num_of_txes * sizeof(bool));
+    if (!device_free) {
+        fprintf(stderr, "Failed to allocate device_free\n");
+        tsi_finalize();
+        abort();
+    }
+    
+    for (int i = 0; i < num_of_txes; i++) {
+        device_free[i] = true;
+    }
 
     workers.reserve(2);
     runtime_initialized = true;
@@ -638,13 +652,13 @@ static inline int acquire_device_blocking() {
     std::unique_lock<std::mutex> lock(device_mutex);
 
     device_cv.wait(lock, [] {
-        for (int i = 0; i < NUM_OF_TXES; ++i)
+        for (int i = 0; i < num_of_txes; ++i)
             if (device_free[i])
                 return true;
         return false;
     });
 
-    for (int i = 0; i < NUM_OF_TXES; ++i) {
+    for (int i = 0; i < num_of_txes; ++i) {
         if (device_free[i]) {
             device_free[i] = false;
             return i;
@@ -673,7 +687,7 @@ static inline void join_all_workers() {
 
     {
         std::lock_guard<std::mutex> lock(device_mutex);
-        for (int i = 0; i < NUM_OF_TXES; ++i)
+        for (int i = 0; i < num_of_txes; ++i)
             device_free[i] = true;
     }
     device_cv.notify_all();
@@ -1213,6 +1227,10 @@ static void ggml_tsavorite_free(struct ggml_backend_tsavorite_context *ctx) {
       #ifndef GGML_TARGET_POSIX
          tsi_unload_all_blobs();
       #endif /* !GGML_TARGET_POSIX */
+      if(device_free) {
+          free(device_free);
+         device_free = NULL;
+    }
       tsi_finalize();
       tsirt::utils::TSIProfiler::finalize();
       sleep(2);
@@ -1233,6 +1251,10 @@ tsi_cleanup() {
     #ifndef GGML_TARGET_POSIX
        tsi_unload_all_blobs();
     #endif /* !GGML_TARGET_POSIX */
+    if(device_free) {
+        free(device_free);
+        device_free = NULL;
+    }
     tsi_finalize();
     GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
     tsirt::utils::TSIProfiler::finalize();

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -46,6 +46,7 @@ using namespace tsi::runtime;
 
 std::vector<std::thread> workers;
 static std::mutex device_mutex;
+static std::mutex tsi_pack_mutex;
 static std::condition_variable device_cv;
 
 // device availability table
@@ -137,34 +138,41 @@ uint64_t num_of_op;
 static void *loadResult_add[NUM_OF_TXES], *loadResult_mult[NUM_OF_TXES], *loadResult_rms_norm[NUM_OF_TXES];
 static BlobDescriptor *blobDescriptor_add[NUM_OF_TXES], *blobDescriptor_mult[NUM_OF_TXES], *blobDescriptor_rms_norm[NUM_OF_TXES];
 
+
+
+// ============================================================
+// FUNCTION REPLACEMENT: tsi_load_all_blobs()
+// (makes blob names unique per device to avoid collisions)
+// ============================================================
+
 void tsi_load_all_blobs() {
+    for (int i = 0; i < NUM_OF_TXES; ++i) {
+        printf("\n ANOOP Loading Blobs \n");
 
-for (int i=0; i < NUM_OF_TXES; ++i) {
-printf("\n ANOOP Loading Blobs \n");
-  loadResult_add[i] = tsi_load_blob(
-      i,
-      "txe_add",
-      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"));
+        char name_add[64], name_mult[64], name_rms[64];
+        snprintf(name_add,  sizeof(name_add),  "txe_add_dev%d", i);
+        snprintf(name_mult, sizeof(name_mult), "txe_mult_dev%d", i);
+        snprintf(name_rms,  sizeof(name_rms),  "txe_rms_norm_dev%d", i);
 
-  blobDescriptor_add[i] = static_cast<BlobDescriptor *>(loadResult_add[i]);
+        loadResult_add[i] = tsi_load_blob(
+            i,
+            name_add,
+            ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"));
+        blobDescriptor_add[i] = static_cast<BlobDescriptor *>(loadResult_add[i]);
 
-  loadResult_mult[i] = tsi_load_blob(
-      i,
-      "txe_mult",
-      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"));
+        loadResult_mult[i] = tsi_load_blob(
+            i,
+            name_mult,
+            ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"));
+       blobDescriptor_mult[i] = static_cast<BlobDescriptor *>(loadResult_mult[i]);
 
-  blobDescriptor_mult[i] = static_cast<BlobDescriptor *>(loadResult_mult[i]);
-
-  loadResult_rms_norm[i] = tsi_load_blob(
-      i,
-      "txe_rms_norm",
-      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"));
-
-  blobDescriptor_rms_norm[i] = static_cast<BlobDescriptor *>(loadResult_rms_norm[i]);
-
-}
-
-  return;
+        loadResult_rms_norm[i] = tsi_load_blob(
+            i,
+            name_rms,
+            ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"));
+        blobDescriptor_rms_norm[i] = static_cast<BlobDescriptor *>(loadResult_rms_norm[i]);
+    }
+    return;
 }
 
 static void tsi_unload_all_blobs() {
@@ -626,54 +634,48 @@ static void tsi_blob_execution_internal(void *commandList) {
   return;
 }
 
+//lock goes out of scope
+// <--- function scope ends here mutex will be released
+//tsi_pack_mutex.unlock() is called automatically
+//std::lock_guard releases the mutex automatically when it goes out of scope.
 static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI_DeviceIdType deviceId) {
-  constexpr int64_t kPackedArgsI64  = 9;
-  constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
+    constexpr int64_t kPackedArgsI64   = 9;
+    constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
 
-  // Create the command list for the blob execute command
-  void *commandList = tsi_create_command_list(deviceId);
+    std::lock_guard<std::mutex> lock(tsi_pack_mutex);
 
-  // Allocate packed args buffer in shared DRAM
-  void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
-  auto *p = static_cast<int64_t *>(packed);
+    void *commandList = tsi_create_command_list(deviceId);
 
-  MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
-  MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
-  MemRefDescriptor<Rank> *C = (MemRefDescriptor<Rank> *)res;
+    void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+    auto *p = static_cast<int64_t *>(packed);
 
-  // Pack args strictly as:
-  // (A handle, A offset, A size0,  B handle, B offset, B size0,  C handle, C offset, C size0)
-  // NOTE: this is NOT "all handles first".
-  int idx = 0;
+    MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
+    MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
+    MemRefDescriptor<Rank> *C = (MemRefDescriptor<Rank> *)res;
 
-  // Arg A
-  p[idx++] = tsi_shmem_handle_from_ptr(A->data);
-  p[idx++] = (int64_t)A->offset;
-  p[idx++] = (int64_t)A->shape[0];
+    int idx = 0;
+    p[idx++] = tsi_shmem_handle_from_ptr(A->data);
+    p[idx++] = (int64_t)A->offset;
+    p[idx++] = (int64_t)A->shape[0];
 
-  // Arg B
-  p[idx++] = tsi_shmem_handle_from_ptr(B->data);
-  p[idx++] = (int64_t)B->offset;
-  p[idx++] = (int64_t)B->shape[0];
+    p[idx++] = tsi_shmem_handle_from_ptr(B->data);
+    p[idx++] = (int64_t)B->offset;
+    p[idx++] = (int64_t)B->shape[0];
 
-  // Arg C
-  p[idx++] = tsi_shmem_handle_from_ptr(C->data);
-  p[idx++] = (int64_t)C->offset;
-  p[idx++] = (int64_t)C->shape[0];
+    p[idx++] = tsi_shmem_handle_from_ptr(C->data);
+    p[idx++] = (int64_t)C->offset;
+    p[idx++] = (int64_t)C->shape[0];
 
-  // Sanity: we must have filled exactly kPackedArgsI64 entries
-  // (avoid silent layout drift).
-  if (idx != kPackedArgsI64) {
-    printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
-    abort();
-  }
+    if (idx != kPackedArgsI64) {
+        printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+        abort();
+    }
 
-  const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
+    const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
+    void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add[deviceId], packedHandle);
+    tsi_add_command_to_list(commandList, blobExecuteCmd);
 
-  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add[deviceId], /*packedArgs*/ packedHandle);
-  tsi_add_command_to_list(commandList, blobExecuteCmd);
-
-  return commandList;
+    return commandList;
 }
 
 static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
@@ -696,54 +698,45 @@ printf("\n ANOOP ADD device ID %d", deviceId);
 
 
 static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TSI_DeviceIdType deviceId) {
-  constexpr int64_t kPackedArgsI64  = 9;
-  constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
+    constexpr int64_t kPackedArgsI64   = 9;
+    constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
 
-  // Create the command list for the blob execute command
-  void *commandList = tsi_create_command_list(deviceId);
+    std::lock_guard<std::mutex> lock(tsi_pack_mutex);
 
-  // Allocate packed args buffer in shared DRAM
-  void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
-  auto *p = static_cast<int64_t *>(packed);
+    void *commandList = tsi_create_command_list(deviceId);
 
-  MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
-  MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
-  MemRefDescriptor<Rank> *C = (MemRefDescriptor<Rank> *)res;
+    void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+    auto *p = static_cast<int64_t *>(packed);
 
-  // Pack args strictly as:
-  // (A handle, A offset, A size0,  B handle, B offset, B size0,  C handle, C offset, C size0)
-  // NOTE: this is NOT "all handles first".
-  int idx = 0;
+    MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
+    MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
+    MemRefDescriptor<Rank> *C = (MemRefDescriptor<Rank> *)res;
 
-  // Arg A
-  p[idx++] = tsi_shmem_handle_from_ptr(A->data);
-  p[idx++] = (int64_t)A->offset;
-  p[idx++] = (int64_t)A->shape[0];
+    int idx = 0;
+    p[idx++] = tsi_shmem_handle_from_ptr(A->data);
+    p[idx++] = (int64_t)A->offset;
+    p[idx++] = (int64_t)A->shape[0];
 
-  // Arg B
-  p[idx++] = tsi_shmem_handle_from_ptr(B->data);
-  p[idx++] = (int64_t)B->offset;
-  p[idx++] = (int64_t)B->shape[0];
+    p[idx++] = tsi_shmem_handle_from_ptr(B->data);
+    p[idx++] = (int64_t)B->offset;
+    p[idx++] = (int64_t)B->shape[0];
+    
+    p[idx++] = tsi_shmem_handle_from_ptr(C->data);
+    p[idx++] = (int64_t)C->offset;
+    p[idx++] = (int64_t)C->shape[0];
 
-  // Arg C
-  p[idx++] = tsi_shmem_handle_from_ptr(C->data);
-  p[idx++] = (int64_t)C->offset;
-  p[idx++] = (int64_t)C->shape[0];
+    if (idx != kPackedArgsI64) {
+        printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+        abort();
+    }
 
-  // Sanity: we must have filled exactly kPackedArgsI64 entries
-  // (avoid silent layout drift).
-  if (idx != kPackedArgsI64) {
-    printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
-    abort();
-  }
+    const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
+    void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult[deviceId], packedHandle);
+    tsi_add_command_to_list(commandList, blobExecuteCmd);
 
-  const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
-
-  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult[deviceId], /*packedArgs*/ packedHandle);
-  tsi_add_command_to_list(commandList, blobExecuteCmd);
-
-  return commandList;
+    return commandList;
 }
+
 
 static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
     if (!multi_thread_enable) {
@@ -765,65 +758,46 @@ printf("\n ANOOP MUL device ID %d", deviceId);
 
 
 static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf, TSI_DeviceIdType deviceId) {
-  constexpr int64_t kPackedArgsI64  = 20;
-  constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
+    constexpr int64_t kPackedArgsI64   = 20;
+    constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
 
-  // Create the command list for the blob execute command
-  void *commandList = tsi_create_command_list(deviceId);
+    std::lock_guard<std::mutex> lock(tsi_pack_mutex);
 
-  // Allocate packed args buffer in shared DRAM
-  void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
-  auto *p = static_cast<int64_t *>(packed);
+    void *commandList = tsi_create_command_list(deviceId);
 
-  MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
-  MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
-  MemRefDescriptor<Rank> *C = (MemRefDescriptor<Rank> *)buf;
+    void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+    auto *p = static_cast<int64_t *>(packed);
 
-  // Pack args strictly as:
-  // (A handle, A offset, A size0,  B handle, B offset, B size0,  C handle, C offset, C size0)
-  // NOTE: this is NOT "all handles first".
-  int idx = 0;
+    MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
+    MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
+    MemRefDescriptor<Rank> *C = (MemRefDescriptor<Rank> *)buf;
 
-  // Arg A
-  p[idx++] = tsi_shmem_handle_from_ptr(A->data);
-  p[idx++] = (int64_t)A->offset;
-  for(int i=0; i <=3; ++i) {
-      p[idx++] = (int64_t)A->shape[i];
-  }
-  for(int i=0; i <=2; ++i) {
-      p[idx++] = (int64_t)A->strides[i];
-  }
+    int idx = 0;
 
-  // Arg B
-  p[idx++] = tsi_shmem_handle_from_ptr(B->data);
-  p[idx++] = (int64_t)B->offset;
+    p[idx++] = tsi_shmem_handle_from_ptr(A->data);
+    p[idx++] = (int64_t)A->offset;
+    for (int i = 0; i <= 3; ++i) p[idx++] = (int64_t)A->shape[i];
+    for (int i = 0; i <= 2; ++i) p[idx++] = (int64_t)A->strides[i];
 
-  for(int i=0; i <=3; ++i) {
-      p[idx++] = (int64_t)B->shape[i];
-  }
+    p[idx++] = tsi_shmem_handle_from_ptr(B->data);
+    p[idx++] = (int64_t)B->offset;
+    for (int i = 0; i <= 3; ++i) p[idx++] = (int64_t)B->shape[i];
+    for (int i = 0; i <= 2; ++i) p[idx++] = (int64_t)B->strides[i];
 
-  for(int i=0; i <=2; ++i) {
-      p[idx++] = (int64_t)B->strides[i];
-  }
- 
+    p[idx++] = tsi_shmem_handle_from_ptr(C->data);
+    p[idx++] = (int64_t)C->offset;
 
-  // Arg C
-  p[idx++] = tsi_shmem_handle_from_ptr(C->data);
-  p[idx++] = (int64_t)C->offset;
+    if (idx != kPackedArgsI64) {
+        printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+        abort();
+    }
 
-  // Sanity: we must have filled exactly kPackedArgsI64 entries
-  // (avoid silent layout drift).
-  if (idx != kPackedArgsI64) {
-    printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
-    abort();
-  }
+    const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
+    void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm[deviceId], packedHandle);
+    tsi_add_command_to_list(commandList, blobExecuteCmd);
 
-  const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
-
-  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm[deviceId], /*packedArgs*/ packedHandle);
-  tsi_add_command_to_list(commandList, blobExecuteCmd);
-  return commandList;
-}
+    return commandList;
+} 
 
 static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
     if (!multi_thread_enable) {

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -688,8 +688,9 @@ static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
     int deviceId = acquire_device_blocking();
 printf("\n ANOOP ADD device ID %d", deviceId);
 
+   // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
+   void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, deviceId);
     workers.emplace_back([=]() {
-        void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, deviceId);
         tsi_blob_execution_internal(commandList);
         release_device(deviceId);
         printf("\n ANOOP Release ADD device ID %d", deviceId);
@@ -748,8 +749,9 @@ static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
     int deviceId = acquire_device_blocking();
 
 printf("\n ANOOP MUL device ID %d", deviceId);
+   // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
+   void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, deviceId);
     workers.emplace_back([=]() {
-        void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, deviceId);
         tsi_blob_execution_internal(commandList);
         release_device(deviceId);
         printf("\n ANOOP Release MUL device ID %d", deviceId);
@@ -809,8 +811,9 @@ static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
     int deviceId = acquire_device_blocking();
 printf("\n ANOOP RMS_NORM device ID %d", deviceId);
 
+    // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
+    void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, deviceId);
     workers.emplace_back([=]() {
-        void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, deviceId);
         tsi_blob_execution_internal(commandList);
         release_device(deviceId);
        printf("\n ANOOP RMS_NORM Releasing device ID %d", deviceId);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -39,13 +39,10 @@
 #include  <mutex>
 #include <condition_variable>
 
-
 using namespace tsi::runtime;
 
-
-
 // This will  go in deployment file at next PR
-#define NUM_OF_TXES 2
+#define NUM_OF_TXES 1
 
 // ggml-tsavorite.cpp
 namespace {
@@ -60,8 +57,6 @@ struct TsavoriteRuntimeState {
     std::mutex device_mutex;
     std::mutex tsi_pack_mutex;
     std::condition_variable device_cv;
-
-
     // blobs
     BlobDescriptor *blobDescriptor_add[NUM_OF_TXES] = {};
     BlobDescriptor *blobDescriptor_mult[NUM_OF_TXES] = {};
@@ -191,14 +186,14 @@ static std::string blob_prefix(const char *rel) {
     return tsavorite_llama_root() + rel;
 }
 
-void tsi_load_all_blobs() {
+static void tsi_load_all_blobs() {
     static void *loadResult_add[NUM_OF_TXES];
     static void *loadResult_mult[NUM_OF_TXES];
     static void *loadResult_rms_norm[NUM_OF_TXES];
     int i;
     char blob_name[64];
 
-    for (int i = 0; i < NUM_OF_TXES; ++i) {
+    for (int i = 0; i < num_of_txes; ++i) {
         char name_add[64];
         char name_mult[64];
         char name_rms[64];
@@ -266,7 +261,7 @@ error:
 
 
 static void tsi_unload_all_blobs() {
-for (int i=0; i < NUM_OF_TXES; ++i) {
+for (int i=0; i < num_of_txes; ++i) {
   tsi_unload_blob(blobDescriptor_add[i]);
   tsi_unload_blob(blobDescriptor_mult[i]);
   tsi_unload_blob(blobDescriptor_rms_norm[i]);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -17,7 +17,6 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-
 #include <string.h>
 
 #include "ggml-tsavorite.h"
@@ -35,7 +34,6 @@
 #include "HostShimCAPI.h"
 #include "tsi-rt/utils/Profiler.h"
 
-
 #include <thread>
 #include <vector>
 #include  <mutex>
@@ -51,7 +49,7 @@ static std::mutex tsi_pack_mutex;
 static std::condition_variable device_cv;
 
 
-// This will also go in deployment file
+// This will  go in deployment file at next PR
 #define NUM_OF_TXES 2
 static uint32_t num_of_txes =  NUM_OF_TXES;
 
@@ -2070,9 +2068,6 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     return GGML_STATUS_SUCCESS;
 }
 
-static void anoop_test() {
-   return;
-}
 // nodes are intermediate which has multiple src tensors & operation
 // Here we create multiple thread
 // Each Thread run the command buffer & pick Tensor and execute and get the result back base on

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -23,13 +23,28 @@
 #include <unistd.h>
 #include <inttypes.h>
 #include <math.h>
-#include <string>
 #include <iostream>
+#include <magic_enum/magic_enum.hpp>
 #include "ggml-backend-impl.h"
 #include "ggml-impl.h"
 #include "ggml.h"
+#include "tsi-rt/TXEDeviceConfig.h"
+#include "tsi-rt/host/BlobDescriptor.h"
+#include "tsi-rt/queues/Command.h"
 #include "HostShimCAPI.h"
 #include "tsi-rt/utils/Profiler.h"
+
+
+#include <thread>
+#include <vector>
+
+
+using namespace tsi::runtime;
+
+
+std::vector<std::thread> workers;
+
+static bool multi_thread_enable = false;
 
 #ifdef TMU_DEBUG_VALIDATE
 
@@ -108,13 +123,57 @@ typedef struct _txe_compute_pipeline_state_t *txe_compute_pipeline_state_s;
 FILE *tsi_op_log_file;
 bool runtime_initialized = false;
 uint64_t num_of_op;
+
+
+static TSI_DeviceIdType deviceId_1 = 0, deviceId_2 = 1;
+static void *loadResult_add, *loadResult_mult, *loadResult_rms_norm;
+static BlobDescriptor *blobDescriptor_add, *blobDescriptor_mult, *blobDescriptor_rms_norm;
+
+void tsi_load_all_blobs() {
+  loadResult_add = tsi_load_blob(
+      deviceId_1,
+      "txe_add",
+      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"));
+
+  blobDescriptor_add = static_cast<BlobDescriptor *>(loadResult_add);
+
+  loadResult_mult = tsi_load_blob(
+      deviceId_1,
+      "txe_mult",
+      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"));
+
+  blobDescriptor_mult = static_cast<BlobDescriptor *>(loadResult_mult);
+  
+  loadResult_rms_norm = tsi_load_blob(
+      deviceId_2,
+      "txe_rms_norm",
+      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"));
+
+  blobDescriptor_rms_norm = static_cast<BlobDescriptor *>(loadResult_rms_norm);
+
+  return;
+}
+
+static void tsi_unload_all_blobs() {
+  tsi_unload_blob(blobDescriptor_add);
+  tsi_unload_blob(blobDescriptor_mult);
+  tsi_unload_blob(blobDescriptor_rms_norm);
+
+  return;
+}
+
 // Centralized TSI runtime initialization - called once globally
 static void ensure_tsi_runtime_initialized() {
   if (!runtime_initialized) {
     std::string mainProfilerName = "OPU ";
     tsirt::utils::TSIProfiler::initialize();
     // TSI Run time Initalization
-    tsi_initialize(NUM_OF_TXES, NULL);
+    //tsi_initialize(NUM_OF_TXES, NULL);
+    tsi_initialize(2, NULL);
+
+    tsi_load_all_blobs();
+
+    workers.reserve(2);
     runtime_initialized = true;
     GGML_TSAVORITE_LOG_INFO("Profiler and TSI runtime initialized early in registration\n");
   }
@@ -491,6 +550,282 @@ static void _mlir_ciface_txe_mult_test (void *src0, void *src1, void *res)
     return;
 }
 
+
+// Packed args layout for 3x memref<?xf32, strided<[1], offset: ?>, 1>
+// Per TXE_PackArgsOp: group per-arg as (handle, offset, sizes, strides),
+// and only dynamic metadata is packed. For this type: offset is dynamic, size(0) is dynamic, stride(0)=1 is static.
+// So each arg contributes: (handle, offset, size0) => 3 int64s per arg.
+// Total = 3 args * 3 int64 = 9 int64 = 72 bytes.)
+
+
+static uint32_t anoop_add_test=0;
+
+
+static void _mlir_ciface_txe_add_host_internal(void *a, void *b, void *res) {
+  //TSI_DeviceIdType deviceId = 0;
+  constexpr int64_t kPackedArgsI64  = 9;
+  constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
+
+  ++anoop_add_test;
+  //if (anoop_add_test <= 2)
+    printf("\n Called _mlir_ciface_txe_add_host_new %d \n", anoop_add_test);
+
+#if 0
+  void *loadResult_add = tsi_load_blob(
+      deviceId,
+      "txe_add",
+      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"));
+
+  BlobDescriptor *blobDescriptor_add = static_cast<BlobDescriptor *>(loadResult_add);
+#endif
+
+  // Create the command list for the blob execute command
+  void *commandList = tsi_create_command_list(deviceId_1);
+
+  // Allocate packed args buffer in shared DRAM
+  void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+  auto *p = static_cast<int64_t *>(packed);
+
+  MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
+  MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
+  MemRefDescriptor<Rank> *C = (MemRefDescriptor<Rank> *)res;
+
+  // Pack args strictly as:
+  // (A handle, A offset, A size0,  B handle, B offset, B size0,  C handle, C offset, C size0)
+  // NOTE: this is NOT "all handles first".
+  int idx = 0;
+
+  // Arg A
+  p[idx++] = tsi_shmem_handle_from_ptr(A->data);
+  p[idx++] = (int64_t)A->offset;
+  p[idx++] = (int64_t)A->shape[0];
+
+  // Arg B
+  p[idx++] = tsi_shmem_handle_from_ptr(B->data);
+  p[idx++] = (int64_t)B->offset;
+  p[idx++] = (int64_t)B->shape[0];
+
+  // Arg C
+  p[idx++] = tsi_shmem_handle_from_ptr(C->data);
+  p[idx++] = (int64_t)C->offset;
+  p[idx++] = (int64_t)C->shape[0];
+
+  // Sanity: we must have filled exactly kPackedArgsI64 entries
+  // (avoid silent layout drift).
+  if (idx != kPackedArgsI64) {
+    printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+    abort();
+  }
+
+  const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
+
+  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add, /*packedArgs*/ packedHandle);
+  tsi_add_command_to_list(commandList, blobExecuteCmd);
+
+  // Enqueue & run
+  tsi_finalize_command_list(commandList);
+  tsi_wait(commandList);
+
+#if 0
+  tsi_unload_blob(blobDescriptor_add);
+#endif
+  return;
+}
+
+static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
+   if(multi_thread_enable) {
+      printf("\n ANOP we are calling thread for ADD \n");
+      workers.emplace_back(_mlir_ciface_txe_add_host_internal, a, b, res);
+   } else {
+       _mlir_ciface_txe_add_host_internal(a, b, res);
+   }
+   return;
+}
+
+static uint32_t anoop_mult_test=0;
+
+
+static void _mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res) {
+  //TSI_DeviceIdType deviceId = 0;
+  constexpr int64_t kPackedArgsI64  = 9;
+  constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
+
+  ++anoop_mult_test;
+  //if (anoop_mult_test <= 2)
+    printf("\n Called _mlir_ciface_txe_mult_host_new %d \n", anoop_mult_test);
+
+#if 0
+  void *loadResult_mult = tsi_load_blob(
+      deviceId,
+      "txe_mult",
+      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"));
+
+  BlobDescriptor *blobDescriptor_mult = static_cast<BlobDescriptor *>(loadResult_mult);
+#endif
+
+  // Create the command list for the blob execute command
+  void *commandList = tsi_create_command_list(deviceId_1);
+
+  // Allocate packed args buffer in shared DRAM
+  void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+  auto *p = static_cast<int64_t *>(packed);
+
+  MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
+  MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
+  MemRefDescriptor<Rank> *C = (MemRefDescriptor<Rank> *)res;
+
+  // Pack args strictly as:
+  // (A handle, A offset, A size0,  B handle, B offset, B size0,  C handle, C offset, C size0)
+  // NOTE: this is NOT "all handles first".
+  int idx = 0;
+
+  // Arg A
+  p[idx++] = tsi_shmem_handle_from_ptr(A->data);
+  p[idx++] = (int64_t)A->offset;
+  p[idx++] = (int64_t)A->shape[0];
+
+  // Arg B
+  p[idx++] = tsi_shmem_handle_from_ptr(B->data);
+  p[idx++] = (int64_t)B->offset;
+  p[idx++] = (int64_t)B->shape[0];
+
+  // Arg C
+  p[idx++] = tsi_shmem_handle_from_ptr(C->data);
+  p[idx++] = (int64_t)C->offset;
+  p[idx++] = (int64_t)C->shape[0];
+
+  // Sanity: we must have filled exactly kPackedArgsI64 entries
+  // (avoid silent layout drift).
+  if (idx != kPackedArgsI64) {
+    printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+    abort();
+  }
+
+  const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
+
+  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult, /*packedArgs*/ packedHandle);
+  tsi_add_command_to_list(commandList, blobExecuteCmd);
+
+  // Enqueue & run
+  tsi_finalize_command_list(commandList);
+  tsi_wait(commandList);
+
+#if 0
+  tsi_unload_blob(blobDescriptor_mult);
+#endif
+  return;
+}
+
+static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
+   if(multi_thread_enable) {
+      printf("\n ANOP we are calling thread for MULT \n");
+      workers.emplace_back(_mlir_ciface_txe_mult_host_internal, a, b, res);
+   } else {
+       _mlir_ciface_txe_mult_host_internal(a, b, res);
+   }
+   return;
+}
+
+
+static uint32_t anoop_rms_norm_test=0;
+
+
+static void _mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf) {
+  //TSI_DeviceIdType deviceId = 1;
+  constexpr int64_t kPackedArgsI64  = 20;
+  constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
+
+  ++anoop_rms_norm_test;
+  //if (anoop_rms_norm_test <= 2)
+    printf("\n Called _mlir_ciface_txe_rms_norm_host_new %d \n", anoop_rms_norm_test);
+
+#if 0
+  void *loadResult_rms_norm = tsi_load_blob(
+      deviceId,
+      "txe_rms_norm",
+      ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"));
+
+  BlobDescriptor *blobDescriptor_rms_norm = static_cast<BlobDescriptor *>(loadResult_rms_norm);
+#endif
+
+  // Create the command list for the blob execute command
+  void *commandList = tsi_create_command_list(deviceId_2);
+
+  // Allocate packed args buffer in shared DRAM
+  void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+  auto *p = static_cast<int64_t *>(packed);
+
+  MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
+  MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
+  MemRefDescriptor<Rank> *C = (MemRefDescriptor<Rank> *)buf;
+
+  // Pack args strictly as:
+  // (A handle, A offset, A size0,  B handle, B offset, B size0,  C handle, C offset, C size0)
+  // NOTE: this is NOT "all handles first".
+  int idx = 0;
+
+  // Arg A
+  p[idx++] = tsi_shmem_handle_from_ptr(A->data);
+  p[idx++] = (int64_t)A->offset;
+  for(int i=0; i <=3; ++i) {
+      p[idx++] = (int64_t)A->shape[i];
+  }
+  for(int i=0; i <=2; ++i) {
+      p[idx++] = (int64_t)A->strides[i];
+  }
+
+  // Arg B
+  p[idx++] = tsi_shmem_handle_from_ptr(B->data);
+  p[idx++] = (int64_t)B->offset;
+
+  for(int i=0; i <=3; ++i) {
+      p[idx++] = (int64_t)B->shape[i];
+  }
+
+  for(int i=0; i <=2; ++i) {
+      p[idx++] = (int64_t)B->strides[i];
+  }
+ 
+
+  // Arg C
+  p[idx++] = tsi_shmem_handle_from_ptr(C->data);
+  p[idx++] = (int64_t)C->offset;
+
+  // Sanity: we must have filled exactly kPackedArgsI64 entries
+  // (avoid silent layout drift).
+  if (idx != kPackedArgsI64) {
+    printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+    abort();
+  }
+
+  const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
+
+  void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm, /*packedArgs*/ packedHandle);
+  tsi_add_command_to_list(commandList, blobExecuteCmd);
+
+  // Enqueue & run
+  tsi_finalize_command_list(commandList);
+  tsi_wait(commandList);
+
+#if 0
+  tsi_unload_blob(blobDescriptor_rms_norm);
+#endif
+  return;
+}
+
+static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
+   if(multi_thread_enable) {
+      printf("\n ANOP we are calling thread for RMS NORM \n");
+      workers.emplace_back(_mlir_ciface_txe_rms_norm_host_internal, a, b, buf);
+   } else {
+       _mlir_ciface_txe_rms_norm_host_internal(a, b, buf);
+   }
+   return;
+}
+
+
+
+
 static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_type kernel_type) {
   txe_compute_pipeline_state_s kernel_pipeline =
       (txe_compute_pipeline_state_s)calloc(1, sizeof(struct _txe_compute_pipeline_state_t));
@@ -507,7 +842,8 @@ static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_
           if (ggml_tsavorite_kernel_mode_flag == GGML_TSAVORITE_KERNEL_MODE_CPU)
               kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_test;
           else {
-              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host;
+              //kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host;
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host_new;
               kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_add_16_host;
 	  }
           kernel_pipeline->kernel_name = "TXE_ADD";
@@ -523,7 +859,8 @@ static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_
           if (ggml_tsavorite_kernel_mode_flag == GGML_TSAVORITE_KERNEL_MODE_CPU)
               kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_test;
           else {
-              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_host;
+              //kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_host;
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_host_new;
               kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_mult_16_host;
 	  }
           kernel_pipeline->kernel_name = "TXE_MULT";
@@ -578,7 +915,8 @@ static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_RMS_NORM:
-          kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_rms_norm_host;
+          //kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_rms_norm_host;
+          kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_rms_norm_host_new;
           kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_rms_norm_16_host;
           kernel_pipeline->kernel_name = "TXE_RMS_NORM";
           flag = true;
@@ -809,6 +1147,7 @@ static void ggml_tsavorite_free(struct ggml_backend_tsavorite_context *ctx) {
   if (runtime_initialized == true) {
       sleep(2);
       runtime_initialized = false;
+      tsi_unload_all_blobs();
       tsi_finalize();
       tsirt::utils::TSIProfiler::finalize();
       sleep(2);
@@ -826,6 +1165,7 @@ tsi_cleanup() {
     if (runtime_initialized != true)
         return;
     runtime_initialized = false;
+    tsi_unload_all_blobs();
     tsi_finalize();
     GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
     tsirt::utils::TSIProfiler::finalize();
@@ -1634,6 +1974,9 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     return GGML_STATUS_SUCCESS;
 }
 
+static void anoop_test() {
+   return;
+}
 // nodes are intermediate which has multiple src tensors & operation
 // Here we create multiple thread
 // Each Thread run the command buffer & pick Tensor and execute and get the result back base on
@@ -1703,6 +2046,31 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
   enum ggml_tsavorite_input_tensors_count num_of_input_tensors;
   tensor_log log_data;
 
+bool skip_multi_threading = false;
+    if (cgraph->n_nodes == 2) {
+          printf("\n ANOOP graph nodes %d \n",cgraph->n_nodes);
+          for (int i = 0; i < cgraph->n_nodes; i++) {
+             node = cgraph->nodes[i];
+             if (node->op == GGML_OP_UNARY) {
+                enum ggml_unary_op subop = ggml_get_unary_op(node);
+                printf ("     OPS:  UNARY(%s)\n", ggml_unary_op_name(subop));
+             } else {
+                printf ("     OPS:  (%s)\n", ggml_op_name(node->op));
+             }
+             if (node->op == GGML_OP_ADD) 
+                skip_multi_threading = true;
+          }
+          
+    }
+    if (cgraph->n_nodes == 2 && !skip_multi_threading) {
+        multi_thread_enable = true;
+       anoop_test();
+    } else {
+        multi_thread_enable = false;
+    }
+
+
+//multi_thread_enable = false;
 
   for (int i = 0; i < cgraph->n_nodes; i++) {
      int32_t kernel_sub_type=-1;
@@ -1740,7 +2108,6 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
         for(ii=0; ii <= 95; ++ii)
                vall[ii] = 0;
     }
-
     switch (node->op) {
     case GGML_OP_ADD:
       kernel_type = GGML_TSAVORITE_KERNEL_TYPE_ADD;
@@ -2182,7 +2549,18 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
         node->perf_time_us += (INT64_MAX - t_start + t_end + 1);
     }
 #endif /* GGML_PERF-related flags */
-  }
+  } /* this is main for loop */
+
+if (cgraph->n_nodes == 2) {
+printf("\n ANOOP WE are joinin the thread\n");
+// join back to main thread
+    for (auto &t : workers) {
+        t.join();
+    }
+    workers.clear();
+    anoop_test();
+}
+
 
   // This this need to implement correctly when we have mixture of CPU and accelerator operation
   // return ggml_graph_compute(cgraph, &cplan);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -43,19 +43,47 @@
 using namespace tsi::runtime;
 
 
-std::vector<std::thread> workers;
-static std::mutex device_mutex;
-static std::mutex tsi_pack_mutex;
-static std::condition_variable device_cv;
-
 
 // This will  go in deployment file at next PR
 #define NUM_OF_TXES 2
-static uint32_t num_of_txes =  NUM_OF_TXES;
+
+// ggml-tsavorite.cpp
+namespace {
+
+struct TsavoriteRuntimeState {
+    // device / threading
+    uint32_t num_of_txes = NUM_OF_TXES;
+    bool *device_free = nullptr;
+    bool multi_thread_enable = false;
+
+    std::vector<std::thread> workers;
+    std::mutex device_mutex;
+    std::mutex tsi_pack_mutex;
+    std::condition_variable device_cv;
 
 
-static bool *device_free = NULL;
-static bool multi_thread_enable = false;
+    // blobs
+    BlobDescriptor *blobDescriptor_add[NUM_OF_TXES] = {};
+    BlobDescriptor *blobDescriptor_mult[NUM_OF_TXES] = {};
+    BlobDescriptor *blobDescriptor_rms_norm[NUM_OF_TXES] = {};
+};
+
+static TsavoriteRuntimeState g_rt;
+
+} // anonymous namespace
+
+auto &num_of_txes = g_rt.num_of_txes;
+auto &device_free = g_rt.device_free;
+auto &multi_thread_enable     = g_rt.multi_thread_enable;
+
+auto &workers = g_rt.workers;
+auto &device_mutex = g_rt.device_mutex;
+auto &tsi_pack_mutex = g_rt.tsi_pack_mutex;
+auto &device_cv = g_rt.device_cv;
+
+auto &blobDescriptor_add      = g_rt.blobDescriptor_add;
+auto &blobDescriptor_mult     = g_rt.blobDescriptor_mult;
+auto &blobDescriptor_rms_norm = g_rt.blobDescriptor_rms_norm;
 
 
 #ifdef TMU_DEBUG_VALIDATE
@@ -136,11 +164,6 @@ FILE *tsi_op_log_file;
 bool runtime_initialized = false;
 uint64_t num_of_op;
 
-
-
-static BlobDescriptor *blobDescriptor_add[NUM_OF_TXES];
-static BlobDescriptor *blobDescriptor_mult[NUM_OF_TXES];
-static BlobDescriptor *blobDescriptor_rms_norm[NUM_OF_TXES];
 // ============================================================
 // (makes blob names unique per device to avoid collisions)
 //  - tsi_load_blob() expects a FILE PREFIX, not a directory.
@@ -172,6 +195,8 @@ void tsi_load_all_blobs() {
     static void *loadResult_add[NUM_OF_TXES];
     static void *loadResult_mult[NUM_OF_TXES];
     static void *loadResult_rms_norm[NUM_OF_TXES];
+    int i;
+    char blob_name[64];
 
     for (int i = 0; i < NUM_OF_TXES; ++i) {
         char name_add[64];
@@ -190,31 +215,53 @@ void tsi_load_all_blobs() {
                 "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"
             ).c_str()
         );
-        blobDescriptor_add[i] =
+
+        if (!loadResult_add[i]) {
+            strcpy(blob_name, name_add);
+            goto error;
+       }
+
+       blobDescriptor_add[i] =
             static_cast<BlobDescriptor *>(loadResult_add[i]);
 
         // MUST end in ".../blobs/txe_mult"
-        loadResult_mult[i] = tsi_load_blob(
+       loadResult_mult[i] = tsi_load_blob(
             i,
             name_mult,
             blob_prefix(
                 "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"
             ).c_str()
         );
+
+        if (!loadResult_mult[i]) {
+            strcpy(blob_name, name_mult);
+            goto error;
+        }
         blobDescriptor_mult[i] =
             static_cast<BlobDescriptor *>(loadResult_mult[i]);
 
         // MUST end in ".../blobs/txe_rms_norm"
-        loadResult_rms_norm[i] = tsi_load_blob(
+       loadResult_rms_norm[i] = tsi_load_blob(
             i,
             name_rms,
             blob_prefix(
                 "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"
             ).c_str()
         );
+
+        if (!loadResult_rms_norm[i]) {
+            strcpy(blob_name, name_rms);
+            goto error;
+        }
         blobDescriptor_rms_norm[i] =
             static_cast<BlobDescriptor *>(loadResult_rms_norm[i]);
     }
+    return;
+error:
+    fprintf(stderr,
+            "Failed to load blob (txe=%u, name=%s)\n", i, blob_name);
+    tsi_cleanup();
+    abort();
 }
 
 
@@ -250,6 +297,7 @@ static void ensure_tsi_runtime_initialized() {
     device_free = (bool *)malloc(num_of_txes * sizeof(bool));
     if (!device_free) {
         fprintf(stderr, "Failed to allocate device_free\n");
+        tsi_unload_all_blobs();
         tsi_finalize();
         abort();
     }
@@ -258,7 +306,7 @@ static void ensure_tsi_runtime_initialized() {
         device_free[i] = true;
     }
 
-    workers.reserve(2);
+    workers.reserve(num_of_txes);
     runtime_initialized = true;
     GGML_TSAVORITE_LOG_INFO("Profiler and TSI runtime initialized early in registration\n");
   }
@@ -712,6 +760,11 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
     void *commandList = tsi_create_command_list(deviceId);
 
     void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+    if(!packed) {
+        printf("\nFailed to allocate packed argument memory in tsi_alloc\n");
+        tsi_cleanup();
+        abort();
+    }
     auto *p = static_cast<int64_t *>(packed);
 
     MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
@@ -733,11 +786,20 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
 
     if (idx != kPackedArgsI64) {
         printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+        tsi_cleanup();
         abort();
     }
 
     const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add[deviceId], packedHandle);
+
+    if (!blobExecuteCmd) {
+        printf("tsi_launch_blob failed for device %d and blobDescriptor %s\n",
+                                     deviceId, (char *)blobDescriptor_add[deviceId]);
+        tsi_cleanup();
+        abort();
+    }
+
     tsi_add_command_to_list(commandList, blobExecuteCmd);
 
     return commandList;
@@ -747,10 +809,15 @@ static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
     if (!multi_thread_enable) {
       _mlir_ciface_txe_add_host(a, b, res);
       // Temporarily disabled; will be enabled in the next release to avoid collateral impact
-       #if 0
+       #if NEW_HOST_CODE
        void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, 0);
+       if (!commandList) {
+            printf("Command List Empt for ADD OPERATION on device 0\n");
+            tsi_cleanup();
+            abort();
+        }
         tsi_blob_execution_internal(commandList);
-       #endif
+       #endif  /* NEW_HOST_CODE */
         return;
     }
 
@@ -758,6 +825,11 @@ static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
 
    // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
    void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, deviceId);
+   if (!commandList) {
+       printf("Command List Empt for ADD on device %d\n", deviceId);
+       tsi_cleanup();
+       abort();
+    }
     workers.emplace_back([=]() {
         tsi_blob_execution_internal(commandList);
         release_device(deviceId);
@@ -774,6 +846,11 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
     void *commandList = tsi_create_command_list(deviceId);
 
     void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+    if(!packed) {
+        printf("\nFailed to allocate packed argument memory in tsi_alloc\n");
+        tsi_cleanup();
+        abort();
+    }
     auto *p = static_cast<int64_t *>(packed);
 
     MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
@@ -795,11 +872,18 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
 
     if (idx != kPackedArgsI64) {
         printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+        tsi_cleanup();
         abort();
     }
 
     const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult[deviceId], packedHandle);
+    if (!blobExecuteCmd) {
+        printf("tsi_launch_blob failed for device %d and blobDescriptor %s\n",
+                                     deviceId, (char *)blobDescriptor_mult[deviceId]);
+        tsi_cleanup();
+        abort();
+    }
     tsi_add_command_to_list(commandList, blobExecuteCmd);
 
     return commandList;
@@ -811,10 +895,15 @@ static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
         _mlir_ciface_txe_mult_host(a, b, res);
       
       // Temporarily disabled; will be enabled in the next release to avoid collateral impact
-        #if 0
+        #if NEW_HOST_CODE
         void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, 1);
+       if (!commandList) {
+            printf("Command List Empt for MUL OPERATION on device 0\n");
+            tsi_cleanup();
+            abort();
+        }
         tsi_blob_execution_internal(commandList);
-        #endif
+        #endif /* NEW_HOST_CODE */
         return;
     }
 
@@ -822,6 +911,11 @@ static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
 
    // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
    void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, deviceId);
+   if (!commandList) {
+        printf("Command List Empt for MUL OPERATION on device %d\n", deviceId);
+        tsi_cleanup();
+        abort();
+   }
     workers.emplace_back([=]() {
         tsi_blob_execution_internal(commandList);
         release_device(deviceId);
@@ -838,6 +932,11 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
     void *commandList = tsi_create_command_list(deviceId);
 
     void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+    if(!packed) {
+        printf("\nFailed to allocate packed argument memory in tsi_alloc\n");
+        tsi_cleanup();
+        abort();
+    }
     auto *p = static_cast<int64_t *>(packed);
 
     MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
@@ -861,11 +960,18 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
 
     if (idx != kPackedArgsI64) {
         printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+        tsi_cleanup();
         abort();
     }
 
     const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm[deviceId], packedHandle);
+    if (!blobExecuteCmd) {
+        printf("tsi_launch_blob failed for device %d and blobDescriptor %s\n",
+                                     deviceId, (char *)blobDescriptor_rms_norm[deviceId]);
+        tsi_cleanup();
+        abort();
+    }
     tsi_add_command_to_list(commandList, blobExecuteCmd);
 
     return commandList;
@@ -875,10 +981,15 @@ static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
     if (!multi_thread_enable) {
         _mlir_ciface_txe_rms_norm_host(a, b, buf);
       // Temporarily disabled; will be enabled in the next release to avoid collateral impact
-      #if 0
+      #if NEW_HOST_CODE
         void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, 0);
+       if (!commandList) {
+            printf("Command List Empt for RMS OPERATION  on device 0\n");
+            tsi_cleanup();
+            abort();
+        }
         tsi_blob_execution_internal(commandList);
-      #endif
+      #endif  /* NEW_HOST_CODE */
         return;
     }
 
@@ -886,6 +997,11 @@ static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
 
     // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
     void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, deviceId);
+    if (!commandList) {
+        printf("Command List Empt for RMS OPERATION on device %d\n", deviceId);
+        tsi_cleanup();
+        abort();
+    }
     workers.emplace_back([=]() {
         tsi_blob_execution_internal(commandList);
         release_device(deviceId);
@@ -2022,6 +2138,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                                         "r=%ld c=%ld TMU=%f REF=%f\n",
                                         (long)m0, (long)n0, (long)k0, K_chunk, pi,
                                         (long)rr, (long)cc, tmu_v, ref_v);
+                                    tsi_cleanup();
                                     abort();
                                 }
                             }

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -17,6 +17,9 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+
+#include <limits.h>
+#include <libgen.h>
 #include <string.h>
 
 #include "ggml-tsavorite.h"
@@ -49,10 +52,13 @@ static std::mutex device_mutex;
 static std::mutex tsi_pack_mutex;
 static std::condition_variable device_cv;
 
+
+// This will also go in deployment file
+#define NUM_OF_TXES 1
 // device availability table
 static bool device_free[NUM_OF_TXES] = { true, true };
-
 static bool multi_thread_enable = false;
+
 
 #ifdef TMU_DEBUG_VALIDATE
 
@@ -133,47 +139,86 @@ bool runtime_initialized = false;
 uint64_t num_of_op;
 
 
-//static TSI_DeviceIdType deviceId_1 = 0, deviceId_2 = 1;
 
-static void *loadResult_add[NUM_OF_TXES], *loadResult_mult[NUM_OF_TXES], *loadResult_rms_norm[NUM_OF_TXES];
-static BlobDescriptor *blobDescriptor_add[NUM_OF_TXES], *blobDescriptor_mult[NUM_OF_TXES], *blobDescriptor_rms_norm[NUM_OF_TXES];
-
-
-
+static BlobDescriptor *blobDescriptor_add[NUM_OF_TXES];
+static BlobDescriptor *blobDescriptor_mult[NUM_OF_TXES];
+static BlobDescriptor *blobDescriptor_rms_norm[NUM_OF_TXES];
 // ============================================================
-// FUNCTION REPLACEMENT: tsi_load_all_blobs()
 // (makes blob names unique per device to avoid collisions)
-// ============================================================
+//  - tsi_load_blob() expects a FILE PREFIX, not a directory.
+//  - It will append ".blob" internally.
+//  - Therefore we must pass ".../blobs/txe_xxx" (NOT ".../blobs").
+//  - This code reconstructs the SAME prefix paths that worked before.
+// =======================================================================
+
+static std::string tsavorite_llama_root() {
+    // __FILE__ =
+    // /proj/work/.../llama.cpp/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+    std::string f(__FILE__);
+    const std::string tag = "/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp";
+    size_t pos = f.find(tag);
+    if (pos == std::string::npos) {
+        // Hard fail — path layout assumption broken
+        return "";
+    }
+    // Result:
+    // /proj/work/.../llama.cpp
+    return f.substr(0, pos);
+}
+
+static std::string blob_prefix(const char *rel) {
+    return tsavorite_llama_root() + rel;
+}
 
 void tsi_load_all_blobs() {
-    for (int i = 0; i < NUM_OF_TXES; ++i) {
-        printf("\n ANOOP Loading Blobs \n");
+    static void *loadResult_add[NUM_OF_TXES];
+    static void *loadResult_mult[NUM_OF_TXES];
+    static void *loadResult_rms_norm[NUM_OF_TXES];
 
-        char name_add[64], name_mult[64], name_rms[64];
+    for (int i = 0; i < NUM_OF_TXES; ++i) {
+        char name_add[64];
+        char name_mult[64];
+        char name_rms[64];
+
         snprintf(name_add,  sizeof(name_add),  "txe_add_dev%d", i);
         snprintf(name_mult, sizeof(name_mult), "txe_mult_dev%d", i);
         snprintf(name_rms,  sizeof(name_rms),  "txe_rms_norm_dev%d", i);
 
+        // MUST end in ".../blobs/txe_add"
         loadResult_add[i] = tsi_load_blob(
             i,
             name_add,
-            ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"));
-        blobDescriptor_add[i] = static_cast<BlobDescriptor *>(loadResult_add[i]);
+            blob_prefix(
+                "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"
+            ).c_str()
+        );
+        blobDescriptor_add[i] =
+            static_cast<BlobDescriptor *>(loadResult_add[i]);
 
+        // MUST end in ".../blobs/txe_mult"
         loadResult_mult[i] = tsi_load_blob(
             i,
             name_mult,
-            ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"));
-       blobDescriptor_mult[i] = static_cast<BlobDescriptor *>(loadResult_mult[i]);
+            blob_prefix(
+                "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"
+            ).c_str()
+        );
+        blobDescriptor_mult[i] =
+            static_cast<BlobDescriptor *>(loadResult_mult[i]);
 
+        // MUST end in ".../blobs/txe_rms_norm"
         loadResult_rms_norm[i] = tsi_load_blob(
             i,
             name_rms,
-            ("/proj/work/akapoor/llama-cpp-march-30-multi-txe/llama.cpp/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"));
-        blobDescriptor_rms_norm[i] = static_cast<BlobDescriptor *>(loadResult_rms_norm[i]);
+            blob_prefix(
+                "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"
+            ).c_str()
+        );
+        blobDescriptor_rms_norm[i] =
+            static_cast<BlobDescriptor *>(loadResult_rms_norm[i]);
     }
-    return;
 }
+
 
 static void tsi_unload_all_blobs() {
 for (int i=0; i < NUM_OF_TXES; ++i) {
@@ -190,9 +235,15 @@ static void ensure_tsi_runtime_initialized() {
     std::string mainProfilerName = "OPU ";
     tsirt::utils::TSIProfiler::initialize();
     // TSI Run time Initalization
-    tsi_initialize(NUM_OF_TXES, NULL);
+    #ifdef GGML_TARGET_POSIX
+        tsi_initialize(1, NULL);
+        multi_thread_enable = false;
+    #else
+        tsi_initialize(NUM_OF_TXES, NULL);
+        multi_thread_enable = false;
+        tsi_load_all_blobs();
+    #endif /* GGML_TARGET_POSIX */
 
-    tsi_load_all_blobs();
 
     workers.reserve(2);
     runtime_initialized = true;
@@ -609,7 +660,8 @@ static inline void release_device(int deviceId) {
 }
 
 // ============================================================
-// FINAL JOIN — CALL AT END OF ggml_tsavorite_graph_compute()
+// Final join — invoke at the end of each node’s execution
+// within the ggml_tsavorite_graph_compute() subgraph loop.
 // ============================================================
 
 static inline void join_all_workers() {
@@ -680,20 +732,22 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
 
 static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
     if (!multi_thread_enable) {
+      _mlir_ciface_txe_add_host(a, b, res);
+      // Temporarily disabled; will be enabled in the next release to avoid collateral impact
+       #if 0
        void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, 0);
         tsi_blob_execution_internal(commandList);
+       #endif
         return;
     }
 
     int deviceId = acquire_device_blocking();
-printf("\n ANOOP ADD device ID %d", deviceId);
 
    // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
    void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, deviceId);
     workers.emplace_back([=]() {
         tsi_blob_execution_internal(commandList);
         release_device(deviceId);
-        printf("\n ANOOP Release ADD device ID %d", deviceId);
     });
 }
 
@@ -741,20 +795,23 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
 
 static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
     if (!multi_thread_enable) {
+        _mlir_ciface_txe_mult_host(a, b, res);
+      
+      // Temporarily disabled; will be enabled in the next release to avoid collateral impact
+        #if 0
         void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, 1);
         tsi_blob_execution_internal(commandList);
+        #endif
         return;
     }
 
     int deviceId = acquire_device_blocking();
 
-printf("\n ANOOP MUL device ID %d", deviceId);
    // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
    void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, deviceId);
     workers.emplace_back([=]() {
         tsi_blob_execution_internal(commandList);
         release_device(deviceId);
-        printf("\n ANOOP Release MUL device ID %d", deviceId);
     });
 }
 
@@ -803,20 +860,22 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
 
 static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
     if (!multi_thread_enable) {
+        _mlir_ciface_txe_rms_norm_host(a, b, buf);
+      // Temporarily disabled; will be enabled in the next release to avoid collateral impact
+      #if 0
         void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, 0);
         tsi_blob_execution_internal(commandList);
+      #endif
         return;
     }
 
     int deviceId = acquire_device_blocking();
-printf("\n ANOOP RMS_NORM device ID %d", deviceId);
 
     // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
     void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, deviceId);
     workers.emplace_back([=]() {
         tsi_blob_execution_internal(commandList);
         release_device(deviceId);
-       printf("\n ANOOP RMS_NORM Releasing device ID %d", deviceId);
     });
 }
 
@@ -837,8 +896,11 @@ static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_
           if (ggml_tsavorite_kernel_mode_flag == GGML_TSAVORITE_KERNEL_MODE_CPU)
               kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_test;
           else {
-              //kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host;
-              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host_new;
+              #ifdef GGML_TARGET_POSIX
+                  kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host;
+              #else
+                  kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host_new;
+              #endif /* GGML_TARGET_POSIX */
               kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_add_16_host;
 	  }
           kernel_pipeline->kernel_name = "TXE_ADD";
@@ -854,8 +916,11 @@ static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_
           if (ggml_tsavorite_kernel_mode_flag == GGML_TSAVORITE_KERNEL_MODE_CPU)
               kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_test;
           else {
-              //kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_host;
-              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_host_new;
+              #ifdef GGML_TARGET_POSIX
+                  kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_host;
+              #else
+                  kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_mult_host_new;
+              #endif /* GGML_TARGET_POSIX */
               kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_mult_16_host;
 	  }
           kernel_pipeline->kernel_name = "TXE_MULT";
@@ -910,8 +975,11 @@ static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_
           flag = true;
           break;
       case GGML_TSAVORITE_KERNEL_TYPE_RMS_NORM:
-          //kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_rms_norm_host;
-          kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_rms_norm_host_new;
+          #ifdef GGML_TARGET_POSIX
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_rms_norm_host;
+          #else
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_rms_norm_host_new;
+          #endif /* GGML_TARGET_POSIX */
           kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_rms_norm_16_host;
           kernel_pipeline->kernel_name = "TXE_RMS_NORM";
           flag = true;
@@ -1142,7 +1210,9 @@ static void ggml_tsavorite_free(struct ggml_backend_tsavorite_context *ctx) {
   if (runtime_initialized == true) {
       sleep(2);
       runtime_initialized = false;
-      tsi_unload_all_blobs();
+      #ifndef GGML_TARGET_POSIX
+         tsi_unload_all_blobs();
+      #endif /* !GGML_TARGET_POSIX */
       tsi_finalize();
       tsirt::utils::TSIProfiler::finalize();
       sleep(2);
@@ -1160,7 +1230,9 @@ tsi_cleanup() {
     if (runtime_initialized != true)
         return;
     runtime_initialized = false;
-    tsi_unload_all_blobs();
+    #ifndef GGML_TARGET_POSIX
+       tsi_unload_all_blobs();
+    #endif /* !GGML_TARGET_POSIX */
     tsi_finalize();
     GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
     tsirt::utils::TSIProfiler::finalize();
@@ -2042,20 +2114,6 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
   tensor_log log_data;
 
 
-multi_thread_enable = false;
-if (cgraph->n_nodes == 2) {
-             node = cgraph->nodes[0];
-             if (node->op == GGML_OP_MUL)  {
-                 multi_thread_enable = true;
-                 printf("\n ANOOP Multi-thread-enable for MUL GRAPH EXECUTIOn going to start");
-             }
-             node = cgraph->nodes[1];
-             if (node->op == GGML_OP_MUL)  {
-                 multi_thread_enable = true;
-                 printf("\n ANOOP Multi-thread-enable for MUL GRAPH EXECUTIOn going to start");
-             }
-}
-
   for (int i = 0; i < cgraph->n_nodes; i++) {
      int32_t kernel_sub_type=-1;
 #if defined(GGML_PERF) || defined(GGML_PERF_RELEASE) || defined(GGML_PERF_DETAIL)
@@ -2533,13 +2591,11 @@ if (cgraph->n_nodes == 2) {
         node->perf_time_us += (INT64_MAX - t_start + t_end + 1);
     }
 #endif /* GGML_PERF-related flags */
+    if (multi_thread_enable) {
+      join_all_workers();
+     }
   } /* this is main for loop */
 
-  if (multi_thread_enable) {
-    printf("\n ANOOP Multi-thread-enable for MUL GRAPH EXECUTIOn Completed");
-    join_all_workers();
-   }
-  anoop_test();
 
 
   // This this need to implement correctly when we have mixture of CPU and accelerator operation


### PR DESCRIPTION
POSIX:
[akapoor@wspd0 llama.cpp]$  ./build-posix/bin/llama-cli-original -p "my cat's name is" -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf  --device tSavorite  -c 12288 --temp 0.0 --n-predict 4 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5  --no-warmup --no-conversationpwd
error: invalid argument: --no-conversationpwd
[akapoor@wspd0 llama.cpp]$ ^C
[akapoor@wspd0 llama.cpp]$  ./build-posix/bin/llama-cli-original -p "my cat's name is" -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf  --device tSavorite  -c 12288 --temp 0.0 --n-predict 4 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5  --no-warmup --no-conversation
 my cat's name is Luna.




llama_perf_sampler_print:    sampling time =       7.93 ms /    11 runs   (    0.72 ms per token,  1386.96 tokens per second)
llama_perf_context_print:        load time =   21596.74 ms
llama_perf_context_print: prompt eval time =    2775.57 ms /     7 tokens (  396.51 ms per token,     2.52 tokens per second)
llama_perf_context_print:        eval time =    1144.22 ms /     3 runs   (  381.41 ms per token,     2.62 tokens per second)
llama_perf_context_print:       total time =   22749.88 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          308             560            543493           1764.59
  MUL              OPU          315             573            398204           1264.14
  RMS_NORM         OPU          315             315            271611            862.26
  MUL_MAT          CPU         5497               0          12412000           2257.96
  CONT             CPU         1206               0             46983             38.96
  RESHAPE          CPU         1752               0               827              0.47
  VIEW             CPU         2610               0               330              0.13
  PERMUTE          CPU         2051               0               400              0.20
  TRANSPOSE        CPU          495               0                95              0.19
  GET_ROWS         CPU           60               0              3215             53.58
  SET_ROWS         CPU         1150               0              1123              0.98
  SOFT_MAX         CPU          602               0             78013            129.59
  ROPE             CPU         1188               0              7227              6.08
  GLU              OPU          154             280            481785           3128.47

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    25.5230   25.5230     24.1650  [1.12e-01%] [Thread] tsi::runtime::TsavRTPosix::initialize
    1     1.1560    1.1560      1.0350  └─ [5.07e-03%] tsi::runtime::TsavRTPosix::initializeQueues
    1     0.0690    0.0690      0.0690    └─ [3.02e-04%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     0.0520    0.0520      0.0480    └─ [2.28e-04%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0040    0.0040      0.0040      └─ [1.75e-05%] tsi::runtime::executeWithTimeout
    1     0.2020    0.2020      0.2020  └─ [8.85e-04%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     5.4380    5.4380      0.0000  [2.38e-02%] [Thread] tsi::runtime::TsavRT::finalize
    1 22385.401922385.4019  22385.4019  └─ [98.13%] TXE 0 Idle
    2     0.1010    0.0505      0.1010  └─ [4.43e-04%] tsi::runtime::executeWithTimeout
    1     0.0097    0.0097      0.0097  └─ [4.27e-05%] Command{command=4 (RELEASE), blob_args=[0[0], 3[0x3], 4[0x...
    2     0.0080    0.0040      0.0080  └─ [3.51e-05%] tsi::runtime::TsavRT::deallocate
    1     0.0020    0.0020      0.0020  └─ [8.77e-06%] RELEASE Command Execution
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260   561.3280    0.4455      0.0000  [ 2.46%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
 1260 22369.4424   17.7535  22369.4424  └─ [98.06%] TXE 0 Idle
  214   165.0478    0.7713    165.0478  └─ [7.24e-01%] [ txe_swiglu ]
  428    62.8471    0.1468     62.8471  └─ [2.75e-01%] [ txe_add ]
  180    59.1579    0.3287     59.1579  └─ [2.59e-01%] [ txe_rms_norm ]
  438    57.0860    0.1303     57.0860  └─ [2.50e-01%] [ txe_mult ]
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260   369.8020    0.2935      0.0000  [ 1.62%] [Thread] tsi::runtime::TsavRTPosix::loadBlob
 1260 22369.2655   17.7534  22369.2655  └─ [98.06%] TXE 0 Idle
 2520   337.9640    0.1341    337.9640  └─ [ 1.48%] tsi::runtime::executeWithTimeout
 1260    41.2602    0.0327     41.2602  └─ [1.81e-01%] Command{command=2 (LOAD_BLOB), blob_args=[140691926922880[...
 1260     0.2920  2.32e-04      0.2920  └─ [1.28e-03%] LOAD_BLOB Command Execution
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260   215.3700    0.1709      0.0000  [9.44e-01%] [Thread] tsi::runtime::TsavRTPosix::unloadBlob
 1260 22369.6286   17.7537  22369.6286  └─ [98.06%] TXE 0 Idle
 2520   178.6750    0.0709    178.6750  └─ [7.83e-01%] tsi::runtime::executeWithTimeout
 1260     9.7590    0.0077      9.7590  └─ [4.28e-02%] Command{command=3 (UNLOAD_BLOB), blob_args=[14069192692288...
 1260     0.4000  3.17e-04      0.4000  └─ [1.75e-03%] UNLOAD_BLOB Command Execution
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1261   518.3220    0.4110     11.3040  [ 2.27%] [Thread] tsi::runtime::TsavRT::processResponses
 1261   507.0180    0.4021    507.0180  └─ [ 2.22%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     0.0830    0.0830      0.0620  [3.64e-04%] [Thread] OPU 
    1     0.0210    0.0210      0.0210  └─ [9.21e-05%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] txe_rms_norm (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  540    72.0060    0.1333     71.1940  [3.16e-01%] [Thread] txe_rms_norm
  540     0.8120    0.0015      0.8120  └─ [3.56e-03%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] txe_swiglu (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  642   176.3970    0.2748    175.3310  [7.73e-01%] [Thread] txe_swiglu
  642     1.0660    0.0017      1.0660  └─ [4.67e-03%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260    17.6460    0.0140     16.1710  [7.74e-02%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
 1260     1.4750    0.0012      1.4750  └─ [6.47e-03%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] txe_add (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1284    78.3100    0.0610     76.5070  [3.43e-01%] [Thread] txe_add
 1284     1.8030    0.0014      1.8030  └─ [7.90e-03%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] txe_mult (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1314    72.3880    0.0551     70.6810  [3.17e-01%] [Thread] txe_mult
 1314     1.7070    0.0013      1.7070  └─ [7.48e-03%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] TXE 0 Idle Time (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260     1.3980    0.0011      1.3980  [6.13e-03%] [Thread] tsi::runtime::TsavRT::deallocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1260     4.9210    0.0039      4.9210  [2.16e-02%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1262     3.7830    0.0030      3.7830  [1.66e-02%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::executeWithTimeout (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 3784 22329.5500    5.9010  22329.5500  [97.88%] [Thread] tsi::runtime::executeWithTimeout
========================================================================================================================
    - 22812.1230    0.0000  22812.1230  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.9992
------------------------------------------------------------------------------------------------------------------------

[akapoor@wspd0 llama.cpp]$ 




TSISM_FPGA
root
21:34:13,711:       
21:34:13,711:        Tsavorite Scalable Intelligence
21:34:13,711: 
21:34:13,711:     |||||||||||||||||||||||||||||||||||||
21:34:13,711:     |||||||||||||||||||||||||||||||||||||
21:34:13,711:     ||||||                          |||||
21:34:13,711:     ||||||                          |||||
21:34:13,711:     |||||||||||||||||   |||||       |||||
21:34:13,711:     |||||||||||||||||   |||||       |||||
21:34:13,711:                ||||||   |||||
21:34:13,712:     ||||||     ||||||   |||||      ||||||
21:34:13,712:      ||||||||  ||||||   |||||   ||||||||
21:34:13,712:        ||||||||||||||   ||||||||||||||
21:34:13,712:           |||||||||||   ||||||||||||
21:34:13,712:             |||||||||   ||||||||||
21:34:13,712:               |||||||   ||||||||
21:34:13,712:                 |||||   |||||
21:34:13,712:                   |||   |||
21:34:13,712:                         |
21:34:13,712: 
21:34:14,006: root@qemuarm64:~# cd /usr
21:34:16,103: root@qemuarm64:/usr# cd bin
21:34:17,185: root@qemuarm64:/usr/bin# cd tsi
21:34:18,466: root@qemuarm64:/usr/bin/tsi# cd bin
21:34:21,492: root@qemuarm64:/usr/bin/tsi/bin# tsictl txe show
21:34:27,500: TXE 0:
21:34:27,500:   txe_id         : 0
21:34:27,500:   init-done      : yes
21:34:27,500:   DB:
21:34:27,500:     agent-id         : 10000
21:34:27,500:     agent_type       : TXE
21:34:27,500:     agent_status     : READY
21:34:27,500:     group_identifier : 0
21:34:27,500:   supervisor:
21:34:27,500:     addr         : 0xffff5fe10000
21:34:27,500:     size         : 1048576
21:34:27,500:     pa           : 0x0000000008c00000
21:34:27,500:   statistics:
21:34:27,500:     DB:
21:34:27,500:       num_allocs       : 0
21:34:27,500:       num_deallocs     : 0
21:34:27,500:     Supervisor:
21:34:27,500:       txe_sup_trace_write_pos      : 36
21:34:27,502:       txe_sup_trace_seq_num        : 0
21:34:27,503:       txe_sup_trace_flush_count    : 0
21:34:27,503:       txe_sup_active_buf_idx       : 0 (A)
21:34:27,503:       txe_sup_dropped_record_count : 0
21:34:27,503:       txe_sup_cmd_count            : 0
21:34:27,503:       txe_sup_execute_blob_count   : 0
21:34:27,503:       txe_sup_nop_blob_count       : 0
21:34:27,503:       txe_sup_release_blob_count   : 0
21:34:27,504:       txe_sup_invalid_cmd_count    : 0
21:34:27,504:       txe_sup_unknown_cmd_count    : 0
21:34:27,504:       txe_sup_enqueue_fail_count   : 0
21:34:27,504:       txe_sup_blob_exec_error_count: 0
21:34:27,504:     TXE Manager:
21:34:27,504:       sup_boot_timestamp                  : 2026-04-08 21:34:23.391
21:34:27,504:       sup_boot_count                      : 1
21:34:27,504:       sup_trace_flush_requests_received   : 0
21:34:27,504:       sup_trace_flush_error_count         : 0
21:34:27,504: TXE 1:
21:34:27,504:   txe_id         : 1
21:34:27,504:   init-done      : yes
21:34:27,504:   DB:
21:34:27,504:     agent-id         : 10001
21:34:27,504:     agent_type       : TXE
21:34:27,504:     agent_status     : READY
21:34:27,504:     group_identifier : 0
21:34:27,504:   supervisor:
21:34:27,504:     addr         : 0xffff5fd10000
21:34:27,504:     size         : 1048576
21:34:27,504:     pa           : 0x0000000009000000
21:34:27,504:   statistics:
21:34:27,504:     DB:
21:34:27,505:       num_allocs       : 0
21:34:27,505:       num_deallocs     : 0
21:34:27,505:     Supervisor:
21:34:27,505:       txe_sup_trace_write_pos      : 36
21:34:27,505:       txe_sup_trace_seq_num        : 0
21:34:27,505:       txe_sup_trace_flush_count    : 0
21:34:27,505:       txe_sup_active_buf_idx       : 0 (A)
21:34:27,505:       txe_sup_dropped_record_count : 0
21:34:27,505:       txe_sup_cmd_count            : 0
21:34:27,505:       txe_sup_execute_blob_count   : 0
21:34:27,505:       txe_sup_nop_blob_count       : 0
21:34:27,505:       txe_sup_release_blob_count   : 0
21:34:27,505:       txe_sup_invalid_cmd_count    : 0
21:34:27,505:       txe_sup_unknown_cmd_count    : 0
21:34:27,506:       txe_sup_enqueue_fail_count   : 0
21:34:27,506:       txe_sup_blob_exec_error_count: 0
21:34:27,506:     TXE Manager:
21:34:27,506:       sup_boot_timestamp                  : 2026-04-08 21:34:23.400
21:34:27,506:       sup_boot_count                      : 1
21:34:27,506:       sup_trace_flush_requests_received   : 0
21:34:27,506:       sup_trace_flush_error_count         : 0
21:34:27,567: root@qemuarm64:/usr/bin/tsi/bin# 
21:34:33,196: root@qemuarm64:/usr/bin/tsi/bin# 
21:34:33,362: root@qemuarm64:/usr/bin/tsi/bin# ./run_llama_cli.sh 
21:34:41,710: [2026-04-08 21:34:41.689] [info] </proj/work/akapoor/mlir_march6/runtime/runtime/third-party/common-runtime/src/cma/cma.c:261> Device buffer file /dev/udmabuf2 does not exist (or not accessible), stopping initialization of further device buffers
21:36:32,371:  is Luna.
21:39:49,397: I'm a cat person and I love my
21:43:15,450: 
21:43:15,451: 
21:43:15,451: 
21:43:15,451: llama_perf_sampler_print:    sampling time =     658.20 ms /    21 runs   (   31.34 ms per token,    31.91 tokens per second)
21:43:15,452: llama_perf_context_print:        load time =  110400.13 ms
21:43:15,452: llama_perf_context_print: prompt eval time =   65277.98 ms /     6 tokens (10879.66 ms per token,     0.09 tokens per second)
21:43:15,452: llama_perf_context_print:        eval time =  402305.04 ms /    14 runs   (28736.07 ms per token,     0.03 tokens per second)
21:43:15,452: llama_perf_context_print:       total time =  513558.87 ms /    20 tokens
21:43:15,452: 
21:43:15,452: === GGML Perf Summary ===
21:43:15,452:   Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
21:43:15,453:   ADD              OPU         4664            4874          99524537          21338.88
21:43:15,453:   MUL              OPU         4770            4985          98618491          20674.74
21:43:15,453:   RMS_NORM         OPU         4770            4770         115399559          24192.78
21:43:15,453:   MUL_MAT          CPU        84256               0       11466883151         136095.75
21:43:15,453:   CONT             CPU        18087               0           8890969            491.57
21:43:15,453:   RESHAPE          CPU        26661               0            476658             17.88
21:43:15,453:   VIEW             CPU        44894               0            151303              3.37
21:43:15,453:   PERMUTE          CPU        35567               0            172451              4.85
21:43:15,453:   TRANSPOSE        CPU         8247               0             71601              8.68
21:43:15,453:   GET_ROWS         CPU          954               0            665249            697.33
21:43:15,453:   SET_ROWS         CPU        18027               0            488136             27.08
21:43:15,453:   SOFT_MAX         CPU         9247               0           8155595            881.97
21:43:15,453:   ROPE             CPU        17672               0           1226826             69.42
21:43:15,453:   GLU              OPU         2332            2437          94519267          40531.42
21:43:15,559: [2026-04-08 21:43:15.553936] 356:356 [warning] TsavRTFPGA TsavRTFPGA.cpp:580: FPGA runtime does not support dynamic device detachment.
21:43:15,597: [2026-04-08 21:43:15.596817] 356:356 [ info] TsavRTFPGA TsavRTFPGA.cpp:244: Releasing TXE instance 0
21:43:17,618: 
21:43:17,618: OPU Profiling Results:
21:43:17,682: ------------------------------------------------------------------------------------------------------------------------
21:43:17,683: Calls  Total(ms)    T/call    Self(ms)  Function
21:43:17,683: ------------------------------------------------------------------------------------------------------------------------
21:43:17,683:     1   117.2460  117.2460     89.0480  [2.28e-02%] [Thread] tsi::runtime::TsavRTFPGA::initialize
21:43:17,683:     1    10.2980   10.2980     10.2980  └─ [2.00e-03%] tsi::runtime::TsavRTFPGA::initializeRuntimeSpace
21:43:17,683:     1     9.5620    9.5620      9.5620  └─ [1.86e-03%] tsi::runtime::TsavRTFPGA::initializeQueues
21:43:17,683:     1     4.5620    4.5620      4.5620  └─ [8.88e-04%] tsi::runtime::TsavRT::initialize
21:43:17,683:     1     3.7760    3.7760      1.4920  └─ [7.35e-04%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
21:43:17,683:     2     2.2840    1.1420      2.2840    └─ [4.44e-04%] tsi::runtime::executeWithTimeout
21:43:17,683: ------------------------------------------------------------------------------------------------------------------------
21:43:17,683: [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
21:43:17,683: ------------------------------------------------------------------------------------------------------------------------
21:43:17,683:  2870 59202.5910   20.6281  55050.0807  [11.52%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
21:43:17,683:  2870  3890.4470    1.3556   3890.4470  └─ [7.57e-01%] TXE 0 Idle
21:43:17,683:   890    66.6137    0.0748     66.6137  └─ [1.30e-02%] [ txe_mult ]
21:43:17,683:   675    66.1396    0.0980     66.1396  └─ [1.29e-02%] [ txe_rms_norm ]
21:43:17,683:   870    65.0628    0.0748     65.0628  └─ [1.27e-02%] [ txe_add ]
21:43:17,684:   435    64.2473    0.1477     64.2473  └─ [1.25e-02%] [ txe_swiglu ]
21:43:17,684: ------------------------------------------------------------------------------------------------------------------------
21:43:17,684: [Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
21:43:17,684: ------------------------------------------------------------------------------------------------------------------------
21:43:17,684:     1   144.4610  144.4610     25.1990  [2.81e-02%] [Thread] tsi::runtime::TsavRTFPGA::finalize
21:43:17,684:     1    88.3110   88.3110     88.3110  └─ [1.72e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
21:43:17,684:     1    30.9510   30.9510     30.9510  └─ [6.02e-03%] tsi::runtime::TsavRT::finalize
21:43:17,684: ------------------------------------------------------------------------------------------------------------------------
21:43:17,684: [Thread] OPU  (cumulative over all threads)
21:43:17,684: ------------------------------------------------------------------------------------------------------------------------
21:43:17,684:     1     2.8490    2.8490      1.5410  [5.54e-04%] [Thread] OPU 
21:43:17,684:     1     1.3080    1.3080      1.3080  └─ [2.54e-04%] tsi::runtime::TsavRT::allocate
21:43:17,684: ------------------------------------------------------------------------------------------------------------------------
21:43:17,684: [Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
21:43:17,684: ------------------------------------------------------------------------------------------------------------------------
21:43:17,684:  2870  3408.0760    1.1875   3317.9160  [6.63e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
21:43:17,684:  2870    90.1600    0.0314     90.1600  └─ [1.75e-02%] tsi::runtime::executeWithTimeout
21:43:17,684: ------------------------------------------------------------------------------------------------------------------------
21:43:17,685: [Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
21:43:17,685: ------------------------------------------------------------------------------------------------------------------------
21:43:17,685:  2870 58925.9890   20.5317    527.2120  [11.46%] [Thread] tsi::runtime::TsavRT::processResponses
21:43:17,685:  2870 58398.7770   20.3480  58398.7770  └─ [11.36%] tsi::runtime::executeWithTimeout
21:43:17,685: ------------------------------------------------------------------------------------------------------------------------
21:43:17,685: [Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
21:43:17,685: ------------------------------------------------------------------------------------------------------------------------
21:43:17,685:  2872   307.4550    0.1071    307.4550  [5.98e-02%] [Thread] tsi::runtime::TsavRT::allocate
21:43:17,685: ------------------------------------------------------------------------------------------------------------------------
21:43:17,685: [Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)
21:43:17,685: ------------------------------------------------------------------------------------------------------------------------
21:43:17,685:  2870  3248.5520    1.1319   3248.5520  [6.32e-01%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob
21:43:17,685: ------------------------------------------------------------------------------------------------------------------------
21:43:17,685: [Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
21:43:17,685: ------------------------------------------------------------------------------------------------------------------------
21:43:17,685:  2870   510.5500    0.1779    510.5500  [9.93e-02%] [Thread] tsi::runtime::TsavRT::addCommandToList
21:43:17,686: ------------------------------------------------------------------------------------------------------------------------
21:43:17,686: [Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)
21:43:17,686: ------------------------------------------------------------------------------------------------------------------------
21:43:17,686:  2870   631.2560    0.2199    631.2560  [1.23e-01%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob
21:43:17,686: ------------------------------------------------------------------------------------------------------------------------
21:43:17,686: [Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
21:43:17,686: ------------------------------------------------------------------------------------------------------------------------
21:43:17,686:  2870   107.4600    0.0374    107.4600  [2.09e-02%] [Thread] tsi::runtime::TsavRT::deallocate
21:43:17,686: ========================================================================================================================
21:43:17,687:     -   5.14e+05    0.0000    5.14e+05  [100.00%] TOTAL
21:43:17,688: ========================================================================================================================
21:43:17,688: 
21:43:17,688: Counter Metrics:
21:43:17,688: ------------------------------------------------------------------------------------------------------------------------
21:43:17,688: Metric                                    Min            Max            Avg
21:43:17,688: ------------------------------------------------------------------------------------------------------------------------
21:43:17,688: Queue_0_Occupancy                      0.0000         1.0000         0.9944
21:43:17,688: ------------------------------------------------------------------------------------------------------------------------
21:43:17,688: 
21:43:18,393: root@qemuarm64:/usr/bin/tsi/bin# 
21:43:19,636: root@qemuarm64:/usr/bin/tsi/b