### PR TITLE
@FIR-1741 - Ollama Crash: For Multi-Txe case

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -118,15 +118,18 @@ auto &loadResult_mult         = g_rt.loadResult_mult;
 auto &loadResult_rms_norm     = g_rt.loadResult_rms_norm;
 } // anonymous namespace
 
+constexpr int kMaxBacktraceFrames = 64;
+constexpr int kSignalExitBase     = 128;
+
 static void tsavorite_sig_handler(int sig) {
-    void *array[64];
-    int size = backtrace(array, 64);
+    void *array[kMaxBacktraceFrames];
+    int size = backtrace(array, kMaxBacktraceFrames);
 
     fprintf(stderr, "\n\n=== TSAVORITE FATAL SIGNAL %d ===\n", sig);
     backtrace_symbols_fd(array, size, STDERR_FILENO);
     fprintf(stderr, "=== END BACKTRACE ===\n");
 
-    _exit(128 + sig); // hard exit, no cleanup
+    _exit(kSignalExitBase + sig); // hard exit, no cleanup
 }
 
 static void tsavorite_install_signal_handlers() {
@@ -538,7 +541,6 @@ static void tsi_load_all_blobs() {
         char name_add[64];
         char name_mult[64];
         char name_rms[64];
-       // packed_args[i] = tsi_alloc(100*8, tsi::MemorySpace::SHARED_DRAM_TS);
 
         snprintf(name_add,  sizeof(name_add),  "txe_add_dev%u",  i);
         snprintf(name_mult, sizeof(name_mult), "txe_mult_dev%u", i);
@@ -630,6 +632,11 @@ static inline void tsi_init_per_txe_state_once() {
     // allocate device_free[]
     if (!device_free) {
         device_free = (bool*)calloc(num_of_txes, sizeof(bool));
+        if (!device_free) {
+            fprintf(stderr, "ERROR: failed to allocate device_free array (calloc failed)\n");
+            tsi_cleanup();
+            abort();
+        }
         for (uint32_t i = 0; i < num_of_txes; ++i) device_free[i] = true;
     }
 
@@ -1161,12 +1168,12 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
     void *commandList = tsi_create_command_list(deviceId);
 
     if ((uint32_t)deviceId >= num_of_txes) {
-        printf("ERROR: deviceId=%d out of range num_of_txes=%u\n", deviceId, num_of_txes);
+        fprintf(stderr, "ERROR: deviceId=%d out of range num_of_txes=%u\n", deviceId, num_of_txes);
         tsi_cleanup();
         abort();
     }
     if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
-        printf("ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
+        fprintf(stderr, "ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
            deviceId, packed_args.size(), num_of_txes);
         tsi_cleanup();
         abort();
@@ -1192,7 +1199,7 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
     p[idx++] = (int64_t)C->shape[0];
 
     if (idx != kPackedArgsI64) {
-        printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+        fprintf(stderr, "ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
         tsi_cleanup();
         abort();
     }
@@ -1201,7 +1208,7 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add[deviceId], packedHandle);
 
     if (!blobExecuteCmd) {
-        printf("tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
+        fprintf(stderr, "tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
                                      (unsigned long)deviceId, (char *)blobDescriptor_add[deviceId]);
         tsi_cleanup();
         abort();
@@ -1220,7 +1227,7 @@ static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
        #if NEW_HOST_CODE
            void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, 0);
            if (!commandList) {
-                printf("Command List Empt for ADD OPERATION on device 0\n");
+                fprintf(stderr, "Command List Empt for ADD OPERATION on device 0\n");
                 tsi_cleanup();
                 abort();
             }
@@ -1242,7 +1249,7 @@ static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
    // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
    void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, deviceId);
    if (!commandList) {
-       printf("Command List Empt for ADD on device %d\n", deviceId);
+       fprintf(stderr, "Command List Empt for ADD on device %d\n", deviceId);
        release_device(deviceId);
        tsi_cleanup();
        abort();
@@ -1267,13 +1274,13 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
     void *commandList = tsi_create_command_list(deviceId);
 
     if ((uint32_t)deviceId >= num_of_txes) {
-        printf("ERROR: deviceId=%d out of range num_of_txes=%u\n", deviceId, num_of_txes);
+        fprintf(stderr, "ERROR: deviceId=%d out of range num_of_txes=%u\n", deviceId, num_of_txes);
         tsi_cleanup();
         abort();
     }
 
     if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
-        printf("ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
+        fprintf(stderr, "ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
            deviceId, packed_args.size(), num_of_txes);
         tsi_cleanup();
         abort();
@@ -1299,7 +1306,7 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
     p[idx++] = (int64_t)C->shape[0];
 
     if (idx != kPackedArgsI64) {
-        printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+        fprintf(stderr, "ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
         tsi_cleanup();
         abort();
     }
@@ -1307,7 +1314,7 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
     const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed_args[deviceId]);
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult[deviceId], packedHandle);
     if (!blobExecuteCmd) {
-        printf("tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
+        fprintf(stderr, "tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
                                      (unsigned long)deviceId, (char *)blobDescriptor_mult[deviceId]);
         tsi_cleanup();
         abort();
@@ -1325,7 +1332,7 @@ static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
         #if NEW_HOST_CODE
             void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, 1);
             if (!commandList) {
-                printf("Command List Empt for MUL OPERATION on device 0\n");
+                fprintf(stderr, "Command List Empt for MUL OPERATION on device 0\n");
                 tsi_cleanup();
                 abort();
             }
@@ -1341,7 +1348,7 @@ static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
    // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
    void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, deviceId);
    if (!commandList) {
-        printf("Command List Empt for MUL OPERATION on device %d\n", deviceId);
+        fprintf(stderr, "Command List Empt for MUL OPERATION on device %d\n", deviceId);
         release_device(deviceId);
         tsi_cleanup();
         abort();
@@ -1366,13 +1373,13 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
     void *commandList = tsi_create_command_list(deviceId);
 
     if ((uint32_t)deviceId >= num_of_txes) {
-        printf("ERROR: deviceId=%d out of range num_of_txes=%u\n", deviceId, num_of_txes);
+        fprintf(stderr, "ERROR: deviceId=%d out of range num_of_txes=%u\n", deviceId, num_of_txes);
         tsi_cleanup();
         abort();
     }
 
     if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
-        printf("ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
+        fprintf(stderr, "ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
            deviceId, packed_args.size(), num_of_txes);
         tsi_cleanup();
         abort();
@@ -1400,7 +1407,7 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
     p[idx++] = (int64_t)C->offset;
 
     if (idx != kPackedArgsI64) {
-        printf("ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
+        fprintf(stderr, "ERROR: packed-args idx=%d expected=%ld\n", idx, (long)kPackedArgsI64);
         tsi_cleanup();
         abort();
     }
@@ -1408,7 +1415,7 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
     const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed_args[deviceId]);
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm[deviceId], packedHandle);
     if (!blobExecuteCmd) {
-        printf("tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
+        fprintf(stderr, "tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
                                      (unsigned long)deviceId, (char *)blobDescriptor_rms_norm[deviceId]);
         tsi_cleanup();
         abort();
@@ -1426,7 +1433,7 @@ static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
         #if NEW_HOST_CODE
             void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, 0);
             if (!commandList) {
-                printf("Command List Empt for RMS OPERATION  on device 0\n");
+                fprintf(stderr, "Command List Empt for RMS OPERATION  on device 0\n");
                 tsi_cleanup();
                 abort();
             }
@@ -1442,7 +1449,7 @@ static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
     // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
     void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, deviceId);
     if (!commandList) {
-        printf("Command List Empt for RMS OPERATION on device %d\n", deviceId);
+        fprintf(stderr, "Command List Empt for RMS OPERATION on device %d\n", deviceId);
         release_device(deviceId);
         tsi_cleanup();
         abort();

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -24,6 +24,12 @@
 #include <inttypes.h>
 #include <math.h>
 #include <iostream>
+#include <filesystem>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <fstream>
 #include <cctype>
 #include <cstdlib>
@@ -46,7 +52,7 @@
 using namespace tsi::runtime;
 
 // This will  go in deployment file at next PR
-#define NUM_OF_TXES 1
+#define NUM_OF_TXES 2
 
 // ggml-tsavorite.cpp
 namespace {
@@ -56,10 +62,16 @@ struct TsavoriteRuntimeState {
     uint32_t num_of_txes = 1;
     bool *device_free = nullptr;
     bool multi_thread_enable = false;
+    // one packed-args buffer per TXE
+    //void *packed_args[NUM_OF_TXES];
+    std::vector<void *> packed_args;
 
     std::vector<std::thread> workers;
+    std::mutex workers_mutex;
     std::mutex device_mutex;
     std::mutex tsi_pack_mutex;
+    // Global guard for TsavRT shim calls (stability for Ollama multi-threading)
+    std::mutex tsavrt_api_mutex;   // Global guard for TsavRT shim calls
     std::condition_variable device_cv;
     // blobs
     BlobDescriptor **blobDescriptor_add = nullptr;
@@ -87,10 +99,13 @@ static TsavoriteRuntimeState g_rt;
 auto &num_of_txes = g_rt.num_of_txes;
 auto &device_free = g_rt.device_free;
 auto &multi_thread_enable     = g_rt.multi_thread_enable;
+auto &packed_args     = g_rt.packed_args;
 
 auto &workers = g_rt.workers;
+auto &workers_mutex = g_rt.workers_mutex;
 auto &device_mutex = g_rt.device_mutex;
 auto &tsi_pack_mutex = g_rt.tsi_pack_mutex;
+auto &tsavrt_api_mutex = g_rt.tsavrt_api_mutex;
 auto &device_cv = g_rt.device_cv;
 
 auto &blobDescriptor_add      = g_rt.blobDescriptor_add;
@@ -101,6 +116,31 @@ auto &loadResult_add          = g_rt.loadResult_add;
 auto &loadResult_mult         = g_rt.loadResult_mult;
 auto &loadResult_rms_norm     = g_rt.loadResult_rms_norm;
 } // anonymous namespace
+
+
+
+
+#include <execinfo.h>
+#include <signal.h>
+
+static void tsavorite_sig_handler(int sig) {
+    void *array[64];
+    int size = backtrace(array, 64);
+
+    fprintf(stderr, "\n\n=== TSAVORITE FATAL SIGNAL %d ===\n", sig);
+    backtrace_symbols_fd(array, size, STDERR_FILENO);
+    fprintf(stderr, "=== END BACKTRACE ===\n");
+
+    _exit(128 + sig); // hard exit, no cleanup
+}
+
+static void tsavorite_install_signal_handlers() {
+    signal(SIGSEGV, tsavorite_sig_handler);
+    signal(SIGABRT, tsavorite_sig_handler);
+    signal(SIGBUS,  tsavorite_sig_handler);
+    signal(SIGILL,  tsavorite_sig_handler);
+    signal(SIGFPE,  tsavorite_sig_handler);
+}
 
 // =============================================================================
 // YAML deployment parsing (no external yaml lib)
@@ -388,13 +428,31 @@ static std::string blob_prefix(const char *rel) {
 
 static inline void tsi_blob_free_tables() {
     // free pointer tables only (does NOT unload blobs)
-    free(loadResult_add);      loadResult_add = nullptr;
-    free(loadResult_mult);     loadResult_mult = nullptr;
-    free(loadResult_rms_norm); loadResult_rms_norm = nullptr;
+    if (loadResult_add) {
+        free(loadResult_add);
+        loadResult_add = nullptr;
+    }
+    if (loadResult_mult) {
+        free(loadResult_mult);
+        loadResult_mult = nullptr;
+    }
+    if (loadResult_rms_norm) {
+        free(loadResult_rms_norm);
+        loadResult_rms_norm = nullptr;
+    }
 
-    free(blobDescriptor_add);      blobDescriptor_add = nullptr;
-    free(blobDescriptor_mult);     blobDescriptor_mult = nullptr;
-    free(blobDescriptor_rms_norm); blobDescriptor_rms_norm = nullptr;
+    if (blobDescriptor_add) {
+        free(blobDescriptor_add);
+        blobDescriptor_add = nullptr;
+    }
+    if (blobDescriptor_mult) {
+        free(blobDescriptor_mult);
+        blobDescriptor_mult = nullptr;
+    }
+    if (blobDescriptor_rms_norm) {
+        free(blobDescriptor_rms_norm);
+        blobDescriptor_rms_norm = nullptr;
+    }
 
     g_rt.blob_tables_txes = 0;
     g_rt.blob_state = TsavoriteRuntimeState::BLOB_UNINITIALIZED;
@@ -477,11 +535,15 @@ static void tsi_load_all_blobs() {
 
     // ensure tables exist (allocates if needed)
     tsi_blob_ensure_tables_allocated();
+    
+    // size matches runtime txe_count
+    //packed_args.resize(num_of_txes, nullptr);
 
     for (uint32_t i = 0; i < num_of_txes; ++i) {
         char name_add[64];
         char name_mult[64];
         char name_rms[64];
+       // packed_args[i] = tsi_alloc(100*8, tsi::MemorySpace::SHARED_DRAM_TS);
 
         snprintf(name_add,  sizeof(name_add),  "txe_add_dev%u",  i);
         snprintf(name_mult, sizeof(name_mult), "txe_mult_dev%u", i);
@@ -569,6 +631,29 @@ static void tsi_unload_all_blobs() {
     tsi_blob_free_tables();
 }
 
+static inline void tsi_init_per_txe_state_once() {
+    // allocate device_free[]
+    if (!device_free) {
+        device_free = (bool*)calloc(num_of_txes, sizeof(bool));
+        for (uint32_t i = 0; i < num_of_txes; ++i) device_free[i] = true;
+    }
+
+    // allocate per-TXE packed args buffer (device-visible)
+    constexpr size_t kPackedArgsBytesMax = 2048;
+
+    if (packed_args.size() != num_of_txes) {
+        packed_args.assign(num_of_txes, nullptr);
+        for (uint32_t i = 0; i < num_of_txes; ++i) {
+            if (!packed_args[i]) {
+                packed_args[i] = tsi_alloc(kPackedArgsBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                if (!packed_args[i]) {
+                    fprintf(stderr, "tsi_alloc failed for packed_args[%u]\n", i);
+                    abort();
+                }
+            }
+        }
+    }
+}
 
 // Centralized TSI runtime initialization - called once globally
 //
@@ -578,6 +663,8 @@ static void ensure_tsi_runtime_initialized() {
         GGML_TSAVORITE_LOG_INFO("\n tsavorite backend already initialized \n");
         return;
     }
+    tsi_blob_free_tables();
+
     std::string mainProfilerName = "OPU ";
     tsirt::utils::TSIProfiler::initialize();
 
@@ -598,28 +685,33 @@ static void ensure_tsi_runtime_initialized() {
     if (txe > (int)NUM_OF_TXES) txe = (int)NUM_OF_TXES;
 
     tsi_initialize(num_of_txes, NULL);
+    tsavorite_install_signal_handlers();
 
     if (multi_thread_enable) {
         // Temporarily disabled; will be enabled in the next release to avoid collateral impact
         tsi_load_all_blobs();
+    } else {
+        #if NEW_HOST_CODE
+            tsi_load_all_blobs();
+        #endif
     }
-    device_free = (bool *)malloc(num_of_txes * sizeof(bool));
+
+    tsi_init_per_txe_state_once();
+
     if (!device_free) {
         fprintf(stderr, "Failed to allocate device_free\n");
         tsi_unload_all_blobs();
+        printf("\n finalize 1 \n");
         tsi_finalize();
         abort();
     }
     
-    for (uint32_t i = 0; i < num_of_txes; i++) {
-        device_free[i] = true;
-    }
-
     workers.reserve(num_of_txes);
     runtime_initialized = true;
     GGML_TSAVORITE_LOG_INFO("Profiler and TSI runtime initialized early in registration\n");
     return;
 }
+
 #ifdef USE_COMMAND_BUFFERS
 typedef struct _txe_command_queue_t *txe_command_queue_s;
 typedef struct _txe_dispatch_queue_t *txe_dispatch_queue_s;
@@ -1007,19 +1099,22 @@ static void _mlir_ciface_txe_mult_test (void *src0, void *src1, void *res)
 static inline int acquire_device_blocking() {
     std::unique_lock<std::mutex> lock(device_mutex);
 
-    device_cv.wait(lock, [] {
-        for (uint32_t i = 0; i < num_of_txes; ++i)
-            if (device_free[i])
-                return true;
+    device_cv.wait(lock, []() {
+        if (!device_free) return false;
+        for (uint32_t i = 0; i < num_of_txes; ++i) {
+            if (device_free[i]) return true;
+        }
         return false;
     });
 
     for (uint32_t i = 0; i < num_of_txes; ++i) {
         if (device_free[i]) {
             device_free[i] = false;
-            return i;
+            return (int)i;
         }
     }
+
+    // Should be unreachable because wait predicate ensures availability
     return -1;
 }
 
@@ -1035,26 +1130,26 @@ static inline void release_device(int deviceId) {
 // ============================================================
 
 static inline void join_all_workers() {
-    for (auto &t : workers) {
-        if (t.joinable())
-            t.join();
-    }
-    workers.clear();
-
+    std::vector<std::thread> local;
     {
-        std::lock_guard<std::mutex> lock(device_mutex);
-        for (uint32_t i = 0; i < num_of_txes; ++i)
-            device_free[i] = true;
+        std::lock_guard<std::mutex> lk(workers_mutex);
+        if (workers.empty()) return;
+        local.swap(workers);   // take ownership, release lock early
     }
-    device_cv.notify_all();
+
+    for (auto &t : local) {
+        if (t.joinable()) t.join();
+    }
 }
 
 static void tsi_blob_execution_internal(void *commandList) {
   // Enqueue & run
+  std::lock_guard<std::mutex> rt_lock(tsavrt_api_mutex);
   tsi_finalize_command_list(commandList);
   tsi_wait(commandList);
   return;
 }
+
 
 //lock goes out of scope
 // <--- function scope ends here mutex will be released
@@ -1063,18 +1158,29 @@ static void tsi_blob_execution_internal(void *commandList) {
 static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI_DeviceIdType deviceId) {
     constexpr int64_t kPackedArgsI64   = 9;
     constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
+    
+    // One lock to protect ALL TsavRT operations + packed_args usage
+    std::lock_guard<std::mutex> rt_lock(tsavrt_api_mutex);
 
     std::lock_guard<std::mutex> lock(tsi_pack_mutex);
 
     void *commandList = tsi_create_command_list(deviceId);
 
-    void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
-    if(!packed) {
-        printf("\nFailed to allocate packed argument memory in tsi_alloc\n");
+    if ((uint32_t)deviceId >= num_of_txes) {
+        printf("ERROR: deviceId=%d out of range num_of_txes=%u\n", deviceId, num_of_txes);
         tsi_cleanup();
         abort();
     }
-    auto *p = static_cast<int64_t *>(packed);
+
+    //void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+    if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
+        printf("ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
+           deviceId, packed_args.size(), num_of_txes);
+        tsi_cleanup();
+        abort();
+    }
+
+    auto *p = static_cast<int64_t *>(packed_args[deviceId]);
 
     MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
     MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
@@ -1099,7 +1205,7 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
         abort();
     }
 
-    const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
+    const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed_args[deviceId]);
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add[deviceId], packedHandle);
 
     if (!blobExecuteCmd) {
@@ -1115,34 +1221,48 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
 }
 
 static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
+    tsi_init_per_txe_state_once();
+
     if (!multi_thread_enable) {
-      _mlir_ciface_txe_add_host(a, b, res);
       // Temporarily disabled; will be enabled in the next release to avoid collateral impact
        #if NEW_HOST_CODE
-       void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, 0);
-       if (!commandList) {
-            printf("Command List Empt for ADD OPERATION on device 0\n");
-            tsi_cleanup();
-            abort();
-        }
-        tsi_blob_execution_internal(commandList);
+           void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, 0);
+           if (!commandList) {
+                printf("Command List Empt for ADD OPERATION on device 0\n");
+                tsi_cleanup();
+                abort();
+            }
+            tsi_blob_execution_internal(commandList);
+       #else
+              _mlir_ciface_txe_add_host(a, b, res);
        #endif  /* NEW_HOST_CODE */
         return;
     }
 
-    int deviceId = acquire_device_blocking();
+    const int deviceId = acquire_device_blocking();
+    
+    if (deviceId < 0) {
+        fprintf(stderr, "Failed to acquire device for ADD\n");
+        tsi_cleanup();
+        abort();
+    }
 
    // IMPORTANT: pack args NOW while MemRefDescriptor fields are still correct
    void *commandList = _mlir_ciface_txe_add_host_internal(a, b, res, deviceId);
    if (!commandList) {
        printf("Command List Empt for ADD on device %d\n", deviceId);
+       release_device(deviceId);
        tsi_cleanup();
        abort();
     }
-    workers.emplace_back([=]() {
-        tsi_blob_execution_internal(commandList);
-        release_device(deviceId);
-    });
+
+   {
+       std::lock_guard<std::mutex> lk(workers_mutex);
+       workers.emplace_back([=]() {
+           tsi_blob_execution_internal(commandList);
+           release_device(deviceId);
+       });
+   }
 }
 
 
@@ -1150,17 +1270,27 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
     constexpr int64_t kPackedArgsI64   = 9;
     constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
 
+    // One lock to protect ALL TsavRT operations + packed_args usage
+    std::lock_guard<std::mutex> rt_lock(tsavrt_api_mutex);
     std::lock_guard<std::mutex> lock(tsi_pack_mutex);
 
     void *commandList = tsi_create_command_list(deviceId);
 
-    void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
-    if(!packed) {
-        printf("\nFailed to allocate packed argument memory in tsi_alloc\n");
+    if ((uint32_t)deviceId >= num_of_txes) {
+        printf("ERROR: deviceId=%d out of range num_of_txes=%u\n", deviceId, num_of_txes);
         tsi_cleanup();
         abort();
     }
-    auto *p = static_cast<int64_t *>(packed);
+
+    //void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+    if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
+        printf("ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
+           deviceId, packed_args.size(), num_of_txes);
+        tsi_cleanup();
+        abort();
+    }
+
+    auto *p = static_cast<int64_t *>(packed_args[deviceId]);
 
     MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
     MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
@@ -1185,7 +1315,7 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
         abort();
     }
 
-    const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
+    const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed_args[deviceId]);
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult[deviceId], packedHandle);
     if (!blobExecuteCmd) {
         printf("tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
@@ -1200,18 +1330,20 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
 
 
 static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
+    tsi_init_per_txe_state_once();
+
     if (!multi_thread_enable) {
-        _mlir_ciface_txe_mult_host(a, b, res);
-      
-      // Temporarily disabled; will be enabled in the next release to avoid collateral impact
+        // Temporarily disabled; will be enabled in the next release to avoid collateral impact
         #if NEW_HOST_CODE
-        void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, 1);
-       if (!commandList) {
-            printf("Command List Empt for MUL OPERATION on device 0\n");
-            tsi_cleanup();
-            abort();
-        }
-        tsi_blob_execution_internal(commandList);
+            void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, 1);
+            if (!commandList) {
+                printf("Command List Empt for MUL OPERATION on device 0\n");
+                tsi_cleanup();
+                abort();
+            }
+            tsi_blob_execution_internal(commandList);
+        #else
+            _mlir_ciface_txe_mult_host(a, b, res);
         #endif /* NEW_HOST_CODE */
         return;
     }
@@ -1222,13 +1354,17 @@ static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
    void *commandList = _mlir_ciface_txe_mult_host_internal(a, b, res, deviceId);
    if (!commandList) {
         printf("Command List Empt for MUL OPERATION on device %d\n", deviceId);
+        release_device(deviceId);
         tsi_cleanup();
         abort();
    }
-    workers.emplace_back([=]() {
-        tsi_blob_execution_internal(commandList);
-        release_device(deviceId);
-    });
+   {
+       std::lock_guard<std::mutex> lk(workers_mutex);
+       workers.emplace_back([=]() {
+           tsi_blob_execution_internal(commandList);
+           release_device(deviceId);
+       });
+   }
 }
 
 
@@ -1236,17 +1372,27 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
     constexpr int64_t kPackedArgsI64   = 20;
     constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
 
+    // One lock to protect ALL TsavRT operations + packed_args usage
+    std::lock_guard<std::mutex> rt_lock(tsavrt_api_mutex);
     std::lock_guard<std::mutex> lock(tsi_pack_mutex);
 
     void *commandList = tsi_create_command_list(deviceId);
 
-    void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
-    if(!packed) {
-        printf("\nFailed to allocate packed argument memory in tsi_alloc\n");
+    if ((uint32_t)deviceId >= num_of_txes) {
+        printf("ERROR: deviceId=%d out of range num_of_txes=%u\n", deviceId, num_of_txes);
         tsi_cleanup();
         abort();
     }
-    auto *p = static_cast<int64_t *>(packed);
+
+    //void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
+    if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
+        printf("ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
+           deviceId, packed_args.size(), num_of_txes);
+        tsi_cleanup();
+        abort();
+    }
+
+    auto *p = static_cast<int64_t *>(packed_args[deviceId]);
 
     MemRefDescriptor<Rank> *A = (MemRefDescriptor<Rank> *)a;
     MemRefDescriptor<Rank> *B = (MemRefDescriptor<Rank> *)b;
@@ -1273,7 +1419,7 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
         abort();
     }
 
-    const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed);
+    const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed_args[deviceId]);
     void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm[deviceId], packedHandle);
     if (!blobExecuteCmd) {
         printf("tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
@@ -1287,18 +1433,21 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
 } 
 
 static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
+    tsi_init_per_txe_state_once();
+
     if (!multi_thread_enable) {
-        _mlir_ciface_txe_rms_norm_host(a, b, buf);
       // Temporarily disabled; will be enabled in the next release to avoid collateral impact
-      #if NEW_HOST_CODE
-        void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, 0);
-       if (!commandList) {
-            printf("Command List Empt for RMS OPERATION  on device 0\n");
-            tsi_cleanup();
-            abort();
-        }
-        tsi_blob_execution_internal(commandList);
-      #endif  /* NEW_HOST_CODE */
+        #if NEW_HOST_CODE
+            void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, 0);
+            if (!commandList) {
+                printf("Command List Empt for RMS OPERATION  on device 0\n");
+                tsi_cleanup();
+                abort();
+            }
+            tsi_blob_execution_internal(commandList);
+        #else
+            _mlir_ciface_txe_rms_norm_host(a, b, buf);
+        #endif  /* NEW_HOST_CODE */
         return;
     }
 
@@ -1308,13 +1457,23 @@ static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
     void *commandList = _mlir_ciface_txe_rms_norm_host_internal(a, b, buf, deviceId);
     if (!commandList) {
         printf("Command List Empt for RMS OPERATION on device %d\n", deviceId);
+        release_device(deviceId);
         tsi_cleanup();
         abort();
     }
+#if 0
     workers.emplace_back([=]() {
         tsi_blob_execution_internal(commandList);
         release_device(deviceId);
     });
+#endif
+   {
+       std::lock_guard<std::mutex> lk(workers_mutex);
+       workers.emplace_back([=]() {
+           tsi_blob_execution_internal(commandList);
+           release_device(deviceId);
+       });
+   }
 }
 
 
@@ -1646,19 +1805,17 @@ static void ggml_tsavorite_free(struct ggml_backend_tsavorite_context *ctx) {
 
   GGML_TSAVORITE_LOG_INFO("Delaying tsi_finalize for 2 sec");
   if (runtime_initialized == true) {
-      sleep(2);
       runtime_initialized = false;
-      #ifndef GGML_TARGET_POSIX
-          if (multi_thread_enable) {
-              // Temporarily disabled; will be enabled in the next release to avoid collateral impact
-              tsi_unload_all_blobs();
-          }
-      #endif /* !GGML_TARGET_POSIX */
+      tsi_unload_all_blobs();
+
       if(device_free) {
           free(device_free);
          device_free = NULL;
-    }
+      }
+      sleep(2);
+      printf("\n finalize 2 \n");
       tsi_finalize();
+      printf("\n finalize 2 \n");
       tsirt::utils::TSIProfiler::finalize();
       sleep(2);
   }
@@ -1675,16 +1832,13 @@ tsi_cleanup() {
     if (runtime_initialized != true)
         return;
     runtime_initialized = false;
-    #ifndef GGML_TARGET_POSIX
-          if (multi_thread_enable) {
-              // Temporarily disabled; will be enabled in the next release to avoid collateral impact
-              tsi_unload_all_blobs();
-          }
-    #endif /* !GGML_TARGET_POSIX */
+    tsi_unload_all_blobs();
     if(device_free) {
         free(device_free);
         device_free = NULL;
     }
+    sleep(2);
+    printf("\n finalize 3 \n");
     tsi_finalize();
     GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
     tsirt::utils::TSIProfiler::finalize();
@@ -2498,12 +2652,16 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     return GGML_STATUS_SUCCESS;
 }
 
+
+static std::mutex g_tsavorite_compute_mutex;
+
 // nodes are intermediate which has multiple src tensors & operation
 // Here we create multiple thread
 // Each Thread run the command buffer & pick Tensor and execute and get the result back base on
 // async or sync all Compute wil finish all tensors execution
 static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
                                                      struct ggml_cgraph *cgraph) {
+std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
 #if 0
     GGML_LOG_INFO("Start %s\n", __func__);
     struct ggml_backend_tsavorite_context        * ctx     = backend->context;
@@ -3045,9 +3203,7 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
         node->perf_time_us += (INT64_MAX - t_start + t_end + 1);
     }
 #endif /* GGML_PERF-related flags */
