### PR TITLE
@FIR-1581 - llama.cpp: Add YAML‑based deployment configuration for Tsavorite backend

### DIFF
--- a/ggml/include/ggml-tsavorite.h
+++ b/ggml/include/ggml-tsavorite.h
@@ -39,6 +39,10 @@
 // See TMU MUL_MAT TILE BLOB ABI below for current contract.
 //
 
+#pragma once
+
+
+
 #include "ggml-backend.h"
 #include "ggml.h"
 
@@ -49,6 +53,10 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef TSAVORITE_GGML_ASSERT
 #define TSAVORITE_GGML_ASSERT(x) do { if (!(x)) abort(); } while (0)
@@ -324,7 +332,6 @@ extern void ggml_tsi_log_tensor_data(tensor_log log_data);
 #define TSI_TVU_MEM_ALIGN 128
 
 void tsi_cleanup();
-void tsi_log_profile_info();
 
 //
 // backend API
@@ -345,3 +352,7 @@ GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_tsavorite_buffer_type(v
 GGML_BACKEND_API void ggml_backend_tsavorite_capture_next_compute(ggml_backend_t backend);
 
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_tsavorite_reg(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/ggml/include/ggml-tsavorite.h
+++ b/ggml/include/ggml-tsavorite.h
@@ -39,10 +39,6 @@
 // See TMU MUL_MAT TILE BLOB ABI below for current contract.
 //
 
-#pragma once
-
-
-
 #include "ggml-backend.h"
 #include "ggml.h"
 
@@ -53,10 +49,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #ifndef TSAVORITE_GGML_ASSERT
 #define TSAVORITE_GGML_ASSERT(x) do { if (!(x)) abort(); } while (0)
@@ -332,6 +324,7 @@ extern void ggml_tsi_log_tensor_data(tensor_log log_data);
 #define TSI_TVU_MEM_ALIGN 128
 
 void tsi_cleanup();
+void tsi_log_profile_info();
 
 //
 // backend API
@@ -352,7 +345,3 @@ GGML_BACKEND_API ggml_backend_buffer_type_t ggml_backend_tsavorite_buffer_type(v
 GGML_BACKEND_API void ggml_backend_tsavorite_capture_next_compute(ggml_backend_t backend);
 
 GGML_BACKEND_API ggml_backend_reg_t ggml_backend_tsavorite_reg(void);
-
-#ifdef __cplusplus
-}
-#endif

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -24,6 +24,9 @@
 #include <inttypes.h>
 #include <math.h>
 #include <iostream>
+#include <fstream>
+#include <cctype>
+#include <cstdlib>
 #include <magic_enum/magic_enum.hpp>
 #include "ggml-backend-impl.h"
 #include "ggml-impl.h"
@@ -49,7 +52,7 @@ namespace {
 
 struct TsavoriteRuntimeState {
     // device / threading
-    uint32_t num_of_txes = NUM_OF_TXES;
+    uint32_t num_of_txes = 1;
     bool *device_free = nullptr;
     bool multi_thread_enable = false;
 
@@ -58,9 +61,12 @@ struct TsavoriteRuntimeState {
     std::mutex tsi_pack_mutex;
     std::condition_variable device_cv;
     // blobs
-    BlobDescriptor *blobDescriptor_add[NUM_OF_TXES] = {};
-    BlobDescriptor *blobDescriptor_mult[NUM_OF_TXES] = {};
-    BlobDescriptor *blobDescriptor_rms_norm[NUM_OF_TXES] = {};
+    BlobDescriptor **blobDescriptor_add = nullptr;
+    BlobDescriptor **blobDescriptor_mult = nullptr;
+    BlobDescriptor **blobDescriptor_rms_norm = nullptr;
+    void **loadResult_add = nullptr;
+    void **loadResult_mult = nullptr;
+    void **loadResult_rms_norm = nullptr;
 };
 
 static TsavoriteRuntimeState g_rt;
@@ -79,6 +85,150 @@ auto &device_cv = g_rt.device_cv;
 auto &blobDescriptor_add      = g_rt.blobDescriptor_add;
 auto &blobDescriptor_mult     = g_rt.blobDescriptor_mult;
 auto &blobDescriptor_rms_norm = g_rt.blobDescriptor_rms_norm;
+
+// =============================================================================
+// YAML deployment parsing (no external yaml lib)
+// Supports:
+//   txe_count: 2
+//   multi_thread_enable: true|false|1|0|yes|no|on|off
+// Optional env:
+//   TSAVORITE_MODEL_DEPLOYMENT_YAML=/path/to/tsavorite-model-deployment.yaml
+// Notes:
+//   - txe_count is CLAMPED to NUM_OF_TXES (fixed-size arrays in this file)
+// =============================================================================
+static inline std::string tsi_trim_copy(const std::string &s) {
+    size_t b = 0, e = s.size();
+    while (b < e && std::isspace((unsigned char)s[b])) b++;
+   while (e > b && std::isspace((unsigned char)s[e - 1])) e--;
+    return s.substr(b, e - b);
+}
+
+static inline bool tsi_starts_with(const std::string &s, const char *pfx) {
+    return s.rfind(pfx, 0) == 0;
+}
+
+static inline std::string tsi_to_lower(std::string v) {
+    for (char &c : v) c = (char)std::tolower((unsigned char)c);
+    return v;
+}
+
+static int tsi_parse_int_after_colon(const std::string &line) {
+    size_t c = line.find(':');
+    if (c == std::string::npos) return -1;
+    std::string rhs = tsi_trim_copy(line.substr(c + 1));
+    if (rhs.empty()) return -1;
+    // allow quotes
+    if (rhs.front() == '"' || rhs.front() == '\'') rhs.erase(0, 1);
+    // parse leading integer
+    int sign = 1;
+    size_t i = 0;
+    if (i < rhs.size() && rhs[i] == '-') { sign = -1; i++; }
+    long v = 0;
+    bool any = false;
+    for (; i < rhs.size() && std::isdigit((unsigned char)rhs[i]); i++) {
+        any = true;
+        v = v * 10 + (rhs[i] - '0');
+    }
+    return any ? (int)(sign * v) : -1;
+}
+
+static bool tsi_parse_bool_after_colon(const std::string &line, bool *out) {
+    if (!out) return false;
+    size_t c = line.find(':');
+    if (c == std::string::npos) return false;
+    std::string rhs = tsi_trim_copy(line.substr(c + 1));
+    if (rhs.empty()) return false;
+    // allow quotes
+    if (rhs.front() == '"' || rhs.front() == '\'') rhs.erase(0, 1);
+    rhs = tsi_to_lower(tsi_trim_copy(rhs));
+    // accept common yaml-ish bools
+    if (rhs == "true" || rhs == "1" || rhs == "yes" || rhs == "y" || rhs == "on")  { *out = true;  return true; }
+    if (rhs == "false"|| rhs == "0" || rhs == "no"  || rhs == "n" || rhs == "off") { *out = false; return true; }
+    return false;
+}
+
+struct tsi_deploy_cfg_t {
+    int  txe_count = -1;
+    bool mt_enable = false;
+    bool has_mt    = false;
+};
+
+// Heuristics supported for txe_count:
+// (A) explicit scalar: txe_count: 4 OR num_txe: 4 OR txeCount: 4
+// (B) list form: txes: \n - ... \n - ...  => count list items under "txes:"
+static tsi_deploy_cfg_t tsi_read_deploy_yaml(const std::string &path) {
+    tsi_deploy_cfg_t cfg;
+    std::ifstream in(path);
+    if (!in.is_open()) return cfg;
+
+    std::string line;
+    bool in_txes_list = false;
+    int txes_list_indent = -1;
+    int txes_count = 0;
+
+    while (std::getline(in, line)) {
+        // strip comments
+        size_t hash = line.find('#');
+        if (hash != std::string::npos) line = line.substr(0, hash);
+
+        std::string raw = line;
+        std::string t = tsi_trim_copy(line);
+        if (t.empty()) continue;
+
+        // txe_count scalar keys
+        if (t.find("txe_count") != std::string::npos && t.find(':') != std::string::npos) {
+            int v = tsi_parse_int_after_colon(t);
+            if (v > 0) cfg.txe_count = v;
+        } else if (t.find("num_txe") != std::string::npos && t.find(':') != std::string::npos) {
+            int v = tsi_parse_int_after_colon(t);
+            if (v > 0) cfg.txe_count = v;
+        } else if (t.find("txeCount") != std::string::npos && t.find(':') != std::string::npos) {
+            int v = tsi_parse_int_after_colon(t);
+            if (v > 0) cfg.txe_count = v;
+        }
+
+        // multi-thread enable keys (accept a few spellings)
+        if (t.find("multi_thread_enable") != std::string::npos && t.find(':') != std::string::npos) {
+            bool b = false;
+            if (tsi_parse_bool_after_colon(t, &b)) { cfg.mt_enable = b; cfg.has_mt = true; }
+        } else if (t.find("multi_threading_enable") != std::string::npos && t.find(':') != std::string::npos) {
+            bool b = false;
+            if (tsi_parse_bool_after_colon(t, &b)) { cfg.mt_enable = b; cfg.has_mt = true; }
+        } else if (t.find("multithreading_enable") != std::string::npos && t.find(':') != std::string::npos) {
+            bool b = false;
+            if (tsi_parse_bool_after_colon(t, &b)) { cfg.mt_enable = b; cfg.has_mt = true; }
+        } else if (t.find("multiThreadEnable") != std::string::npos && t.find(':') != std::string::npos) {
+            bool b = false;
+            if (tsi_parse_bool_after_colon(t, &b)) { cfg.mt_enable = b; cfg.has_mt = true; }
+        }
+
+        // list counting under "txes:"
+        if (tsi_starts_with(t, "txes:")) {
+            in_txes_list = true;
+            txes_count = 0;
+            int indent = 0;
+            while (indent < (int)raw.size() && std::isspace((unsigned char)raw[indent])) indent++;
+            txes_list_indent = indent;
+            continue;
+        }
+
+        if (in_txes_list) {
+            int indent = 0;
+            while (indent < (int)raw.size() && std::isspace((unsigned char)raw[indent])) indent++;
+            if (txes_list_indent >= 0 && indent <= txes_list_indent) {
+                if (txes_count > 0 && cfg.txe_count <= 0) cfg.txe_count = txes_count;
+                in_txes_list = false;
+                txes_list_indent = -1;
+            } else {
+                std::string tt = tsi_trim_copy(raw);
+                if (tsi_starts_with(tt, "-")) txes_count++;
+            }
+        }
+    }
+
+    if (txes_count > 0 && cfg.txe_count <= 0) cfg.txe_count = txes_count;
+    return cfg;
+}
 
 
 #ifdef TMU_DEBUG_VALIDATE
@@ -186,12 +336,65 @@ static std::string blob_prefix(const char *rel) {
     return tsavorite_llama_root() + rel;
 }
 
+static TsavoriteRuntimeState &rt = g_rt;
+
 static void tsi_load_all_blobs() {
-    static void *loadResult_add[NUM_OF_TXES];
-    static void *loadResult_mult[NUM_OF_TXES];
-    static void *loadResult_rms_norm[NUM_OF_TXES];
     int i;
     char blob_name[64];
+    TsavoriteRuntimeState &rt = g_rt;
+
+    /* loadResult_* */
+    if (!rt.loadResult_add) {
+        rt.loadResult_add = (void **)calloc(rt.num_of_txes, sizeof(void *));
+        if (!rt.loadResult_add) {
+            fprintf(stderr, "Failed to allocate loadResult_add\n");
+            abort();
+        }
+    }
+
+    if (!rt.loadResult_mult) {
+        rt.loadResult_mult = (void **)calloc(rt.num_of_txes, sizeof(void *));
+        if (!rt.loadResult_mult) {
+            fprintf(stderr, "Failed to allocate loadResult_mult\n");
+            abort();
+        }
+    }
+
+    if (!rt.loadResult_rms_norm) {
+        rt.loadResult_rms_norm = (void **)calloc(rt.num_of_txes, sizeof(void *));
+        if (!rt.loadResult_rms_norm) {
+            fprintf(stderr, "Failed to allocate loadResult_rms_norm\n");
+            abort();
+        }
+    }
+
+    /* blobDescriptor_* */
+    if (!rt.blobDescriptor_add) {
+        rt.blobDescriptor_add =
+            (BlobDescriptor **)calloc(rt.num_of_txes, sizeof(BlobDescriptor *));
+        if (!rt.blobDescriptor_add) {
+            fprintf(stderr, "Failed to allocate blobDescriptor_add\n");
+            abort();
+        }
+    }
+
+    if (!rt.blobDescriptor_mult) {
+        rt.blobDescriptor_mult =
+            (BlobDescriptor **)calloc(rt.num_of_txes, sizeof(BlobDescriptor *));
+        if (!rt.blobDescriptor_mult) {
+            fprintf(stderr, "Failed to allocate blobDescriptor_mult\n");
+            abort();
+        }
+    }
+
+    if (!rt.blobDescriptor_rms_norm) {
+        rt.blobDescriptor_rms_norm =
+            (BlobDescriptor **)calloc(rt.num_of_txes, sizeof(BlobDescriptor *));
+        if (!rt.blobDescriptor_rms_norm) {
+            fprintf(stderr, "Failed to allocate blobDescriptor_rms_norm\n");
+            abort();
+        }
+    }
 
     for (int i = 0; i < num_of_txes; ++i) {
         char name_add[64];
@@ -270,19 +473,34 @@ for (int i=0; i < num_of_txes; ++i) {
 }
 
 // Centralized TSI runtime initialization - called once globally
+//
+
 static void ensure_tsi_runtime_initialized() {
   if (!runtime_initialized) {
     std::string mainProfilerName = "OPU ";
     tsirt::utils::TSIProfiler::initialize();
 
+    const char *yaml_path_env = std::getenv("TSAVORITE_MODEL_DEPLOYMENT_YAML");
+        std::string yaml_path = yaml_path_env ? std::string(yaml_path_env)
+                                       : std::string("tsavorite-model-deployment.yaml");
+        tsi_deploy_cfg_t cfg = tsi_read_deploy_yaml(yaml_path);
+
+        int txe = (cfg.txe_count > 0) ? cfg.txe_count : (int)NUM_OF_TXES;
+        if (txe <= 0) txe = 1;
+
+        num_of_txes = (uint32_t)txe;
+        multi_thread_enable = cfg.has_mt ? cfg.mt_enable : false;
+
+        // Just to Test
+         printf("\nANOOP TSI deploy yaml=%s txe_count=%u multi_thread_enable=%d\n",
+                yaml_path.c_str(), (unsigned)num_of_txes, (int)multi_thread_enable);
+
+    // IMPORTANT: fixed-size arrays in this file => clamp
+    if (txe > (int)NUM_OF_TXES) txe = (int)NUM_OF_TXES;
+
     // TSI Run time Initalization
-    #ifdef GGML_TARGET_POSIX
-        num_of_txes = 1;
-        multi_thread_enable = false;
-    #else
-        num_of_txes = NUM_OF_TXES;
-        multi_thread_enable = false;
-    #endif /* GGML_TARGET_POSIX */
+    multi_thread_enable = false;
+    num_of_txes = NUM_OF_TXES;
     tsi_initialize(num_of_txes, NULL);
 
     if (multi_thread_enable) {

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -64,6 +64,7 @@ struct TsavoriteRuntimeState {
     BlobDescriptor **blobDescriptor_add = nullptr;
     BlobDescriptor **blobDescriptor_mult = nullptr;
     BlobDescriptor **blobDescriptor_rms_norm = nullptr;
+
     void **loadResult_add = nullptr;
     void **loadResult_mult = nullptr;
     void **loadResult_rms_norm = nullptr;
@@ -346,60 +347,28 @@ static TsavoriteRuntimeState &rt = g_rt;
 static void tsi_load_all_blobs() {
     int i;
     char blob_name[64];
-    TsavoriteRuntimeState &rt = g_rt;
 
-    /* loadResult_* */
-    if (!rt.loadResult_add) {
-        rt.loadResult_add = (void **)calloc(rt.num_of_txes, sizeof(void *));
-        if (!rt.loadResult_add) {
-            fprintf(stderr, "Failed to allocate loadResult_add\n");
-            abort();
-        }
+    
+    // already loaded
+    if (blobDescriptor_add || blobDescriptor_mult || blobDescriptor_rms_norm) {
+        return;
     }
 
-    if (!rt.loadResult_mult) {
-        rt.loadResult_mult = (void **)calloc(rt.num_of_txes, sizeof(void *));
-        if (!rt.loadResult_mult) {
-            fprintf(stderr, "Failed to allocate loadResult_mult\n");
-            abort();
-        }
+    // allocate pointer tables (size = num_of_txes)
+    loadResult_add = (void **)calloc(num_of_txes, sizeof(void *));
+    loadResult_mult = (void **)calloc(num_of_txes, sizeof(void *));
+    loadResult_rms_norm = (void **)calloc(num_of_txes, sizeof(void *));
+
+    blobDescriptor_add = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
+    blobDescriptor_mult = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
+    blobDescriptor_rms_norm = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
+
+    if (!loadResult_add || !loadResult_mult || !loadResult_rms_norm ||
+        !blobDescriptor_add || !blobDescriptor_mult || !blobDescriptor_rms_norm) {
+        fprintf(stderr, "Failed to allocate blob tables (num_of_txes=%u)\n", (unsigned)num_of_txes);
+        abort();
     }
 
-    if (!rt.loadResult_rms_norm) {
-        rt.loadResult_rms_norm = (void **)calloc(rt.num_of_txes, sizeof(void *));
-        if (!rt.loadResult_rms_norm) {
-            fprintf(stderr, "Failed to allocate loadResult_rms_norm\n");
-            abort();
-        }
-    }
-
-    /* blobDescriptor_* */
-    if (!rt.blobDescriptor_add) {
-        rt.blobDescriptor_add =
-            (BlobDescriptor **)calloc(rt.num_of_txes, sizeof(BlobDescriptor *));
-        if (!rt.blobDescriptor_add) {
-            fprintf(stderr, "Failed to allocate blobDescriptor_add\n");
-            abort();
-        }
-    }
-
-    if (!rt.blobDescriptor_mult) {
-        rt.blobDescriptor_mult =
-            (BlobDescriptor **)calloc(rt.num_of_txes, sizeof(BlobDescriptor *));
-        if (!rt.blobDescriptor_mult) {
-            fprintf(stderr, "Failed to allocate blobDescriptor_mult\n");
-            abort();
-        }
-    }
-
-    if (!rt.blobDescriptor_rms_norm) {
-        rt.blobDescriptor_rms_norm =
-            (BlobDescriptor **)calloc(rt.num_of_txes, sizeof(BlobDescriptor *));
-        if (!rt.blobDescriptor_rms_norm) {
-            fprintf(stderr, "Failed to allocate blobDescriptor_rms_norm\n");
-            abort();
-        }
-    }
 
     for (int i = 0; i < num_of_txes; ++i) {
         char name_add[64];
@@ -469,12 +438,29 @@ error:
 
 
 static void tsi_unload_all_blobs() {
-for (int i=0; i < num_of_txes; ++i) {
-  tsi_unload_blob(blobDescriptor_add[i]);
-  tsi_unload_blob(blobDescriptor_mult[i]);
-  tsi_unload_blob(blobDescriptor_rms_norm[i]);
-}
-  return;
+    for (uint32_t i = 0; i < num_of_txes; ++i) {
+        if (blobDescriptor_add && blobDescriptor_add[i]) {
+            tsi_unload_blob(blobDescriptor_add[i]);
+            blobDescriptor_add[i] = nullptr;
+        }
+        if (blobDescriptor_mult && blobDescriptor_mult[i]) {
+            tsi_unload_blob(blobDescriptor_mult[i]);
+            blobDescriptor_mult[i] = nullptr;
+        }
+        if (blobDescriptor_rms_norm && blobDescriptor_rms_norm[i]) {
+            tsi_unload_blob(blobDescriptor_rms_norm[i]);
+            blobDescriptor_rms_norm[i] = nullptr;
+        }
+    }
+
+    free(loadResult_add);        loadResult_add = nullptr;
+    free(loadResult_mult);       loadResult_mult = nullptr;
+    free(loadResult_rms_norm);   loadResult_rms_norm = nullptr;
+
+    free(blobDescriptor_add);    blobDescriptor_add = nullptr;
+    free(blobDescriptor_mult);   blobDescriptor_mult = nullptr;
+    free(blobDescriptor_rms_norm); blobDescriptor_rms_norm = nullptr;
+    return;
 }
 
 // Centralized TSI runtime initialization - called once globally

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -583,7 +583,7 @@ static void ensure_tsi_runtime_initialized() {
         abort();
     }
     
-    for (int i = 0; i < num_of_txes; i++) {
+    for (uint32_t i = 0; i < num_of_txes; i++) {
         device_free[i] = true;
     }
 
@@ -980,13 +980,13 @@ static inline int acquire_device_blocking() {
     std::unique_lock<std::mutex> lock(device_mutex);
 
     device_cv.wait(lock, [] {
-        for (int i = 0; i < num_of_txes; ++i)
+        for (uint32_t i = 0; i < num_of_txes; ++i)
             if (device_free[i])
                 return true;
         return false;
     });
 
-    for (int i = 0; i < num_of_txes; ++i) {
+    for (uint32_t i = 0; i < num_of_txes; ++i) {
         if (device_free[i]) {
             device_free[i] = false;
             return i;
@@ -1015,7 +1015,7 @@ static inline void join_all_workers() {
 
     {
         std::lock_guard<std::mutex> lock(device_mutex);
-        for (int i = 0; i < num_of_txes; ++i)
+        for (uint32_t i = 0; i < num_of_txes; ++i)
             device_free[i] = true;
     }
     device_cv.notify_all();
@@ -1075,8 +1075,8 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add[deviceId], packedHandle);
 
     if (!blobExecuteCmd) {
-        printf("tsi_launch_blob failed for device %d and blobDescriptor %s\n",
-                                     deviceId, (char *)blobDescriptor_add[deviceId]);
+        printf("tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
+                                     (unsigned long)deviceId, (char *)blobDescriptor_add[deviceId]);
         tsi_cleanup();
         abort();
     }
@@ -1160,8 +1160,8 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
     const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult[deviceId], packedHandle);
     if (!blobExecuteCmd) {
-        printf("tsi_launch_blob failed for device %d and blobDescriptor %s\n",
-                                     deviceId, (char *)blobDescriptor_mult[deviceId]);
+        printf("tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
+                                     (unsigned long)deviceId, (char *)blobDescriptor_mult[deviceId]);
         tsi_cleanup();
         abort();
     }
@@ -1248,8 +1248,8 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
     const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm[deviceId], packedHandle);
     if (!blobExecuteCmd) {
-        printf("tsi_launch_blob failed for device %d and blobDescriptor %s\n",
-                                     deviceId, (char *)blobDescriptor_rms_norm[deviceId]);
+        printf("tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
+                                     (unsigned long)deviceId, (char *)blobDescriptor_rms_norm[deviceId]);
         tsi_cleanup();
         abort();
     }

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -71,8 +71,7 @@ struct TsavoriteRuntimeState {
 
 static TsavoriteRuntimeState g_rt;
 
-} // anonymous namespace
-
+// aliases (USE THESE EVERYWHERE)
 auto &num_of_txes = g_rt.num_of_txes;
 auto &device_free = g_rt.device_free;
 auto &multi_thread_enable     = g_rt.multi_thread_enable;
@@ -85,6 +84,12 @@ auto &device_cv = g_rt.device_cv;
 auto &blobDescriptor_add      = g_rt.blobDescriptor_add;
 auto &blobDescriptor_mult     = g_rt.blobDescriptor_mult;
 auto &blobDescriptor_rms_norm = g_rt.blobDescriptor_rms_norm;
+
+auto &loadResult_add          = g_rt.loadResult_add;
+auto &loadResult_mult         = g_rt.loadResult_mult;
+auto &loadResult_rms_norm     = g_rt.loadResult_rms_norm;
+
+} // anonymous namespace
 
 // =============================================================================
 // YAML deployment parsing (no external yaml lib)
@@ -476,31 +481,35 @@ for (int i=0; i < num_of_txes; ++i) {
 //
 
 static void ensure_tsi_runtime_initialized() {
-  if (!runtime_initialized) {
+    if (runtime_initialized) {
+        printf("\n tsavorite backend already initialized \n");
+        return;
+    }
     std::string mainProfilerName = "OPU ";
     tsirt::utils::TSIProfiler::initialize();
 
+    // YAML placeholder (intentionally ignored)
     const char *yaml_path_env = std::getenv("TSAVORITE_MODEL_DEPLOYMENT_YAML");
-        std::string yaml_path = yaml_path_env ? std::string(yaml_path_env)
-                                       : std::string("tsavorite-model-deployment.yaml");
-        tsi_deploy_cfg_t cfg = tsi_read_deploy_yaml(yaml_path);
+    std::string yaml_path = yaml_path_env ? std::string(yaml_path_env)
+                                   : std::string("tsavorite-model-deployment.yaml");
+    tsi_deploy_cfg_t cfg = tsi_read_deploy_yaml(yaml_path);
 
-        int txe = (cfg.txe_count > 0) ? cfg.txe_count : (int)NUM_OF_TXES;
-        if (txe <= 0) txe = 1;
+    int txe = (cfg.txe_count > 0) ? cfg.txe_count : (int)NUM_OF_TXES;
 
-        num_of_txes = (uint32_t)txe;
-        multi_thread_enable = cfg.has_mt ? cfg.mt_enable : false;
+    num_of_txes = (uint32_t)txe;
+    multi_thread_enable = cfg.has_mt ? cfg.mt_enable : false;
 
-        // Just to Test
-         printf("\nANOOP TSI deploy yaml=%s txe_count=%u multi_thread_enable=%d\n",
-                yaml_path.c_str(), (unsigned)num_of_txes, (int)multi_thread_enable);
+    // Just to Test
+    printf("\nANOOP TSI deploy yaml=%s txe_count=%u multi_thread_enable=%d\n",
+             yaml_path.c_str(), (unsigned)num_of_txes, (int)multi_thread_enable);
 
+    if (txe <= 0) txe = 1;
     // IMPORTANT: fixed-size arrays in this file => clamp
     if (txe > (int)NUM_OF_TXES) txe = (int)NUM_OF_TXES;
 
-    // TSI Run time Initalization
+    // INTENTIONAL PLACEHOLDER
     multi_thread_enable = false;
-    num_of_txes = NUM_OF_TXES;
+    num_of_txes = 1;
     tsi_initialize(num_of_txes, NULL);
 
     if (multi_thread_enable) {
@@ -522,7 +531,7 @@ static void ensure_tsi_runtime_initialized() {
     workers.reserve(num_of_txes);
     runtime_initialized = true;
     GGML_TSAVORITE_LOG_INFO("Profiler and TSI runtime initialized early in registration\n");
-  }
+    return;
 }
 #ifdef USE_COMMAND_BUFFERS
 typedef struct _txe_command_queue_t *txe_command_queue_s;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -68,6 +68,16 @@ struct TsavoriteRuntimeState {
     void **loadResult_add = nullptr;
     void **loadResult_mult = nullptr;
     void **loadResult_rms_norm = nullptr;
+
+    // blob lifetime state machine
+    enum BlobState : uint8_t {
+        BLOB_UNINITIALIZED = 0,   // no tables, no blobs
+        BLOB_TABLES_ALLOCATED,    // tables allocated, blobs may be null
+        BLOB_BLOBS_LOADED         // all blobs loaded successfully
+    };
+
+    BlobState blob_state = BLOB_UNINITIALIZED;
+    uint32_t blob_tables_txes = 0;   // tracks num_of_txes used to size the tables
 };
 
 static TsavoriteRuntimeState g_rt;
@@ -89,18 +99,8 @@ auto &blobDescriptor_rms_norm = g_rt.blobDescriptor_rms_norm;
 auto &loadResult_add          = g_rt.loadResult_add;
 auto &loadResult_mult         = g_rt.loadResult_mult;
 auto &loadResult_rms_norm     = g_rt.loadResult_rms_norm;
-
-// blob lifetime state machine
-enum BlobState : uint8_t {
-    BLOB_UNINITIALIZED = 0,   // no tables, no blobs
-    BLOB_TABLES_ALLOCATED,    // tables allocated, blobs may be null
-    BLOB_BLOBS_LOADED         // all blobs loaded successfully
-};
-
-BlobState blob_state = BLOB_UNINITIALIZED;
-uint32_t blob_tables_txes = 0;   // tracks num_of_txes used to size the tables
-
 } // anonymous namespace
+
 
 // =============================================================================
 // YAML deployment parsing (no external yaml lib)

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -1670,21 +1670,6 @@ tsi_cleanup() {
     return;
 }
 
-void
-tsi_log_profile_info() {
-    GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
-    tsi_finalize();
-    tsirt::utils::TSIProfiler::finalize();
-    // Profiling results already printed during first cleanup
-    std::cout << "\nOPU Profiling Results:" << std::endl;
-    std::cout << tsirt::utils::TSIProfiler::getFormattedResults(
-                  /*truncateFuncNames*/ true)
-               << std::endl;
-    GGML_TSAVORITE_LOG_INFO("End %s\n", __func__);
-    fflush(stdout);
-    return;
-}
-
 #if 0
 // finds the tSavorite buffer that contains the tensor data on the TXE device unified memory
 // the assumption is that there is 1-to-1 mapping between the host and device memory buffers, so we can find the
@@ -3435,11 +3420,6 @@ static struct ggml_backend_i ggml_backend_tsavorite_i = {
     /* .graph_compute           = */ ggml_backend_tsavorite_graph_compute,
     /* .event_record            = */ NULL,
     /* .event_wait              = */ NULL,
-    /* .graph_optimize          = */ NULL,
-    /* .graph_reserve           = */ NULL,
-    /* .buffer_size             = */ NULL,
-    /* .reset                   = */ NULL,
-    /* .profile                 = */ tsi_log_profile_info
 };
 
 static ggml_guid_t ggml_backend_tsavorite_guid(void) {
@@ -3849,47 +3829,14 @@ static struct ggml_backend_reg_i ggml_backend_tsavorite_reg_i = {
     /* .get_proc_address = */ NULL,
 };
 
-#define SHM_NAME "/ollama_init_shm"
-
-typedef struct {
-  bool init_done;
-} shared_state_t;
-
-static shared_state_t *state = NULL;
-
-static void init_shared_state() {
-  int fd = shm_open(SHM_NAME, O_CREAT | O_RDWR, 0666);
-  if (fd == -1) {
-      perror("shm_open");
-      return;
-  }
-  ftruncate(fd, sizeof(shared_state_t));
-
-  state = (shared_state_t *) mmap(NULL, sizeof(shared_state_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-  if (state == MAP_FAILED) {
-      perror("mmap");
-      return;
-  }
-}
 
 ggml_backend_reg_t ggml_backend_tsavorite_reg(void) {
   ggml_tsavorite_log_type_val = GGML_TSAVORITE_LOG_NONE;
   ggml_tsavorite_kernel_mode_flag = GGML_TSAVORITE_KERNEL_MODE_MLIR;
   GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
-
-  init_shared_state();
-
-  if (state->init_done == true) {
-      GGML_LOG_DEBUG("%s: Initialization already done, calling tsi_initialize...\n", __func__);
-      ensure_tsi_runtime_initialized();
-  } else {
-      state->init_done = true;
-      GGML_LOG_DEBUG("%s: Initialization not done, proceeding...\n", __func__);
-  }
-
+  ensure_tsi_runtime_initialized();
   g_ggml_backend_tsavorite_reg.iface = ggml_backend_tsavorite_reg_i;
   g_ggml_backend_tsavorite_reg.context = NULL;
-  g_ggml_backend_tsavorite_reg.api_version = GGML_BACKEND_API_VERSION;
   g_ggml_backend_tsavorite_device.iface = ggml_backend_tsavorite_device_i;
   g_ggml_backend_tsavorite_device.reg = &g_ggml_backend_tsavorite_reg;
   g_ggml_backend_tsavorite_device.context = &g_ggml_ctx_dev_main;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -1670,6 +1670,21 @@ tsi_cleanup() {
     return;
 }
 
+void
+tsi_log_profile_info() {
+    GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
+    tsi_finalize();
+    tsirt::utils::TSIProfiler::finalize();
+    // Profiling results already printed during first cleanup
+    std::cout << "\nOPU Profiling Results:" << std::endl;
+    std::cout << tsirt::utils::TSIProfiler::getFormattedResults(
+                  /*truncateFuncNames*/ true)
+               << std::endl;
+    GGML_TSAVORITE_LOG_INFO("End %s\n", __func__);
+    fflush(stdout);
+    return;
+}
+
 #if 0
 // finds the tSavorite buffer that contains the tensor data on the TXE device unified memory
 // the assumption is that there is 1-to-1 mapping between the host and device memory buffers, so we can find the
@@ -3420,6 +3435,11 @@ static struct ggml_backend_i ggml_backend_tsavorite_i = {
     /* .graph_compute           = */ ggml_backend_tsavorite_graph_compute,
     /* .event_record            = */ NULL,
     /* .event_wait              = */ NULL,
+    /* .graph_optimize          = */ NULL,
+    /* .graph_reserve           = */ NULL,
+    /* .buffer_size             = */ NULL,
+    /* .reset                   = */ NULL,
+    /* .profile                 = */ tsi_log_profile_info
 };
 
 static ggml_guid_t ggml_backend_tsavorite_guid(void) {
@@ -3829,14 +3849,47 @@ static struct ggml_backend_reg_i ggml_backend_tsavorite_reg_i = {
     /* .get_proc_address = */ NULL,
 };
 
+#define SHM_NAME "/ollama_init_shm"
+
+typedef struct {
+  bool init_done;
+} shared_state_t;
+
+static shared_state_t *state = NULL;
+
+static void init_shared_state() {
+  int fd = shm_open(SHM_NAME, O_CREAT | O_RDWR, 0666);
+  if (fd == -1) {
+      perror("shm_open");
+      return;
+  }
+  ftruncate(fd, sizeof(shared_state_t));
+
+  state = (shared_state_t *) mmap(NULL, sizeof(shared_state_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  if (state == MAP_FAILED) {
+      perror("mmap");
+      return;
+  }
+}
 
 ggml_backend_reg_t ggml_backend_tsavorite_reg(void) {
   ggml_tsavorite_log_type_val = GGML_TSAVORITE_LOG_NONE;
   ggml_tsavorite_kernel_mode_flag = GGML_TSAVORITE_KERNEL_MODE_MLIR;
   GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
-  ensure_tsi_runtime_initialized();
+
+  init_shared_state();
+
+  if (state->init_done == true) {
+      GGML_LOG_DEBUG("%s: Initialization already done, calling tsi_initialize...\n", __func__);
+      ensure_tsi_runtime_initialized();
+  } else {
+      state->init_done = true;
+      GGML_LOG_DEBUG("%s: Initialization not done, proceeding...\n", __func__);
+  }
+
   g_ggml_backend_tsavorite_reg.iface = ggml_backend_tsavorite_reg_i;
   g_ggml_backend_tsavorite_reg.context = NULL;
+  g_ggml_backend_tsavorite_reg.api_version = GGML_BACKEND_API_VERSION;
   g_ggml_backend_tsavorite_device.iface = ggml_backend_tsavorite_device_i;
   g_ggml_backend_tsavorite_device.reg = &g_ggml_backend_tsavorite_reg;
   g_ggml_backend_tsavorite_device.context = &g_ggml_ctx_dev_main;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -90,6 +90,16 @@ auto &loadResult_add          = g_rt.loadResult_add;
 auto &loadResult_mult         = g_rt.loadResult_mult;
 auto &loadResult_rms_norm     = g_rt.loadResult_rms_norm;
 
+// blob lifetime state machine
+enum BlobState : uint8_t {
+    BLOB_UNINITIALIZED = 0,   // no tables, no blobs
+    BLOB_TABLES_ALLOCATED,    // tables allocated, blobs may be null
+    BLOB_BLOBS_LOADED         // all blobs loaded successfully
+};
+
+BlobState blob_state = BLOB_UNINITIALIZED;
+uint32_t blob_tables_txes = 0;   // tracks num_of_txes used to size the tables
+
 } // anonymous namespace
 
 // =============================================================================
@@ -342,69 +352,132 @@ static std::string blob_prefix(const char *rel) {
     return tsavorite_llama_root() + rel;
 }
 
-static TsavoriteRuntimeState &rt = g_rt;
+static inline void tsi_blob_free_tables() {
+    // free pointer tables only (does NOT unload blobs)
+    free(loadResult_add);      loadResult_add = nullptr;
+    free(loadResult_mult);     loadResult_mult = nullptr;
+    free(loadResult_rms_norm); loadResult_rms_norm = nullptr;
 
-static void tsi_load_all_blobs() {
-    int i;
-    char blob_name[64];
+    free(blobDescriptor_add);      blobDescriptor_add = nullptr;
+    free(blobDescriptor_mult);     blobDescriptor_mult = nullptr;
+    free(blobDescriptor_rms_norm); blobDescriptor_rms_norm = nullptr;
 
-    
-    // already loaded
-    if (blobDescriptor_add || blobDescriptor_mult || blobDescriptor_rms_norm) {
-        return;
+    g_rt.blob_tables_txes = 0;
+    g_rt.blob_state = TsavoriteRuntimeState::BLOB_UNINITIALIZED;
+}
+
+static inline void tsi_blob_unload_only() {
+    // unload blobs if present, keep tables allocated
+    if (blobDescriptor_add) {
+        for (uint32_t i = 0; i < num_of_txes; ++i) {
+            if (blobDescriptor_add[i]) {
+                tsi_unload_blob(blobDescriptor_add[i]);
+                blobDescriptor_add[i] = nullptr;
+            }
+        }
+    }
+    if (blobDescriptor_mult) {
+        for (uint32_t i = 0; i < num_of_txes; ++i) {
+            if (blobDescriptor_mult[i]) {
+                tsi_unload_blob(blobDescriptor_mult[i]);
+                blobDescriptor_mult[i] = nullptr;
+            }
+        }
+    }
+    if (blobDescriptor_rms_norm) {
+        for (uint32_t i = 0; i < num_of_txes; ++i) {
+            if (blobDescriptor_rms_norm[i]) {
+                tsi_unload_blob(blobDescriptor_rms_norm[i]);
+                blobDescriptor_rms_norm[i] = nullptr;
+            }
+        }
     }
 
-    // allocate pointer tables (size = num_of_txes)
-    loadResult_add = (void **)calloc(num_of_txes, sizeof(void *));
-    loadResult_mult = (void **)calloc(num_of_txes, sizeof(void *));
+    // best-effort: clear loadResult_* entries too
+    if (loadResult_add)      memset(loadResult_add,      0, num_of_txes * sizeof(void *));
+    if (loadResult_mult)     memset(loadResult_mult,     0, num_of_txes * sizeof(void *));
+    if (loadResult_rms_norm) memset(loadResult_rms_norm, 0, num_of_txes * sizeof(void *));
+
+    g_rt.blob_state = TsavoriteRuntimeState::BLOB_TABLES_ALLOCATED;
+}
+
+static inline void tsi_blob_ensure_tables_allocated() {
+    if (g_rt.blob_state != TsavoriteRuntimeState::BLOB_UNINITIALIZED) {
+        // if sized for a different txe count, reset hard (future-proof)
+        if (g_rt.blob_tables_txes != num_of_txes) {
+            tsi_blob_unload_only();
+            tsi_blob_free_tables();
+        } else {
+            return;
+        }
+    }
+
+    loadResult_add      = (void **)calloc(num_of_txes, sizeof(void *));
+    loadResult_mult     = (void **)calloc(num_of_txes, sizeof(void *));
     loadResult_rms_norm = (void **)calloc(num_of_txes, sizeof(void *));
 
-    blobDescriptor_add = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
-    blobDescriptor_mult = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
+    blobDescriptor_add      = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
+    blobDescriptor_mult     = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
     blobDescriptor_rms_norm = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
 
     if (!loadResult_add || !loadResult_mult || !loadResult_rms_norm ||
         !blobDescriptor_add || !blobDescriptor_mult || !blobDescriptor_rms_norm) {
+        // free any partial allocations before abort
+        tsi_blob_free_tables();
         fprintf(stderr, "Failed to allocate blob tables (num_of_txes=%u)\n", (unsigned)num_of_txes);
         abort();
     }
 
+    g_rt.blob_tables_txes = num_of_txes;
+    g_rt.blob_state = TsavoriteRuntimeState::BLOB_TABLES_ALLOCATED;
+}
 
-    for (int i = 0; i < num_of_txes; ++i) {
+static void tsi_load_all_blobs() {
+    char blob_name[64];
+    uint32_t failed_txe = 0;
+
+    // already loaded
+    if (g_rt.blob_state == TsavoriteRuntimeState::BLOB_BLOBS_LOADED) {
+        return;
+    }
+
+    // ensure tables exist (allocates if needed)
+    tsi_blob_ensure_tables_allocated();
+
+    for (uint32_t i = 0; i < num_of_txes; ++i) {
         char name_add[64];
         char name_mult[64];
         char name_rms[64];
 
-        snprintf(name_add,  sizeof(name_add),  "txe_add_dev%d", i);
-        snprintf(name_mult, sizeof(name_mult), "txe_mult_dev%d", i);
-        snprintf(name_rms,  sizeof(name_rms),  "txe_rms_norm_dev%d", i);
+        snprintf(name_add,  sizeof(name_add),  "txe_add_dev%u",  i);
+        snprintf(name_mult, sizeof(name_mult), "txe_mult_dev%u", i);
+        snprintf(name_rms,  sizeof(name_rms),  "txe_rms_norm_dev%u", i);
 
-        // MUST end in ".../blobs/txe_add"
+        failed_txe = i;
+
+        // ADD
         loadResult_add[i] = tsi_load_blob(
-            i,
+            (int)i,
             name_add,
             blob_prefix(
                 "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"
             ).c_str()
         );
-
         if (!loadResult_add[i]) {
             strcpy(blob_name, name_add);
             goto error;
-       }
-
-       blobDescriptor_add[i] =
+        }
+        blobDescriptor_add[i] =
             static_cast<BlobDescriptor *>(loadResult_add[i]);
 
-        // MUST end in ".../blobs/txe_mult"
-       loadResult_mult[i] = tsi_load_blob(
-            i,
+        // MULT
+        loadResult_mult[i] = tsi_load_blob(
+            (int)i,
             name_mult,
             blob_prefix(
                 "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"
             ).c_str()
         );
-
         if (!loadResult_mult[i]) {
             strcpy(blob_name, name_mult);
             goto error;
@@ -412,15 +485,14 @@ static void tsi_load_all_blobs() {
         blobDescriptor_mult[i] =
             static_cast<BlobDescriptor *>(loadResult_mult[i]);
 
-        // MUST end in ".../blobs/txe_rms_norm"
-       loadResult_rms_norm[i] = tsi_load_blob(
-            i,
+        // RMS NORM
+        loadResult_rms_norm[i] = tsi_load_blob(
+            (int)i,
             name_rms,
             blob_prefix(
                 "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"
             ).c_str()
         );
-
         if (!loadResult_rms_norm[i]) {
             strcpy(blob_name, name_rms);
             goto error;
@@ -428,40 +500,41 @@ static void tsi_load_all_blobs() {
         blobDescriptor_rms_norm[i] =
             static_cast<BlobDescriptor *>(loadResult_rms_norm[i]);
     }
+
+    // success
+    g_rt.blob_state = TsavoriteRuntimeState::BLOB_BLOBS_LOADED;
     return;
+
 error:
     fprintf(stderr,
-            "Failed to load blob (txe=%u, name=%s)\n", i, blob_name);
+        "Failed to load blob (txe=%u, name=%s)\n",
+        failed_txe, blob_name
+    );
+
+    // Cleanup: unload any blobs that did load + free tables before abort
+    tsi_blob_unload_only();   // unload any blobs that succeeded
+    tsi_blob_free_tables();   // free calloc’d tables
+
+    // preserve existing hard‑fail behavior
     tsi_cleanup();
     abort();
 }
 
-
 static void tsi_unload_all_blobs() {
-    for (uint32_t i = 0; i < num_of_txes; ++i) {
-        if (blobDescriptor_add && blobDescriptor_add[i]) {
-            tsi_unload_blob(blobDescriptor_add[i]);
-            blobDescriptor_add[i] = nullptr;
-        }
-        if (blobDescriptor_mult && blobDescriptor_mult[i]) {
-            tsi_unload_blob(blobDescriptor_mult[i]);
-            blobDescriptor_mult[i] = nullptr;
-        }
-        if (blobDescriptor_rms_norm && blobDescriptor_rms_norm[i]) {
-            tsi_unload_blob(blobDescriptor_rms_norm[i]);
-            blobDescriptor_rms_norm[i] = nullptr;
-        }
+    if (g_rt.blob_state == TsavoriteRuntimeState::BLOB_UNINITIALIZED) {
+        return;
     }
 
-    free(loadResult_add);        loadResult_add = nullptr;
-    free(loadResult_mult);       loadResult_mult = nullptr;
-    free(loadResult_rms_norm);   loadResult_rms_norm = nullptr;
+    // if blobs were loaded (or partially loaded), unload them
+    if (g_rt.blob_state == TsavoriteRuntimeState::BLOB_BLOBS_LOADED ||
+        g_rt.blob_state == TsavoriteRuntimeState::BLOB_TABLES_ALLOCATED) {
+        tsi_blob_unload_only();
+    }
 
-    free(blobDescriptor_add);    blobDescriptor_add = nullptr;
-    free(blobDescriptor_mult);   blobDescriptor_mult = nullptr;
-    free(blobDescriptor_rms_norm); blobDescriptor_rms_norm = nullptr;
-    return;
+    // always free tables after unload
+    tsi_blob_free_tables();
 }
+
 
 // Centralized TSI runtime initialization - called once globally
 //

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -457,7 +457,7 @@ static void tsi_load_all_blobs() {
 
         // ADD
         loadResult_add[i] = tsi_load_blob(
-            (int)i,
+            i,
             name_add,
             blob_prefix(
                 "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"
@@ -472,7 +472,7 @@ static void tsi_load_all_blobs() {
 
         // MULT
         loadResult_mult[i] = tsi_load_blob(
-            (int)i,
+            i,
             name_mult,
             blob_prefix(
                 "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"
@@ -487,7 +487,7 @@ static void tsi_load_all_blobs() {
 
         // RMS NORM
         loadResult_rms_norm[i] = tsi_load_blob(
-            (int)i,
+            i,
             name_rms,
             blob_prefix(
                 "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"
@@ -541,7 +541,7 @@ static void tsi_unload_all_blobs() {
 
 static void ensure_tsi_runtime_initialized() {
     if (runtime_initialized) {
-        printf("\n tsavorite backend already initialized \n");
+        GGML_TSAVORITE_LOG_INFO("\n tsavorite backend already initialized \n");
         return;
     }
     std::string mainProfilerName = "OPU ";

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -559,7 +559,7 @@ static void ensure_tsi_runtime_initialized() {
     multi_thread_enable = cfg.has_mt ? cfg.mt_enable : false;
 
     // Just to Test
-    printf("\nANOOP TSI deploy yaml=%s txe_count=%u multi_thread_enable=%d\n",
+    printf("\n TSI deploy yaml=%s txe_count=%u multi_thread_enable=%d\n",
              yaml_path.c_str(), (unsigned)num_of_txes, (int)multi_thread_enable);
 
     if (txe <= 0) txe = 1;

--- a/tsavorite-model-deployment.yaml
+++ b/tsavorite-model-deployment.yaml
@@ -1,0 +1,3 @@
+# Tsavorite deployment config
+txe_count: 2
+multi_thread_enable: true


### PR DESCRIPTION


Address following
@FIR-1701 - llama.cpp: tsi_load/tsi_unload Blob with some improvement


POsix log
./build-posix/bin/llama-cli-original -p "my cat's name is" -m /proj/rel/sw/ggml/models/tinyllama-vo-5m-para.gguf  --device tSavorite  -c 12288 --temp 0.0 --n-predict 4 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5  --no-warmup --no-conversation

TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=2 multi_thread_enable=1
 my cat's name is Tim. He has



llama_perf_sampler_print:    sampling time =       9.83 ms /    11 runs   (    0.89 ms per token,  1119.59 tokens per second)
llama_perf_context_print:        load time =     399.62 ms
llama_perf_context_print: prompt eval time =     220.88 ms /     7 tokens (   31.55 ms per token,    31.69 tokens per second)
llama_perf_context_print:        eval time =     142.94 ms /     3 runs   (   47.65 ms per token,    20.99 tokens per second)
llama_perf_context_print:       total time =     553.47 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          112             196            129478           1156.05
  MUL              OPU          119             209            137112           1152.20
  RMS_NORM         OPU          119             119             82543            693.64
  MUL_MAT          CPU         1928               0             99148             51.43
  CONT             CPU          428               0             12932             30.21
  RESHAPE          CPU          593               0               129              0.22
  VIEW             CPU          942               0                96              0.10
  PERMUTE          CPU          717               0                93              0.13
  TRANSPOSE        CPU          185               0                33              0.18
  GET_ROWS         CPU           61               0              1348             22.10
  SET_ROWS         CPU          419               0               259              0.62
  SOFT_MAX         CPU          219               0             14448             65.97
  ROPE             CPU          430               0               709              1.65
  GLU              OPU           56              98             70483           1258.62

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    33.0700   33.0700     28.1000  [ 5.21%] [Thread] tsi::runtime::TsavRTPosix::initialize
    1     4.8060    4.8060      4.0540  └─ [7.57e-01%] tsi::runtime::TsavRTPosix::initializeQueues
    1     0.6990    0.6990      0.6990    └─ [1.10e-01%] tsi::runtime::TsavRT::awaitCommandListCompletion
    1     0.0530    0.0530      0.0480    └─ [8.35e-03%] tsi::runtime::TsavRT::finalizeCommandList
    1     0.0050    0.0050      0.0050      └─ [7.88e-04%] tsi::runtime::executeWithTimeout
    1     0.1640    0.1640      0.1640  └─ [2.58e-02%] tsi::runtime::TsavRT::initialize
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     6.8610    6.8610      0.0000  [ 1.08%] [Thread] tsi::runtime::TsavRT::finalize
    1   528.6455  528.6455    528.6455  └─ [83.29%] TXE 0 Idle
    2     0.2590    0.1295      0.2590  └─ [4.08e-02%] tsi::runtime::executeWithTimeout
    2     0.0080    0.0040      0.0080  └─ [1.26e-03%] tsi::runtime::TsavRT::deallocate
    1     0.0050    0.0050      0.0050  └─ [7.92e-04%] Command{command=4 (RELEASE), blob_args=[0[0], 3[0x3], 4[0x...
    1     0.0020    0.0020      0.0020  └─ [3.15e-04%] RELEASE Command Execution
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  448   122.9730    0.2745      0.0000  [19.37%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
  448   522.5459    1.1664    522.5459  └─ [82.33%] TXE 0 Idle
  148    14.0518    0.0949     14.0518  └─ [ 2.21%] [ txe_add ]
  158    13.6389    0.0863     13.6389  └─ [ 2.15%] [ txe_mult ]
   74     9.4289    0.1274      9.4289  └─ [ 1.49%] [ txe_swiglu ]
   68     7.5857    0.1116      7.5857  └─ [ 1.20%] [ txe_rms_norm ]
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  448    89.4080    0.1996      0.0000  [14.09%] [Thread] tsi::runtime::TsavRTPosix::loadBlob
  448   522.3698    1.1660    522.3698  └─ [82.30%] TXE 0 Idle
  896    80.1560    0.0895     80.1560  └─ [12.63%] tsi::runtime::executeWithTimeout
  448    15.9564    0.0356     15.9564  └─ [ 2.51%] Command{command=2 (LOAD_BLOB), blob_args=[140505491269248[0x7...
  448     0.0540  1.21e-04      0.0540  └─ [8.51e-03%] LOAD_BLOB Command Execution
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTPosix::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  448    75.2270    0.1679      0.0000  [11.85%] [Thread] tsi::runtime::TsavRTPosix::unloadBlob
  448   522.7221    1.1668    522.7221  └─ [82.35%] TXE 0 Idle
  896    63.2360    0.0706     63.2360  └─ [ 9.96%] tsi::runtime::executeWithTimeout
  448     3.2599    0.0073      3.2599  └─ [5.14e-01%] Command{command=3 (UNLOAD_BLOB), blob_args=[14050549126924...
  448     0.1530  3.42e-04      0.1530  └─ [2.41e-02%] UNLOAD_BLOB Command Execution
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  449   108.8600    0.2424      3.6220  [17.15%] [Thread] tsi::runtime::TsavRT::processResponses
  449   105.2380    0.2344    105.2380  └─ [16.58%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     0.0800    0.0800      0.0610  [1.26e-02%] [Thread] OPU 
    1     0.0190    0.0190      0.0190  └─ [2.99e-03%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] txe_rms_norm (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  204    12.0940    0.0593     11.8360  [ 1.91%] [Thread] txe_rms_norm
  204     0.2580    0.0013      0.2580  └─ [4.06e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] txe_swiglu (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  222    15.0290    0.0677     14.7190  [ 2.37%] [Thread] txe_swiglu
  222     0.3100    0.0014      0.3100  └─ [4.88e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  448     6.0990    0.0136      5.5180  [9.61e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
  448     0.5810    0.0013      0.5810  └─ [9.15e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] txe_add (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  444    17.8410    0.0402     17.3140  [ 2.81%] [Thread] txe_add
  444     0.5270    0.0012      0.5270  └─ [8.30e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] txe_mult (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  474    19.4740    0.0411     18.8960  [ 3.07%] [Thread] txe_mult
  474     0.5780    0.0012      0.5780  └─ [9.11e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] TXE 0 Idle Time (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  448     0.4570    0.0010      0.4570  [7.20e-02%] [Thread] tsi::runtime::TsavRT::deallocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  448     1.6420    0.0037      1.6420  [2.59e-01%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  450     0.6690    0.0015      0.6690  [1.05e-01%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::executeWithTimeout (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1348   514.1620    0.3814    514.1620  [81.01%] [Thread] tsi::runtime::executeWithTimeout
========================================================================================================================
    -   634.7270    0.0000    634.7270  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.9978
------------------------------------------------------------------------------------------------------------------------

[akapoor@wspd0 llama.cpp]$ 
