### PR TITLE
@FIR-1770 - llama.cpp: Runtime Re-architecture Integrated with ggml a…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ if (GGML_TSAVORITE)
     include_directories(${TSAVORITE_INCLUDE_DIR})
     include_directories(${MLIR_COMPILER_DIR}/include/tsi-rt/shim)
     include_directories(${RUNTIME_DIR}/include)
+    include_directories(${MLIR_COMPILER_DIR}/../toolbox/build/install-fpga/include)
     message("tsavorite backend is enabled")
 endif()
 

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -396,6 +396,7 @@ typedef struct _txe_compute_pipeline_state_t *txe_compute_pipeline_state_s;
 FILE *tsi_op_log_file;
 bool runtime_initialized = false;
 uint64_t num_of_op;
+#define TSI_RUN_TIME_INSTANCE 1
 
 // ============================================================
 // (makes blob names unique per device to avoid collisions)
@@ -459,7 +460,7 @@ static inline void tsi_blob_free_tables() {
 static inline void tsi_blob_unload_only() {
     // unload blobs if present, keep tables allocated
     if (blobDescriptor_add) {
-        for (uint32_t i = 0; i < num_of_txes; ++i) {
+        for (uint32_t i = 0; i < TSI_RUN_TIME_INSTANCE; ++i) {
             if (blobDescriptor_add[i]) {
                 tsi_unload_blob(blobDescriptor_add[i]);
                 blobDescriptor_add[i] = nullptr;
@@ -467,7 +468,7 @@ static inline void tsi_blob_unload_only() {
         }
     }
     if (blobDescriptor_mult) {
-        for (uint32_t i = 0; i < num_of_txes; ++i) {
+        for (uint32_t i = 0; i < TSI_RUN_TIME_INSTANCE; ++i) {
             if (blobDescriptor_mult[i]) {
                 tsi_unload_blob(blobDescriptor_mult[i]);
                 blobDescriptor_mult[i] = nullptr;
@@ -475,7 +476,7 @@ static inline void tsi_blob_unload_only() {
         }
     }
     if (blobDescriptor_rms_norm) {
-        for (uint32_t i = 0; i < num_of_txes; ++i) {
+        for (uint32_t i = 0; i < TSI_RUN_TIME_INSTANCE; ++i) {
             if (blobDescriptor_rms_norm[i]) {
                 tsi_unload_blob(blobDescriptor_rms_norm[i]);
                 blobDescriptor_rms_norm[i] = nullptr;
@@ -484,9 +485,9 @@ static inline void tsi_blob_unload_only() {
     }
 
     // best-effort: clear loadResult_* entries too
-    if (loadResult_add)      memset(loadResult_add,      0, num_of_txes * sizeof(void *));
-    if (loadResult_mult)     memset(loadResult_mult,     0, num_of_txes * sizeof(void *));
-    if (loadResult_rms_norm) memset(loadResult_rms_norm, 0, num_of_txes * sizeof(void *));
+    if (loadResult_add)      memset(loadResult_add,      0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
+    if (loadResult_mult)     memset(loadResult_mult,     0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
+    if (loadResult_rms_norm) memset(loadResult_rms_norm, 0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
 
     g_rt.blob_state = TsavoriteRuntimeState::BLOB_TABLES_ALLOCATED;
 }
@@ -502,13 +503,13 @@ static inline void tsi_blob_ensure_tables_allocated() {
         }
     }
 
-    loadResult_add      = (void **)calloc(num_of_txes, sizeof(void *));
-    loadResult_mult     = (void **)calloc(num_of_txes, sizeof(void *));
-    loadResult_rms_norm = (void **)calloc(num_of_txes, sizeof(void *));
+    loadResult_add      = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
+    loadResult_mult     = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
+    loadResult_rms_norm = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
 
-    blobDescriptor_add      = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
-    blobDescriptor_mult     = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
-    blobDescriptor_rms_norm = (BlobDescriptor **)calloc(num_of_txes, sizeof(BlobDescriptor *));
+    blobDescriptor_add      = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
+    blobDescriptor_mult     = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
+    blobDescriptor_rms_norm = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
 
     if (!loadResult_add || !loadResult_mult || !loadResult_rms_norm ||
         !blobDescriptor_add || !blobDescriptor_mult || !blobDescriptor_rms_norm) {
@@ -537,7 +538,7 @@ static void tsi_load_all_blobs() {
     // size matches runtime txe_count
     //packed_args.resize(num_of_txes, nullptr);
 
-    for (uint32_t i = 0; i < num_of_txes; ++i) {
+    for (uint32_t i = 0; i < TSI_RUN_TIME_INSTANCE; ++i) {
         char name_add[64];
         char name_mult[64];
         char name_rms[64];
@@ -1205,11 +1206,11 @@ static void *_mlir_ciface_txe_add_host_internal(void *a, void *b, void *res, TSI
     }
 
     const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed_args[deviceId]);
-    void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add[deviceId], packedHandle);
+    void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_add[0], packedHandle, kPackedArgsBytes);
 
     if (!blobExecuteCmd) {
         fprintf(stderr, "tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
-                                     (unsigned long)deviceId, (char *)blobDescriptor_add[deviceId]);
+                                     (unsigned long)deviceId, (char *)blobDescriptor_add[0]);
         tsi_cleanup();
         abort();
     }
@@ -1312,10 +1313,10 @@ static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TS
     }
 
     const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed_args[deviceId]);
-    void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult[deviceId], packedHandle);
+    void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_mult[0], packedHandle, kPackedArgsBytes);
     if (!blobExecuteCmd) {
         fprintf(stderr, "tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
-                                     (unsigned long)deviceId, (char *)blobDescriptor_mult[deviceId]);
+                                     (unsigned long)deviceId, (char *)blobDescriptor_mult[0]);
         tsi_cleanup();
         abort();
     }
@@ -1413,10 +1414,10 @@ static void *_mlir_ciface_txe_rms_norm_host_internal(void *a, void *b, void *buf
     }
 
     const int64_t packedHandle = tsi_shmem_handle_from_ptr(packed_args[deviceId]);
-    void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm[deviceId], packedHandle);
+    void *blobExecuteCmd = tsi_launch_blob(blobDescriptor_rms_norm[0], packedHandle, kPackedArgsBytes);
     if (!blobExecuteCmd) {
         fprintf(stderr, "tsi_launch_blob failed for device %lu and blobDescriptor %s\n",
-                                     (unsigned long)deviceId, (char *)blobDescriptor_rms_norm[deviceId]);
+                                     (unsigned long)deviceId, (char *)blobDescriptor_rms_norm[0]);
         tsi_cleanup();
         abort();
     }

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -556,31 +556,39 @@ parse_args() {
 }
 
 resolve_paths() {
-  local arch="$1"
+    local arch="$1"
 
-  if [ -z "${MLIR_COMPILER_DIR_IN}" ]; then
-    # REQUIRED CHANGE: remove hardcoded 0.4.0 and use SDK_VERSION
-    MLIR_SDK_VERSION="${MLIR_SDK_VERSION:-/proj/rel/sw/tsi-sw/staging/sdk/sdk-r.${SDK_VERSION}/${arch}}"
-    MLIR_COMPILER_DIR_IN="${MLIR_SDK_VERSION}/compiler"
-  fi
+    if [ -z "${MLIR_COMPILER_DIR_IN}" ]; then
+        MLIR_SDK_VERSION="${MLIR_SDK_VERSION:-/proj/rel/sw/tsi-sw/staging/sdk/sdk-r.${SDK_VERSION}/${arch}}"
+        MLIR_COMPILER_DIR_IN="${MLIR_SDK_VERSION}/compiler"
+    fi
 
-  if [ -z "${TOOLBOX_DIR_IN}" ]; then
-    MLIR_SDK_VERSION="${MLIR_SDK_VERSION:-$(dirname "${MLIR_COMPILER_DIR_IN}")}"
-    TOOLBOX_DIR_IN="${MLIR_SDK_VERSION}/toolbox/build/install-fpga"
-  fi
+    if [ -z "${TOOLBOX_DIR_IN}" ]; then
+        MLIR_SDK_VERSION="${MLIR_SDK_VERSION:-$(dirname "${MLIR_COMPILER_DIR_IN}")}"
+        TOOLBOX_DIR_IN="${MLIR_SDK_VERSION}/toolbox/build/install-fpga"
+    fi
 
-  MLIR_COMPILER_DIR="$(absdir "${MLIR_COMPILER_DIR_IN}")" || die "MLIR_COMPILER_DIR not found: ${MLIR_COMPILER_DIR_IN}"
-  TOOLBOX_DIR="$(absdir "${TOOLBOX_DIR_IN}")" || die "TOOLBOX_DIR not found: ${TOOLBOX_DIR_IN}"
+    MLIR_COMPILER_DIR="$(absdir "${MLIR_COMPILER_DIR_IN}")" \
+        || die "MLIR_COMPILER_DIR not found: ${MLIR_COMPILER_DIR_IN}"
 
-  export MLIR_SDK_VERSION="${MLIR_SDK_VERSION:-$(dirname "${MLIR_COMPILER_DIR}")}"
-  export MLIR_COMPILER_DIR
-  export COMPILER_INSTALL_DIR="${MLIR_COMPILER_DIR}"
-  export TOOLBOX_DIR
-  export FAU_LOOKUP_TABLE_PATH="${MLIR_SDK_VERSION}/ffm/txe-ffm-cpp/third-party/FAU/include/"
+    TOOLBOX_DIR="$(absdir "${TOOLBOX_DIR_IN}")" \
+        || die "TOOLBOX_DIR not found: ${TOOLBOX_DIR_IN}"
 
-  log_info "SDK_VERSION: ${SDK_VERSION}"
-  log_info "MLIR_COMPILER_DIR: ${MLIR_COMPILER_DIR}"
-  log_info "TOOLBOX_DIR: ${TOOLBOX_DIR}"
+    # Derive TSICommon_DIR from TOOLBOX_DIR (SDK 0.4.1 compatible)
+    TSICommon_DIR="${TOOLBOX_DIR}/lib/cmake/TSICommon"
+    [ -d "${TSICommon_DIR}" ] || die "TSICommon_DIR not found: ${TSICommon_DIR}"
+    export TSICommon_DIR
+
+    export MLIR_SDK_VERSION="${MLIR_SDK_VERSION:-$(dirname "${MLIR_COMPILER_DIR}")}"
+    export MLIR_COMPILER_DIR
+    export COMPILER_INSTALL_DIR="${MLIR_COMPILER_DIR}"
+    export TOOLBOX_DIR
+    export FAU_LOOKUP_TABLE_PATH="${MLIR_SDK_VERSION}/ffm/txe-ffm-cpp/third-party/FAU/include/"
+
+    log_info "SDK_VERSION:        ${SDK_VERSION}"
+    log_info "MLIR_COMPILER_DIR: ${MLIR_COMPILER_DIR}"
+    log_info "TOOLBOX_DIR:       ${TOOLBOX_DIR}"
+    log_info "TSICommon_DIR:     ${TSICommon_DIR}"
 }
 
 setup_toolchain() {

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -617,8 +617,29 @@ setup_python() {
 
   log_info "installing mlir and python dependencies"
   run pip install --upgrade pip || return 1
+
+  # Keep torch install as before (this is what your logs show)
   run pip install torch==2.7.0 || return 1
-  run pip install -r "${MLIR_COMPILER_DIR}/python/requirements-common.txt" || return 1
+
+  # ---- FIX for SDK 0.4.1: requirements-common.txt may include "-r /python/...."
+  local REQ_DIR="${MLIR_COMPILER_DIR}/python"
+  local REQ_MAIN="${REQ_DIR}/requirements-common.txt"
+
+  if [ ! -f "${REQ_MAIN}" ]; then
+    die "requirements-common.txt not found: ${REQ_MAIN}"
+  fi
+
+  if grep -qE '^[[:space:]]*-r[[:space:]]+/python/' "${REQ_MAIN}"; then
+    log_info "requirements-common.txt contains absolute /python includes; rewriting to ${REQ_DIR}"
+    local REQ_TMP
+    REQ_TMP="$(mktemp -t tsi-req-XXXXXX.txt)"
+    sed -E "s|(^[[:space:]]*-r[[:space:]]+)/python/|\\1${REQ_DIR}/|g" "${REQ_MAIN}" > "${REQ_TMP}"
+    run pip install -r "${REQ_TMP}" || { rm -f "${REQ_TMP}" >/dev/null 2>&1 || true; return 1; }
+    rm -f "${REQ_TMP}" >/dev/null 2>&1 || true
+  else
+    run pip install -r "${REQ_MAIN}" || return 1
+  fi
+  # ---- END FIX
 
   local MLIR_WHL
   MLIR_WHL="$(ls "${MLIR_COMPILER_DIR}/python"/mlir_external_packages-*.whl 2>/dev/null | head -1 || true)"


### PR DESCRIPTION

[sdk-4.2-log.rtf](https://github.com/user-attachments/files/27286404/sdk-4.2-log.rtf)
This PR integrates the Runtime re‑architecture changes with ggml and updates the build flow to automatically resolve TSICommon_DIR from the SDK layout when using SDK version 0.4.1.
Key Changes
1. Automatic TSICommon_DIR Resolution

tsi-pkg-build.sh now derives TSICommon_DIR directly from the SDK installation path.
The path is resolved internally using resolve_path, eliminating the need for users to manually export:
TSICommon_DIR=/proj/rel/sw/tsi-sw/staging/sdk/sdk-r.0.4.1/x86_64/toolbox/build/install-fpga/lib/cmake/TSICommon

This aligns the script with the SDK 0.4.1 directory structure and restores a smooth out‑of‑the‑box build experience.
2. Runtime Re‑architecture Integrated with ggml

Incorporates the updated runtime architecture changes required for ggml integration.
Ensures compatibility with the new runtime execution flow and SDK 0.4.1 interfaces.
Verified to work with the updated toolbox, runtime, and compiler expectations introduced in SDK 0.4.1.

Log Are attached at POSIX and TSISIM(one or multi-txe with multi-threading enable)