-    if (multi_thread_enable) {
-      join_all_workers();
-     }
+    join_all_workers();
   } /* this is main for loop */
 
 
@@ -3056,6 +3212,8 @@ static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
   // return ggml_graph_compute(cgraph, &cplan);
   ggml_backend_tsavorite_device_rel(
       (struct ggml_backend_tsavorite_device_context *)backend->device->context);
+
+  join_all_workers();
   return GGML_STATUS_SUCCESS;
 
   GGML_UNUSED(backend);
@@ -3385,13 +3543,21 @@ static void ggml_backend_tsavorite_free(ggml_backend_t backend) {
   GGML_TSAVORITE_LOG_INFO("End %s\n", __func__);
 }
 
+#if 0
 static void ggml_backend_tsavorite_synchronize(ggml_backend_t backend) {
 // We need to implement ASYN  Method to take output of tensor data to input of other Tensor
 // We will evaluate and implement at later PR
 #ifdef SYNC_DEBUG
   usleep(100000);
 #endif /* SYNC_DEBUG */
+  
   TSI_UNUSED(backend);
+}
+#endif
+
+static void ggml_backend_tsavorite_synchronize(ggml_backend_t backend) {
+    join_all_workers();
+    (void)backend;
 }
 
 static ggml_backend_buffer_type_t
@@ -3434,6 +3600,29 @@ static void ggml_backend_tsavorite_set_n_cb(ggml_backend_t backend, int n_cb) {
   GGML_TSAVORITE_LOG_INFO("End %s\n", __func__);
 }
 
+#ifdef OLLAMA
+void
+tsi_log_profile_info() {
+    GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
+    tsi_unload_all_blobs();
+    if(device_free) {
+        free(device_free);
+        device_free = NULL;
+    }
+    printf("\n finalize 4 \n");
+    tsi_finalize();
+    tsirt::utils::TSIProfiler::finalize();
+    // Profiling results already printed during first cleanup
+    std::cout << "\nOPU Profiling Results:" << std::endl;
+    std::cout << tsirt::utils::TSIProfiler::getFormattedResults(
+                  /*truncateFuncNames*/ true)
+               << std::endl;
+    GGML_TSAVORITE_LOG_INFO("End %s\n", __func__);
+    fflush(stdout);
+    return;
+}
+#endif /* OLLAMA */
+
 static struct ggml_backend_i ggml_backend_tsavorite_i = {
     /* .get_name                = */ ggml_backend_tsavorite_name,
     /* .free                    = */ ggml_backend_tsavorite_free,
@@ -3447,7 +3636,16 @@ static struct ggml_backend_i ggml_backend_tsavorite_i = {
     /* .graph_plan_compute      = */ NULL,
     /* .graph_compute           = */ ggml_backend_tsavorite_graph_compute,
     /* .event_record            = */ NULL,
+#ifdef OLLAMA
     /* .event_wait              = */ NULL,
+    /* .graph_optimize          = */ NULL,
+    /* .graph_reserve           = */ NULL,
+    /* .buffer_size             = */ NULL,
+    /* .reset                   = */ NULL,
+    /* .profile                 = */ tsi_log_profile_info
+#else
+    /* .event_wait              = */ NULL
+#endif /* OLLAMA */
 };
 
 static ggml_guid_t ggml_backend_tsavorite_guid(void) {
@@ -3857,19 +4055,80 @@ static struct ggml_backend_reg_i ggml_backend_tsavorite_reg_i = {
     /* .get_proc_address = */ NULL,
 };
 
+#ifdef OLLAMA
+#define SHM_NAME "/ollama_init_shm"
+
+typedef struct {
+  bool init_done;
+} shared_state_t;
+
+static shared_state_t *state = NULL;
+
+static bool init_shared_state() {
+    int fd = shm_open(SHM_NAME, O_CREAT | O_RDWR, 0666);
+    if (fd == -1) {
+        perror("shm_open");
+        return false;
+    }
+
+    if (ftruncate(fd, sizeof(shared_state_t)) != 0) {
+        perror("ftruncate");
+        close(fd);
+        return false;
+    }
+
+    void *p = mmap(NULL,
+                   sizeof(shared_state_t),
+                   PROT_READ | PROT_WRITE,
+                   MAP_SHARED,
+                   fd,
+                   0);
+    close(fd);
+
+    if (p == MAP_FAILED) {
+        perror("mmap");
+        return false;
+    }
+
+    state = (shared_state_t *)p;
+    return true;
+}
+#endif /* OLLAMA */
 
 ggml_backend_reg_t ggml_backend_tsavorite_reg(void) {
-  ggml_tsavorite_log_type_val = GGML_TSAVORITE_LOG_NONE;
-  ggml_tsavorite_kernel_mode_flag = GGML_TSAVORITE_KERNEL_MODE_MLIR;
-  GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
-  ensure_tsi_runtime_initialized();
-  g_ggml_backend_tsavorite_reg.iface = ggml_backend_tsavorite_reg_i;
-  g_ggml_backend_tsavorite_reg.context = NULL;
-  g_ggml_backend_tsavorite_device.iface = ggml_backend_tsavorite_device_i;
-  g_ggml_backend_tsavorite_device.reg = &g_ggml_backend_tsavorite_reg;
-  g_ggml_backend_tsavorite_device.context = &g_ggml_ctx_dev_main;
-  GGML_TSAVORITE_LOG_INFO("End %s\n", __func__);
-  return &g_ggml_backend_tsavorite_reg;
+    ggml_tsavorite_log_type_val    = GGML_TSAVORITE_LOG_NONE;
+    ggml_tsavorite_kernel_mode_flag = GGML_TSAVORITE_KERNEL_MODE_MLIR;
+
+#ifdef OLLAMA
+    bool shm_ok = init_shared_state();
+
+    if (!shm_ok || state == NULL) {
+        // No shared memory available → per-process init
+        ensure_tsi_runtime_initialized();
+    } else {
+        // Shared memory available → exactly-once init
+        if (!state->init_done) {
+            state->init_done = true;
+            GGML_LOG_DEBUG("%s: Initialization not done, proceeding...\n", __func__);
+        } else {
+            ensure_tsi_runtime_initialized();
+        }
+        // else: already initialized in another process
+    }
+    g_ggml_backend_tsavorite_reg.api_version = GGML_BACKEND_API_VERSION;
+#else
+    ensure_tsi_runtime_initialized();
+    
+#endif /* OLLAMA */
+
+    g_ggml_backend_tsavorite_reg.iface = ggml_backend_tsavorite_reg_i;
+    g_ggml_backend_tsavorite_reg.context = NULL;
+
+    g_ggml_backend_tsavorite_device.iface   = ggml_backend_tsavorite_device_i;
+    g_ggml_backend_tsavorite_device.reg     = &g_ggml_backend_tsavorite_reg;
+    g_ggml_backend_tsavorite_device.context = &g_ggml_ctx_dev_main;
+
+    return &g_ggml_backend_tsavorite_reg;
 }
 
 GGML_BACKEND_DL_IMPL(ggml_backend_tsavorite_reg)

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -18,6 +18,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <execinfo.h>
+#include <signal.h>
 
 #include "ggml-tsavorite.h"
 #include <unistd.h>
@@ -63,7 +65,6 @@ struct TsavoriteRuntimeState {
     bool *device_free = nullptr;
     bool multi_thread_enable = false;
     // one packed-args buffer per TXE
-    //void *packed_args[NUM_OF_TXES];
     std::vector<void *> packed_args;
 
     std::vector<std::thread> workers;
@@ -116,12 +117,6 @@ auto &loadResult_add          = g_rt.loadResult_add;
 auto &loadResult_mult         = g_rt.loadResult_mult;
 auto &loadResult_rms_norm     = g_rt.loadResult_rms_norm;
 } // anonymous namespace
-
-
-
-
-#include <execinfo.h>
-#include <signal.h>
 
 static void tsavorite_sig_handler(int sig) {
     void *array[64];
@@ -1170,8 +1165,6 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
         tsi_cleanup();
         abort();
     }
-
-    //void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
     if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
         printf("ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
            deviceId, packed_args.size(), num_of_txes);
@@ -1254,16 +1247,14 @@ static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
        tsi_cleanup();
        abort();
     }
-
-   {
+    {
        std::lock_guard<std::mutex> lk(workers_mutex);
        workers.emplace_back([=]() {
            tsi_blob_execution_internal(commandList);
            release_device(deviceId);
        });
-   }
+    }
 }
-
 
 static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TSI_DeviceIdType deviceId) {
     constexpr int64_t kPackedArgsI64   = 9;
@@ -1281,7 +1272,6 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
         abort();
     }
 
-    //void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
     if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
         printf("ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
            deviceId, packed_args.size(), num_of_txes);
@@ -1327,7 +1317,6 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
     return commandList;
 }
 
-
 static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
     tsi_init_per_txe_state_once();
 
@@ -1366,7 +1355,6 @@ static void _mlir_ciface_txe_mult_host_new(void *a, void *b, void *res) {
    }
 }
 
-
 static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf, TSI_DeviceIdType deviceId) {
     constexpr int64_t kPackedArgsI64   = 20;
     constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * 8;
@@ -1383,7 +1371,6 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
         abort();
     }
 
-    //void *packed = tsi_alloc(kPackedArgsBytes, tsi::MemorySpace::SHARED_DRAM_TS);
     if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
         printf("ERROR: packed_args not initialized for deviceId=%d (size=%zu, num_of_txes=%u)\n",
            deviceId, packed_args.size(), num_of_txes);
@@ -1460,19 +1447,13 @@ static void _mlir_ciface_txe_rms_norm_host_new(void *a, void *b, void *buf) {
         tsi_cleanup();
         abort();
     }
-#if 0
-    workers.emplace_back([=]() {
-        tsi_blob_execution_internal(commandList);
-        release_device(deviceId);
-    });
-#endif
-   {
+    {
        std::lock_guard<std::mutex> lk(workers_mutex);
        workers.emplace_back([=]() {
            tsi_blob_execution_internal(commandList);
            release_device(deviceId);
        });
-   }
+    }
 }
 
 
@@ -3538,18 +3519,6 @@ static void ggml_backend_tsavorite_free(ggml_backend_t backend) {
   free(backend);
   GGML_TSAVORITE_LOG_INFO("End %s\n", __func__);
 }
-
-#if 0
-static void ggml_backend_tsavorite_synchronize(ggml_backend_t backend) {
-// We need to implement ASYN  Method to take output of tensor data to input of other Tensor
-// We will evaluate and implement at later PR
-#ifdef SYNC_DEBUG
-  usleep(100000);
-#endif /* SYNC_DEBUG */
-  
-  TSI_UNUSED(backend);
-}
-#endif
 
 static void ggml_backend_tsavorite_synchronize(ggml_backend_t backend) {
     join_all_workers();

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -701,7 +701,6 @@ static void ensure_tsi_runtime_initialized() {
     if (!device_free) {
         fprintf(stderr, "Failed to allocate device_free\n");
         tsi_unload_all_blobs();
-        printf("\n finalize 1 \n");
         tsi_finalize();
         abort();
     }
@@ -1813,9 +1812,7 @@ static void ggml_tsavorite_free(struct ggml_backend_tsavorite_context *ctx) {
          device_free = NULL;
       }
       sleep(2);
-      printf("\n finalize 2 \n");
       tsi_finalize();
-      printf("\n finalize 2 \n");
       tsirt::utils::TSIProfiler::finalize();
       sleep(2);
   }
@@ -1838,7 +1835,6 @@ tsi_cleanup() {
         device_free = NULL;
     }
     sleep(2);
-    printf("\n finalize 3 \n");
     tsi_finalize();
     GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
     tsirt::utils::TSIProfiler::finalize();


### PR DESCRIPTION
Three issue were fixed
**@FIR-1741 - Ollama Crash: For Multi-Txe case
@FIR-1739 - Ollama: Multi‑TXE – tsi_finalize reports blobs not unloaded
@FIR-1747 - llama.cpp: Memory Leak for Multi-threading**

**Root Cause & Current Fix**
We identified that the TsavRT runtime object is global to the process and is created once per llama.cpp / ollama runner process. This runtime state is not thread‑safe. As a result, concurrent invocations of Runtime Host Wrapper APIs can race and lead to crashes.
The affected APIs include (but are not limited to):

tsi_create_command_list
tsi_shmem_handle_from_ptr
tsi_launch_blob
tsi_add_command_to_list
tsi_finalize_command_list
tsi_wait

To stabilize execution, we currently protect all Runtime Host Wrapper API calls with a global mutex. This fixes the crash, but it also serializes execution, which effectively negates the intended parallelism even when:

multi‑threading is enabled, and
multiple TXEs are available.

**Next Steps**
This PR does not introduce parallelism‑related caveats. It focuses only on correctness and stability.
I will next work with Nithya to move this synchronization inside the Runtime Shim layer, so that:

the runtime itself enforces proper locking, and
host‑side serialization can be removed,
enabling true parallelism across multiple TXEs without requiring higher‑level locking in ggml/llama.cpp or the Ollama runner.



TEST CASE RAN:


Multi-threading-disable
Ollama Passed

Multi-threading Enable and below regression functional and Stress test cases ran
Ollama Tested myself and Ashish is running Stress test where below steps repeated 500 times(ar far now 220 times ran and all passed no memory leak)
ollama run Gemma3:270M "Where is Amazon river?" 
ollama run qwen:0.5b "Where is Amazon river?" 


**Llama-cli log

MUlti-threading Disable**
4;mroot@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh

 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0

 
 is Luna.




llama_perf_sampler_print:    sampling time =     449.12 ms /    11 runs   (   40.83 ms per token,    24.49 tokens per second)
llama_perf_context_print:        load time =   92187.52 ms
llama_perf_context_print: prompt eval time =   56809.50 ms /     6 tokens ( 9468.25 ms per token,     0.11 tokens per second)
llama_perf_context_print:        eval time =  198521.28 ms /     4 runs   (49630.32 ms per token,     0.02 tokens per second)
llama_perf_context_print:       total time =  292040.25 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          484             694          14521847          30003.82
  MUL              OPU          495             710          13810352          27899.70
  RMS_NORM         OPU          495             495          13554268          27382.36
  MUL_MAT          CPU         8596               0        1807235875         210241.49
  CONT             CPU         1924               0          14210745           7386.04
  RESHAPE          CPU         2816               0            258961             91.96
  VIEW             CPU         4749               0            198961             41.90
  PERMUTE          CPU         3758               0            106794             28.42
  TRANSPOSE        CPU          913               0             11909             13.04
  GET_ROWS         CPU           99               0             56556            571.27
  SET_ROWS         CPU         1913               0           1225048            640.38
  SOFT_MAX         CPU          968               0           2143351           2214.21
  ROPE             CPU         1831               0            725197            396.07
  GLU              OPU          242             347          12632131          52198.89

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1   896.0790  896.0790    875.8260  [3.03e-01%] [Thread] tsi::runtime::TsavRTFPGA::initialize
    1     7.9320    7.9320      7.9320  └─ [2.69e-03%] tsi::runtime::TsavRTFPGA::initializeRuntimeSpace
    1     7.7640    7.7640      7.7640  └─ [2.63e-03%] tsi::runtime::TsavRTFPGA::initializeQueues
    1     2.9980    2.9980      2.9980  └─ [1.02e-03%] tsi::runtime::TsavRT::initialize
    1     1.5590    1.5590      0.3450  └─ [5.28e-04%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    2     1.2140    0.6070      1.2140    └─ [4.11e-04%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310 19720.8290   15.0541  16935.6330  [ 6.68%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
 1310  2690.8075    2.0541   2690.8075  └─ [9.11e-01%] TXE 0 Idle
  215    26.7507    0.1244     26.7507  └─ [9.06e-03%] [ txe_swiglu ]
  225    22.7670    0.1012     22.7670  └─ [7.71e-03%] [ txe_rms_norm ]
  440    22.7000    0.0516     22.7000  └─ [7.69e-03%] [ txe_mult ]
  430    22.1708    0.0516     22.1708  └─ [7.51e-03%] [ txe_add ]
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1   199.5960  199.5960     28.7110  [6.76e-02%] [Thread] tsi::runtime::TsavRTFPGA::finalize
    1    89.5450   89.5450     89.5450  └─ [3.03e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
    1    81.3400   81.3400     81.3400  └─ [2.75e-02%] tsi::runtime::TsavRT::finalize
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     9.7870    9.7870      9.2580  [3.31e-03%] [Thread] OPU 
    1     0.5290    0.5290      0.5290  └─ [1.79e-04%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310  1846.9520    1.4099   1729.8080  [6.25e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
 1310   117.1440    0.0894    117.1440  └─ [3.97e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310 17797.2570   13.5857    457.3360  [ 6.03%] [Thread] tsi::runtime::TsavRT::processResponses
 1310 17339.9210   13.2366  17339.9210  └─ [ 5.87%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1313   515.8240    0.3929    515.8240  [1.75e-01%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310  5058.9390    3.8618   5058.9390  [ 1.71%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310   393.8570    0.3007    393.8570  [1.33e-01%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310   567.0600    0.4329    567.0600  [1.92e-01%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310   119.2210    0.0910    119.2210  [4.04e-02%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    -   2.95e+05    0.0000    2.95e+05  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.9741
------------------------------------------------------------------------------------------------------------------------

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 


LLama-clu
Mult-threading Enable

./run_llama_cli.sh

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=2 multi_thread_enable=1

 is Luna.




llama_perf_sampler_print:    sampling time =     319.07 ms /    11 runs   (   29.01 ms per token,    34.47 tokens per second)
llama_perf_context_print:        load time =   86322.20 ms
llama_perf_context_print: prompt eval time =   62448.07 ms /     6 tokens (10408.01 ms per token,     0.10 tokens per second)
llama_perf_context_print:        eval time =  191779.08 ms /     4 runs   (47944.77 ms per token,     0.02 tokens per second)
llama_perf_context_print:       total time =  279188.45 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          484             694           7180788          14836.34
  MUL              OPU          495             710           5802263          11721.74
  RMS_NORM         OPU          495             495           3112578           6288.04
  MUL_MAT          CPU         8576               0        1640310776         191267.58
  CONT             CPU         1901               0          13301856           6997.29
  RESHAPE          CPU         2787               0            101429             36.39
  VIEW             CPU         4729               0            239653             50.68
  PERMUTE          CPU         3753               0            117253             31.24
  TRANSPOSE        CPU          899               0             94969            105.64
  GET_ROWS         CPU           99               0             99889           1008.98
  SET_ROWS         CPU         1901               0            737228            387.81
  SOFT_MAX         CPU          965               0           1740492           1803.62
  ROPE             CPU         1849               0            538560            291.27
  GLU              OPU          242             347          13263125          54806.30


OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
 1310 20184.0700   15.4077  16748.7888  [ 7.15%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
 1059  2576.2338    2.4327   2576.2338  └─ [9.12e-01%] TXE 0 Idle
  251   764.6816    3.0465    764.6816  └─ [2.71e-01%] TXE 1 Idle
  215    26.7354    0.1244     26.7354  └─ [9.46e-03%] [ txe_swiglu ]
  225    22.7582    0.1011     22.7582  └─ [8.06e-03%] [ txe_rms_norm_dev0 ]
  314    16.2029    0.0516     16.2029  └─ [5.74e-03%] [ txe_mult_dev0 ]
  305    15.7258    0.0516     15.7258  └─ [5.57e-03%] [ txe_add_dev0 ]
  126     6.4985    0.0516      6.4985  └─ [2.30e-03%] [ txe_mult_dev1 ]
  125     6.4450    0.0516      6.4450  └─ [2.28e-03%] [ txe_add_dev1 ]
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::initialize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1   937.6480  937.6480    886.2690  [3.32e-01%] [Thread] tsi::runtime::TsavRTFPGA::initialize
    1    19.6260   19.6260     19.6260  └─ [6.95e-03%] tsi::runtime::TsavRTFPGA::initializeQueues
    1    13.3480   13.3480     13.3480  └─ [4.73e-03%] tsi::runtime::TsavRT::initialize
    1    12.8790   12.8790     12.8790  └─ [4.56e-03%] tsi::runtime::TsavRTFPGA::initializeRuntimeSpace
    1     5.5260    5.5260      2.8790  └─ [1.96e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    4     2.6470    0.6617      2.6470    └─ [9.37e-04%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1   152.0480  152.0480     36.6920  [5.38e-02%] [Thread] tsi::runtime::TsavRTFPGA::finalize
    1    64.8140   64.8140     64.8140  └─ [2.29e-02%] tsi::runtime::TsavRT::finalize
    1    50.5420   50.5420     50.5420  └─ [1.79e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
------------------------------------------------------------------------------------------------------------------------
[Thread] OPU  (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1     3.9280    3.9280      2.1010  [1.39e-03%] [Thread] OPU 
    1     1.8270    1.8270      1.8270  └─ [6.47e-04%] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310  2152.3650    1.6430   1954.8600  [7.62e-01%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
 1310   197.5050    0.1508    197.5050  └─ [6.99e-02%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310 17594.0300   13.4306    558.9890  [ 6.23%] [Thread] tsi::runtime::TsavRT::processResponses
 1310 17035.0410   13.0038  17035.0410  └─ [ 6.03%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  221  1022.3950    4.6262   1022.3950  [3.62e-01%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  219   105.8020    0.4831    105.8020  [3.75e-02%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1310   666.3820    0.5087    666.3820  [2.36e-01%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  221    66.5910    0.3013     66.5910  [2.36e-02%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
  215    36.7990    0.1712     36.7990  [1.30e-02%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    -   2.82e+05    0.0000    2.82e+05  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.9585
Queue_1_Occupancy                      0.0000         1.0000         0.9881
------------------------------------------------------------------------------------------------------------------------


