### PR TITLE
@FIR-1754 - Trition Kernel TVU Add kernel Integration with GGML

### DIFF
--- a/ggml/include/ggml-tsavorite.h
+++ b/ggml/include/ggml-tsavorite.h
@@ -200,6 +200,7 @@ typedef enum tsi_data_type_ {
 /*
  * FP32
  */
+extern void _mlir_ciface_add_kernel_memory_wrapper(void *a, void *b, void *res, void *scalar_loop, void *scalar_grid1, void *scalar_grid2, void *scalar_grid3);
 extern void _mlir_ciface_txe_add_host(void *a, void *b, void *res);
 extern void _mlir_ciface_txe_sub_host(void *a, void *b, void *res);
 extern void _mlir_ciface_txe_mult_host(void *a, void *b, void *res);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3336,7 +3336,7 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
                     ++node->tsi_kernel_runs;
                 }
             }
-         }
+        }
         }
 
         if (ggml_tsavorite_log_type_val == GGML_TSAVORITE_LOG_DEBUG) {

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -70,6 +70,16 @@ struct TsavoriteRuntimeState {
     // one packed-args buffer per TXE
     std::vector<void *> packed_args;
 
+    std::vector<void *> scalar_loop_args;
+
+    std::vector<void *> scalar_m_args;
+    std::vector<void *> scalar_n_args;
+    std::vector<void *> scalar_k_args;
+
+    std::vector<void *> scalar_grid1_args;
+    std::vector<void *> scalar_grid2_args;
+    std::vector<void *> scalar_grid3_args;
+
     std::vector<std::thread> workers;
     std::mutex workers_mutex;
     std::mutex device_mutex;
@@ -102,6 +112,15 @@ auto &num_of_txes = g_rt.num_of_txes;
 auto &device_free = g_rt.device_free;
 auto &multi_thread_enable     = g_rt.multi_thread_enable;
 auto &packed_args     = g_rt.packed_args;
+
+auto &scalar_loop_args        = g_rt.scalar_loop_args;
+auto &scalar_m_args           = g_rt.scalar_m_args;
+auto &scalar_n_args           = g_rt.scalar_n_args;
+auto &scalar_k_args           = g_rt.scalar_k_args;
+
+auto &scalar_grid1_args       = g_rt.scalar_grid1_args;
+auto &scalar_grid2_args       = g_rt.scalar_grid2_args;
+auto &scalar_grid3_args       = g_rt.scalar_grid3_args;
 
 auto &workers = g_rt.workers;
 auto &workers_mutex = g_rt.workers_mutex;
@@ -643,14 +662,78 @@ static inline void tsi_init_per_txe_state_once() {
 
     // allocate per-TXE packed args buffer (device-visible)
     constexpr size_t kPackedArgsBytesMax = 2048;
+    constexpr size_t scalarLoopBytesMax  = 2048;
 
     if (packed_args.size() != num_of_txes) {
         packed_args.assign(num_of_txes, nullptr);
+
+        scalar_loop_args.assign(num_of_txes, nullptr);
+        scalar_m_args.assign(num_of_txes, nullptr);
+        scalar_n_args.assign(num_of_txes, nullptr);
+        scalar_k_args.assign(num_of_txes, nullptr);
+
+        scalar_grid1_args.assign(num_of_txes, nullptr);
+        scalar_grid2_args.assign(num_of_txes, nullptr);
+        scalar_grid3_args.assign(num_of_txes, nullptr);
         for (uint32_t i = 0; i < num_of_txes; ++i) {
             if (!packed_args[i]) {
                 packed_args[i] = tsi_alloc(kPackedArgsBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
                 if (!packed_args[i]) {
                     fprintf(stderr, "tsi_alloc failed for packed_args[%u]\n", i);
+                    abort();
+                }
+            }
+
+            if (!scalar_loop_args[i]) {
+                scalar_loop_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                if (!scalar_loop_args[i]) {
+                    fprintf(stderr, "tsi_alloc failed for scalar_loop_args[%u]\n", i);
+                    abort();
+                }
+            }
+            if (!scalar_m_args[i]) {
+                scalar_m_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                if (!scalar_m_args[i]) {
+                    fprintf(stderr, "tsi_alloc failed for scalar_m_args[%u]\n", i);
+                    abort();
+                }
+            }
+
+            if (!scalar_n_args[i]) {
+                scalar_n_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                if (!scalar_n_args[i]) {
+                    fprintf(stderr, "tsi_alloc failed for scalar_n_args[%u]\n", i);
+                    abort();
+                }
+            }
+
+            if (!scalar_k_args[i]) {
+                scalar_k_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                if (!scalar_k_args[i]) {
+                    fprintf(stderr, "tsi_alloc failed for scalar_k_args[%u]\n", i);
+                    abort();
+                }
+            }
+
+
+            if (!scalar_grid1_args[i]) {
+                scalar_grid1_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                if (!scalar_grid1_args[i]) {
+                    fprintf(stderr, "tsi_alloc failed for scalar_grid1_args[%u]\n", i);
+                    abort();
+                }
+            }
+            if (!scalar_grid2_args[i]) {
+                scalar_grid2_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                if (!scalar_grid2_args[i]) {
+                    fprintf(stderr, "tsi_alloc failed for scalar_grid2_args[%u]\n", i);
+                    abort();
+                }
+            }
+            if (!scalar_grid3_args[i]) {
+                scalar_grid3_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                if (!scalar_grid3_args[i]) {
+                    fprintf(stderr, "tsi_alloc failed for scalar_grid3_args[%u]\n", i);
                     abort();
                 }
             }
@@ -1153,6 +1236,21 @@ static void tsi_blob_execution_internal(void *commandList) {
 }
 
 
+// NOTE:
+// Triton ADD kernel supports a host_wrapper-based invocation path today.
+// For Multi-TXE support, we plan to bypass the generated host_wrapper and
+// directly invoke the runtime shim API with manually packed arguments.
+//
+// However, the exact argument packing (ABI/layout) used by Triton-generated
+// kernels is currently not well understood. Due to this, the direct
+// pack-args + runtime shim path is temporarily disabled
+//
+// This will be revisited once we fully reverse-engineer or document the
+// Triton argument packing format through experiments and validation.
+//
+// Follow-up work tracked here:
+// https://tsavoritesi.atlassian.net/browse/FIR-1984
+#if TRITON_MULTI_TXE
 //lock goes out of scope
 // <--- function scope ends here mutex will be released
 //tsi_pack_mutex.unlock() is called automatically
@@ -1261,6 +1359,7 @@ static void _mlir_ciface_txe_add_host_new(void *a, void *b, void *res) {
        });
     }
 }
+#endif /* TRITON_MULTI_TXE */
 
 static void *_mlir_ciface_txe_mult_host_internal(void *a, void *b, void *res, TSI_DeviceIdType deviceId) {
     constexpr int64_t kPackedArgsI64   = 9;
@@ -1477,11 +1576,15 @@ static txe_compute_pipeline_state_s tsi_kernel_setup(enum ggml_tsavorite_kernel_
           if (ggml_tsavorite_kernel_mode_flag == GGML_TSAVORITE_KERNEL_MODE_CPU)
               kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_test;
           else {
+// TODO(FIR-1984): Will be addressed as part of Triton multi-TXE packed-args support
+#if TRITON_MULTI_TXE
               #ifdef GGML_TARGET_POSIX
                   kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host;
               #else
                   kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host_new;
               #endif /* GGML_TARGET_POSIX */
+#endif /* TRITON_MULTI_TXE */
+              kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F32_INDEX] = &_mlir_ciface_txe_add_host;
               kernel_pipeline->_mlir_fptr_2_input[DATA_TYPE_F16_INDEX] = &_mlir_ciface_txe_add_16_host;
 	  }
           kernel_pipeline->kernel_name = "TXE_ADD";
@@ -3137,7 +3240,6 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
 	    } else {
 
             GGML_TENSOR_BINARY_OP_LOCALS
-
             for (int ir = 0; ir < nr; ++ir) {
                 const int64_t i03 = ir / (ne02 * ne01);
                 const int64_t i02 = (ir - i03 * ne02 * ne01) / ne01;
@@ -3156,19 +3258,88 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
 	        // (i.e., the first dimension) for all blob-related processing.
 
                 for (int64_t r = 0; r < nr0; ++r) {
+                   memset(srcP0, 0, sizeof(MemRefDescriptor<Rank>));
+                   memset(srcP1, 0, sizeof(MemRefDescriptor<Rank>));
+                   memset(nodeP, 0, sizeof(MemRefDescriptor<Rank>));
+
+
+
                     srcP0->shape[0]   = ne10;
+                    srcP0->offset     = 0;
+
                     srcP1->shape[0]   = ne10;
+                    srcP1->offset     = 0;
+
                     nodeP->shape[0]   = ne10;
+                    nodeP->offset     = 0;
+
                     srcP1->data =  srcP1->base = (void *)(src1_ptr);
                     srcP0->data =  srcP0->base = (void *)(src0_ptr + r * ne10);
                     nodeP->data =  nodeP->base = (void *)(dst_ptr + r * ne10);
                     // kernel call
-                    ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, srcP1, nodeP);
+                       //printf("\n  CALLING GGML_OP_ADD -0 \n");
+                    if (kernel_type == GGML_TSAVORITE_KERNEL_TYPE_ADD) {
+                        // MemRefDescriptor
+                        int32_t *scalar_val; 
+                        srcP0->strides[0] = 1;
+                        srcP1->strides[0] = 1;
+                        nodeP->strides[0] = 1;
+                        MemRefDescriptor<Rank> *scalar_loop;
+                        MemRefDescriptor<Rank> *scalar_grid1;
+                        MemRefDescriptor<Rank> *scalar_grid2;
+                        MemRefDescriptor<Rank> *scalar_grid3;
+
+                        scalar_loop = (MemRefDescriptor<Rank> *)scalar_loop_args[0];
+                        scalar_grid1 = (MemRefDescriptor<Rank> *)scalar_grid1_args[0];
+                        scalar_grid2 = (MemRefDescriptor<Rank> *)scalar_grid2_args[0];
+                        scalar_grid3 = (MemRefDescriptor<Rank> *)scalar_grid3_args[0];
+
+                        memset(scalar_loop, 0, sizeof(MemRefDescriptor<Rank>));
+                        memset(scalar_grid1, 0, sizeof(MemRefDescriptor<Rank>));
+                        memset(scalar_grid2, 0, sizeof(MemRefDescriptor<Rank>));
+                        memset(scalar_grid3, 0, sizeof(MemRefDescriptor<Rank>));
+
+                        scalar_loop->shape[0] = 1;
+                        scalar_loop->data = scalar_loop->base = (void *)(scalar_loop+1);
+                        scalar_loop->offset = 0;
+
+                        scalar_val = (int32_t *)(scalar_loop+1);
+                        *scalar_val = (int32_t)srcP0->shape[0];
+
+                        scalar_grid1->shape[0] = 1;
+                        scalar_grid1->data = scalar_grid1->base = (void *)(scalar_grid1 +1);
+                        scalar_grid1->offset = 0;
+
+                        scalar_val = (int32_t *)(scalar_grid1+1);
+                        *scalar_val = 1;
+
+                        scalar_grid2->shape[0] = 1;
+                        scalar_grid2->data = scalar_grid2->base = (void *)(scalar_grid2 +1);
+                        scalar_grid2->offset = 0;
+
+                        scalar_val = (int32_t *)(scalar_grid2+1);
+                        *scalar_val = 1;
+
+                        scalar_grid3->shape[0] = 1;
+                        scalar_grid3->data = scalar_grid3->base = (void *)(scalar_grid3 +1);
+                        scalar_grid3->offset = 0;
+
+                        scalar_val = (int32_t *)(scalar_grid3+1);
+                        *scalar_val = 1;
+
+                        //ctx->kernels[kernel_type].pipeline->_mlir_fptr_3_input[kernel_sub_type](srcP0, srcP1, nodeP, scalar_loop);
+                        _mlir_ciface_add_kernel_memory_wrapper(srcP0, srcP1, nodeP,
+                                        scalar_loop, scalar_grid1, scalar_grid2, scalar_grid3);
+                        //ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, srcP1, nodeP);
+                       //printf("\n  CALLING GGML_OP_ADD DONE\n");
+                    } else {
+                        ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, srcP1, nodeP);
+                    }
                     ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
                     ++node->tsi_kernel_runs;
                 }
             }
-        }
+         }
         }
 
         if (ggml_tsavorite_log_type_val == GGML_TSAVORITE_LOG_DEBUG) {

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3277,7 +3277,6 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
                     srcP0->data =  srcP0->base = (void *)(src0_ptr + r * ne10);
                     nodeP->data =  nodeP->base = (void *)(dst_ptr + r * ne10);
                     // kernel call
-                       //printf("\n  CALLING GGML_OP_ADD -0 \n");
                     if (kernel_type == GGML_TSAVORITE_KERNEL_TYPE_ADD) {
                         // MemRefDescriptor
                         int32_t *scalar_val; 
@@ -3330,8 +3329,6 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
                         //ctx->kernels[kernel_type].pipeline->_mlir_fptr_3_input[kernel_sub_type](srcP0, srcP1, nodeP, scalar_loop);
                         _mlir_ciface_add_kernel_memory_wrapper(srcP0, srcP1, nodeP,
                                         scalar_loop, scalar_grid1, scalar_grid2, scalar_grid3);
-                        //ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, srcP1, nodeP);
-                       //printf("\n  CALLING GGML_OP_ADD DONE\n");
                     } else {
                         ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, srcP1, nodeP);
                     }

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -936,12 +936,12 @@ for kernel in "${tsi_kernels[@]}"; do
 done
 
 # Triton ADD
-dst="__TSI_BLOB_INSTALL_DIR__/txe_trition_add/blobs"
+dst="__TSI_BLOB_INSTALL_DIR__/txe_triton_add/blobs"
 rm -rf "${dst}"
 mkdir -p "${dst}"
 
-if [ -f "blobs/trition_add/txe_blob_0.blob" ]; then
-  cp "blobs/txe_trition_add/txe_blob_0.blob" "${dst}/txe_blob_0.blob"
+if [ -f "blobs/txe_triton_add/txe_blob_0.blob" ]; then
+  cp "blobs/txe_triton_add/txe_blob_0.blob" "${dst}/txe_blob_0.blob"
 fi
 EOL
 

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -917,15 +917,31 @@ bundle_fpga() {
   mkdir -p "${TSI_GGML_BUNDLE_INSTALL_DIR}"
   rm -f "${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh"
 
-  cat > "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh" <<'EOL'
+cat > "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh" <<'EOL'
 #!/bin/bash
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)
+
 tsi_kernels=("add" "sub" "mult" "div" "abs" "inv" "neg" "sin" "sqrt" "sqr" "sigmoid" "silu" "rms_norm" "swiglu" \
-"add_16" "sub_16" "mult_16" "div_16" "abs_16" "inv_16" "neg_16" "sin_16" "sqrt_16" "sqr_16" "sigmoid_16" "silu_16" "rms_norm_16" "swiglu_16" "mul_mat_tile_f32_k32" "mul_mat_tile_f32_k64" "mul_mat_tile_f32_k128")
+"add_16" "sub_16" "mult_16" "div_16" "abs_16" "inv_16" "neg_16" "sin_16" "sqrt_16" "sqr_16" "sigmoid_16" "silu_16" "rms_norm_16" "swiglu_16" \
+"mul_mat_tile_f32_k32" "mul_mat_tile_f32_k64" "mul_mat_tile_f32_k128")
+
+# copy normal kernels (same as before)
 for kernel in "${tsi_kernels[@]}"; do
   mkdir -p __TSI_BLOB_INSTALL_DIR__/txe_${kernel}
   cp blobs __TSI_BLOB_INSTALL_DIR__/txe_${kernel}/ -r
 done
+
+# ---------- (ONLY Triton) ----------
+TRITON_SRC="__TSI_BLOB_INSTALL_DIR__/txe_add/blobs/trition_add/txe_blob_0.blob"
+TRITON_DST="__TSI_BLOB_INSTALL_DIR__/txe_add_trition/blobs"
+
+rm -rf "${TRITON_DST}"
+mkdir -p "${TRITON_DST}"
+
+if [ -f "${TRITON_SRC}" ]; then
+  cp "${TRITON_SRC}" "${TRITON_DST}/txe_blob_0.blob"
+fi
+# --------------------------------------
 EOL
 
   sed -i "s|__TSI_BLOB_INSTALL_DIR__|${TSI_BLOB_INSTALL_DIR}|g" "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh"

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -925,23 +925,24 @@ tsi_kernels=("add" "sub" "mult" "div" "abs" "inv" "neg" "sin" "sqrt" "sqr" "sigm
 "add_16" "sub_16" "mult_16" "div_16" "abs_16" "inv_16" "neg_16" "sin_16" "sqrt_16" "sqr_16" "sigmoid_16" "silu_16" "rms_norm_16" "swiglu_16" \
 "mul_mat_tile_f32_k32" "mul_mat_tile_f32_k64" "mul_mat_tile_f32_k128")
 
-# copy normal kernels (same as before)
 for kernel in "${tsi_kernels[@]}"; do
-  mkdir -p __TSI_BLOB_INSTALL_DIR__/txe_${kernel}
-  cp blobs __TSI_BLOB_INSTALL_DIR__/txe_${kernel}/ -r
+  dst="__TSI_BLOB_INSTALL_DIR__/txe_${kernel}/blobs"
+  rm -rf "${dst}"
+  mkdir -p "${dst}"
+
+  if [ -f "blobs/txe_${kernel}.blob" ]; then
+    cp "blobs/txe_${kernel}.blob" "${dst}/txe_${kernel}.blob"
+  fi
 done
 
-# ---------- (ONLY Triton) ----------
-TRITON_SRC="__TSI_BLOB_INSTALL_DIR__/txe_add/blobs/trition_add/txe_blob_0.blob"
-TRITON_DST="__TSI_BLOB_INSTALL_DIR__/txe_trition_add/blobs"
+# Triton ADD
+dst="__TSI_BLOB_INSTALL_DIR__/txe_trition_add/blobs"
+rm -rf "${dst}"
+mkdir -p "${dst}"
 
-rm -rf "${TRITON_DST}"
-mkdir -p "${TRITON_DST}"
-
-if [ -f "${TRITON_SRC}" ]; then
-  cp "${TRITON_SRC}" "${TRITON_DST}/txe_blob_0.blob"
+if [ -f "blobs/trition_add/txe_blob_0.blob" ]; then
+  cp "blobs/txe_trition_add/txe_blob_0.blob" "${dst}/txe_blob_0.blob"
 fi
-# --------------------------------------
 EOL
 
   sed -i "s|__TSI_BLOB_INSTALL_DIR__|${TSI_BLOB_INSTALL_DIR}|g" "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh"

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -644,7 +644,7 @@ setup_python() {
 
   # ---------------------------------------------------------------------------
   # Install latest Tsavorite Triton wheel from SDK triton/
-  # (your manual flow used triton_tsiai-1.0.0 / 0.1.3)
+  # (manual flow used triton_tsiai-1.0.0 / 0.1.3)
   # ---------------------------------------------------------------------------
   local TRITON_WHL
   TRITON_WHL="$(ls -1 "${TRITON_DIR}"/triton_tsiai-*.whl 2>/dev/null | sort -V | tail -1 || true)"

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -933,7 +933,7 @@ done
 
 # ---------- (ONLY Triton) ----------
 TRITON_SRC="__TSI_BLOB_INSTALL_DIR__/txe_add/blobs/trition_add/txe_blob_0.blob"
-TRITON_DST="__TSI_BLOB_INSTALL_DIR__/txe_add_trition/blobs"
+TRITON_DST="__TSI_BLOB_INSTALL_DIR__/txe_trition_add/blobs"
 
 rm -rf "${TRITON_DST}"
 mkdir -p "${TRITON_DST}"

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -570,17 +570,16 @@ resolve_paths() {
         TOOLBOX_DIR_IN="${MLIR_SDK_VERSION}/toolbox/build/install-fpga"
     fi
 
-    MLIR_COMPILER_DIR="$(absdir "${MLIR_COMPILER_DIR_IN}")" \
-        || die "MLIR_COMPILER_DIR not found: ${MLIR_COMPILER_DIR_IN}"
+    MLIR_COMPILER_DIR="$(absdir "${MLIR_COMPILER_DIR_IN}")"
+    [ -n "${MLIR_COMPILER_DIR}" ] || die "MLIR_COMPILER_DIR not found: ${MLIR_COMPILER_DIR_IN}"
 
-    TOOLBOX_DIR="$(absdir "${TOOLBOX_DIR_IN}")" \
-        || die "TOOLBOX_DIR not found: ${TOOLBOX_DIR_IN}"
+    TOOLBOX_DIR="$(absdir "${TOOLBOX_DIR_IN}")"
+    [ -n "${TOOLBOX_DIR}" ] || die "TOOLBOX_DIR not found: ${TOOLBOX_DIR_IN}"
 
-    # Derive TSICommon_DIR from TOOLBOX_DIR (SDK 0.4.1 compatible)
     TSICommon_DIR="${TOOLBOX_DIR}/lib/cmake/TSICommon"
     [ -d "${TSICommon_DIR}" ] || die "TSICommon_DIR not found: ${TSICommon_DIR}"
-    export TSICommon_DIR
 
+    export TSICommon_DIR
     export MLIR_SDK_VERSION="${MLIR_SDK_VERSION:-$(dirname "${MLIR_COMPILER_DIR}")}"
     export MLIR_COMPILER_DIR
     export COMPILER_INSTALL_DIR="${MLIR_COMPILER_DIR}"
@@ -603,7 +602,7 @@ setup_toolchain() {
 # Python venv (only when needed for blob generation)
 # -------------------------
 setup_python() {
-  # Save the caller's current VIRTUAL_ENV (if any). This allows restore.
+  # Save caller venv so cleanup() can restore it.
   __OLD_VIRTUAL_ENV="${VIRTUAL_ENV:-}"
 
   if [ "${OVERWRITE_VENV}" -eq 1 ] && [ -d "blob-creation" ]; then
@@ -616,25 +615,48 @@ setup_python() {
     # shellcheck disable=SC1091
     source blob-creation/bin/activate || return 1
     [ "${VIRTUAL_ENV:-}" != "${__OLD_VIRTUAL_ENV:-}" ] && __TSI_CHANGED_VENV=1 || true
-    return 0
+  else
+    run /proj/local/Python-3.11.12/bin/python3 -m venv blob-creation || return 1
+    run bash -c 'source blob-creation/bin/activate && python -V >/dev/null' || return 1
+    # shellcheck disable=SC1091
+    source blob-creation/bin/activate || return 1
+    [ "${VIRTUAL_ENV:-}" != "${__OLD_VIRTUAL_ENV:-}" ] && __TSI_CHANGED_VENV=1 || true
   fi
 
-  run /proj/local/Python-3.11.12/bin/python3 -m venv blob-creation || return 1
-  run bash -c 'source blob-creation/bin/activate && python -V >/dev/null' || return 1
-  # shellcheck disable=SC1091
-  source blob-creation/bin/activate || return 1
-  [ "${VIRTUAL_ENV:-}" != "${__OLD_VIRTUAL_ENV:-}" ] && __TSI_CHANGED_VENV=1 || true
-
-  log_info "installing mlir and python dependencies"
+  log_info "installing mlir / triton python dependencies from SDK"
   run pip install --upgrade pip || return 1
 
-  # Keep torch install as before (this is what your logs show)
-  run pip install torch==2.7.0 || return 1
-
-  # ---- FIX for SDK 0.4.1: requirements-common.txt may include "-r /python/...."
   local REQ_DIR="${MLIR_COMPILER_DIR}/python"
-  local REQ_MAIN="${REQ_DIR}/requirements-common.txt"
+  local TRITON_DIR="${MLIR_SDK_VERSION}/triton"
 
+  [ -d "${REQ_DIR}" ] || die "MLIR python directory not found: ${REQ_DIR}"
+  [ -d "${TRITON_DIR}" ] || die "SDK Triton directory not found: ${TRITON_DIR}"
+
+  # ---------------------------------------------------------------------------
+  # Install latest mlir_external_packages wheel from SDK compiler/python
+  # (your manual flow tried 1.8.2, 1.8.3, 1.9.1; safest is pick highest version)
+  # ---------------------------------------------------------------------------
+  local MLIR_WHL
+  MLIR_WHL="$(ls -1 "${REQ_DIR}"/mlir_external_packages-*.whl 2>/dev/null | sort -V | tail -1 || true)"
+  [ -n "${MLIR_WHL}" ] || die "No mlir_external_packages-*.whl found in ${REQ_DIR}"
+  log_info "Installing MLIR wheel: ${MLIR_WHL}"
+  run pip install "${MLIR_WHL}" || return 1
+
+  # ---------------------------------------------------------------------------
+  # Install latest Tsavorite Triton wheel from SDK triton/
+  # (your manual flow used triton_tsiai-1.0.0 / 0.1.3)
+  # ---------------------------------------------------------------------------
+  local TRITON_WHL
+  TRITON_WHL="$(ls -1 "${TRITON_DIR}"/triton_tsiai-*.whl 2>/dev/null | sort -V | tail -1 || true)"
+  [ -n "${TRITON_WHL}" ] || die "No triton_tsiai-*.whl found in ${TRITON_DIR}"
+  log_info "Installing Triton wheel: ${TRITON_WHL}"
+  run pip install "${TRITON_WHL}" || return 1
+
+  # ---------------------------------------------------------------------------
+  # Install compiler python requirements
+  # Keep the existing rewrite for bad '-r /python/...' includes
+  # ---------------------------------------------------------------------------
+  local REQ_MAIN="${REQ_DIR}/requirements-common.txt"
   if [ ! -f "${REQ_MAIN}" ]; then
     die "requirements-common.txt not found: ${REQ_MAIN}"
   fi
@@ -642,24 +664,43 @@ setup_python() {
   if grep -qE '^[[:space:]]*-r[[:space:]]+/python/' "${REQ_MAIN}"; then
     log_info "requirements-common.txt contains absolute /python includes; rewriting to ${REQ_DIR}"
     local REQ_TMP
-    REQ_TMP="$(mktemp -t tsi-req-XXXXXX.txt)"
+    REQ_TMP="$(mktemp -t tsi-req-XXXXXX.txt)" || return 1
     sed -E "s|(^[[:space:]]*-r[[:space:]]+)/python/|\\1${REQ_DIR}/|g" "${REQ_MAIN}" > "${REQ_TMP}"
-    run pip install -r "${REQ_TMP}" || { rm -f "${REQ_TMP}" >/dev/null 2>&1 || true; return 1; }
+    run pip install -r "${REQ_TMP}" || {
+      rm -f "${REQ_TMP}" >/dev/null 2>&1 || true
+      return 1
+    }
     rm -f "${REQ_TMP}" >/dev/null 2>&1 || true
   else
     run pip install -r "${REQ_MAIN}" || return 1
   fi
-  # ---- END FIX
 
-  local MLIR_WHL
-  MLIR_WHL="$(ls "${MLIR_COMPILER_DIR}/python"/mlir_external_packages-*.whl 2>/dev/null | head -1 || true)"
-  if [ -n "${MLIR_WHL}" ]; then
-    run pip install "${MLIR_WHL}" || return 1
-  else
-    log_info "WARNING: mlir_external_packages wheel not found in ${MLIR_COMPILER_DIR}/python/"
+  # Optional packages that your manual flow used later
+  if ! pip show torch >/dev/null 2>&1; then
+    run pip install torch==2.7.0 || return 1
   fi
 
-  run pip install onnxruntime-training || return 1
+  if ! pip show onnxruntime-training >/dev/null 2>&1; then
+    run pip install onnxruntime-training || return 1
+  fi
+
+  # ---------------------------------------------------------------------------
+  # Export runtime/library paths needed by create-all-kernels.sh
+  # based on your manual env setup
+  # ---------------------------------------------------------------------------
+  export LD_LIBRARY_PATH="${MLIR_SDK_VERSION}/toolbox/build/install-posix/lib:${LD_LIBRARY_PATH:-}"
+  export LD_LIBRARY_PATH="${MLIR_SDK_VERSION}/ffm/txe-ffm-cpp/lib:${LD_LIBRARY_PATH}"
+  export LD_LIBRARY_PATH="${MLIR_SDK_VERSION}/ffm/txe-ffm-wrapper/lib:${LD_LIBRARY_PATH}"
+
+  export LIBRARY_PATH="${MLIR_SDK_VERSION}/ffm/txe-ffm-cpp/lib:${LIBRARY_PATH:-}"
+  export LIBRARY_PATH="${MLIR_SDK_VERSION}/ffm/txe-ffm-wrapper/lib:${LIBRARY_PATH}"
+
+  # Helpful trace
+  log_info "Python: $(python -V 2>/dev/null)"
+  log_info "Using MLIR wheel: ${MLIR_WHL}"
+  log_info "Using Triton wheel: ${TRITON_WHL}"
+  python -c "import triton; print('INFO: triton module:', triton.__file__)" || return 1
+
   return 0
 }
 
@@ -954,19 +995,45 @@ do_clean_all() {
 
 main() {
   set -o pipefail
+
   local arch
+  local ORIG_PWD
+  ORIG_PWD="$(pwd)"
+
   arch="$(select_arch)" || return $?
   parse_args "$@" || return $?
+
   if [ "${SHOW_HELP}" -eq 1 ]; then
     usage
     return 0
   fi
-  if [ "${DO_CLEAN_ALL}" -eq 1 ]; then do_clean_all; return 0; fi
-  if [ "${DO_CLEAN}" -eq 1 ]; then do_clean; return 0; fi
 
-  resolve_paths "$arch" || return $?
-  setup_toolchain || return 1
-  ensure_submodules "${GIT_SUBMODULE_PULL}" || return 1
+  if [ "${DO_CLEAN_ALL}" -eq 1 ]; then
+    do_clean_all
+    cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  if [ "${DO_CLEAN}" -eq 1 ]; then
+    do_clean
+    cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  resolve_paths "$arch" || {
+    cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+    return $?
+  }
+
+  setup_toolchain || {
+    cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+    return 1
+  }
+
+  ensure_submodules "${GIT_SUBMODULE_PULL}" || {
+    cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+    return 1
+  }
 
   local need_python=0
   if [ "${OVERWRITE_VENV}" -eq 1 ] || [ "${DO_BLOB_FPGA}" -eq 1 ] || [ "${DO_BLOB_POSIX}" -eq 1 ]; then
@@ -977,7 +1044,11 @@ main() {
   local auto_fpga_blob=0
 
   if [ "${AUTO_BLOBS}" -eq 1 ]; then
-    cd "${SUBMODULE_DIR}" || return 1
+    cd "${SUBMODULE_DIR}" || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
+
     if [ "${DO_BUILD_POSIX}" -eq 1 ] || [ "${DO_BUILD_POSIX_TMU_ONLY}" -eq 1 ] || [ "${DO_BUILD_POSIX_TMU_DISABLE}" -eq 1 ]; then
       if ! posix_host_objs_present; then
         auto_posix_blob=1
@@ -986,6 +1057,7 @@ main() {
         DO_BLOB_POSIX=1
       fi
     fi
+
     if [ "${DO_BUILD_FPGA}" -eq 1 ] || [ "${DO_BUILD_FPGA_TMU_ONLY}" -eq 1 ] || [ "${DO_BUILD_FPGA_TMU_DISABLE}" -eq 1 ]; then
       if ! fpga_host_objs_present; then
         auto_fpga_blob=1
@@ -994,59 +1066,104 @@ main() {
         DO_BLOB_FPGA=1
       fi
     fi
-    cd .. || return 1
+
+    cd "${ORIG_PWD}" || return 1
   fi
 
   if [ "${need_python}" -eq 1 ] && ( [ "${DO_BLOB_FPGA}" -eq 1 ] || [ "${DO_BLOB_POSIX}" -eq 1 ] ); then
-    cd "${SUBMODULE_DIR}" || die "cannot enter ggml-tsi-kernel"
-    setup_python || return 1
-    [ "${DO_BLOB_FPGA}" -eq 1 ] && build_fpga_blobs || return 1
-    [ "${DO_BLOB_POSIX}" -eq 1 ] && build_posix_blobs || return 1
-    cd .. || return 1
+    (
+      cd "${SUBMODULE_DIR}" || exit 1
+      setup_python || exit 1
+      [ "${DO_BLOB_FPGA}" -eq 1 ] && build_fpga_blobs || exit 1
+      [ "${DO_BLOB_POSIX}" -eq 1 ] && build_posix_blobs || exit 1
+    )
+    local rc=$?
+    cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+    [ $rc -eq 0 ] || return $rc
   fi
 
   if [ "${DO_BUILD_POSIX}" -eq 1 ]; then
-    build_posix || return 1
-    wrap_glibc_bins "build-posix" || return 1
+    build_posix || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
+    wrap_glibc_bins "build-posix" || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
   fi
+
   if [ "${DO_BUILD_POSIX_TMU_ONLY}" -eq 1 ]; then
-    build_posix_tmu_only || return 1
-    wrap_glibc_bins "build-posix-tmu-only" || return 1
+    build_posix_tmu_only || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
+    wrap_glibc_bins "build-posix-tmu-only" || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
   fi
+
   if [ "${DO_BUILD_POSIX_TMU_DISABLE}" -eq 1 ]; then
-    build_posix_tmu_disable || return 1
-    wrap_glibc_bins "build-posix-tmu-disable" || return 1
+    build_posix_tmu_disable || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
+    wrap_glibc_bins "build-posix-tmu-disable" || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
   fi
 
   if [ "${DO_BUILD_FPGA}" -eq 1 ]; then
-    build_fpga || return 1
+    build_fpga || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
     PACKAGE_FPGA_BUILD_DIR="${PACKAGE_FPGA_BUILD_DIR:-build-fpga}"
   fi
+
   if [ "${DO_BUILD_FPGA_TMU_ONLY}" -eq 1 ]; then
-    build_fpga_tmu_only || return 1
+    build_fpga_tmu_only || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
     PACKAGE_FPGA_BUILD_DIR="${PACKAGE_FPGA_BUILD_DIR:-build-fpga-tmu-only}"
   fi
+
   if [ "${DO_BUILD_FPGA_TMU_DISABLE}" -eq 1 ]; then
-    build_fpga_tmu_disable || return 1
+    build_fpga_tmu_disable || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
     PACKAGE_FPGA_BUILD_DIR="${PACKAGE_FPGA_BUILD_DIR:-build-fpga-tmu-disable}"
   fi
 
   if [ "${DO_PACKAGE_FPGA}" -eq 1 ]; then
     local pkg_dir
     pkg_dir="$(choose_existing_fpga_build_dir_for_package)"
-    [ -n "${pkg_dir}" ] || die "package requested but no FPGA build output found (expected build-fpga / build-fpga-tmu-only / build-fpga-tmu-disable)."
-    bundle_fpga "${pkg_dir}" || return 1
+    [ -n "${pkg_dir}" ] || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      die "package requested but no FPGA build output found (expected build-fpga / build-fpga-tmu-only / build-fpga-tmu-disable)."
+    }
+    bundle_fpga "${pkg_dir}" || {
+      cd "${ORIG_PWD}" >/dev/null 2>&1 || true
+      return 1
+    }
   fi
 
   if [ "${auto_posix_blob}" -eq 1 ]; then
     log_info "NOTE: POSIX blobs were auto-built because they are required for linking _mlir_ciface_*_host."
   fi
+
   if [ "${auto_fpga_blob}" -eq 1 ]; then
     log_info "NOTE: FPGA blobs were auto-built because they are required for linking _mlir_ciface_*_host."
   fi
 
+  cd "${ORIG_PWD}" >/dev/null 2>&1 || true
   return 0
 }
+
 
 if [ "$__TSI_SOURCED" -eq 1 ]; then
   trap cleanup RETURN


### PR DESCRIPTION
posix
[akapoor@wspd0 llama.cpp]$  build-posix/bin/llama-cli-original -p "My cat's name is" -m /proj/rel/sw/ggml/models/tinyllama-vo-5m-para.gguf  --device tsavorite -c 12288 --temp 0.0 --n-predict 10 --repeat-penalty 1.5 -b 1024 --top-k 50 --top-p 0.9 --repeat-last-n 5 --no-warmup  --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
 My cat's name is Tim. He has a big, red ball.



llama_perf_sampler_print:    sampling time =      29.39 ms /    17 runs   (    1.73 ms per token,   578.45 tokens per second)
llama_perf_context_print:        load time =     681.66 ms
llama_perf_context_print: prompt eval time =     250.07 ms /     7 tokens (   35.72 ms per token,    27.99 tokens per second)
llama_perf_context_print:        eval time =     474.34 ms /     9 runs   (   52.70 ms per token,    18.97 tokens per second)
llama_perf_context_print:       total time =    1187.98 ms /    16 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          736             820            652335            886.32
  MUL              OPU          782             872            599267            766.33
  RMS_NORM         OPU          782             782            536268            685.76
  MUL_MAT          CPU        13006               0            517742             39.81
  CONT             OPU          736               0             39199             53.26
  RESHAPE          CPU         3835               0               558              0.15
  VIEW             CPU         3708               0               514              0.14
  VIEW             OPU          736               0               136              0.18
  PERMUTE          CPU         2574               0               436              0.17
  PERMUTE          OPU          736               0                59              0.08
  TRANSPOSE        CPU         1277               0               242              0.19
  GET_ROWS         OPU          138               0               182              1.32
  SET_ROWS         CPU         2642               0              1494              0.57
  SOFT_MAX         OPU          368               0             59675            162.16
  ROPE             CPU         2732               0              3482              1.27
  GLU              OPU          368             410            313157            850.97

OPU Profiling Results:
Profiler disabled





tsisim for sdk-4.9
root@tsisim:/usr/bin/tsi/bin/tsi-ggml# cd ..
root@tsisim:/usr/bin/tsi/bin# ls -lrt
total 2360
-rwxr-xr-x 1 root root  113408 Jun 18 16:12 tsictl
-rwxr-xr-x 1 root root 1002553 Jun 18 16:12 tsi_txe_kernel.lst
-rwxr-xr-x 1 root root    1627 Jun 18 16:12 run_llama_cli.sh
-rw-r--r-- 1 root root     546 Jun 18 16:12 platform_layout.json
-rwxr-xr-x 1 root root   47540 Jun 18 16:12 vecadd_blob_tvu_main.blob
-rwxr-xr-x 1 root root  138656 Jun 18 16:12 tsi_txe_kernel.elf
-rwxr-xr-x 1 root root   37196 Jun 18 16:12 tsi_txe_kernel.bin
-rwxr-xr-x 1 root root  673992 Jun 18 16:12 tnApcMgr
-rwxr-xr-x 1 root root   79960 Jun 18 16:12 sys-diagtool
-rwxr-xr-x 1 root root    1967 Jun 18 16:12 run_platform_test.sh
-rwxr-xr-x 1 root root   81216 Jun 18 16:12 recvFromHost
lrwxrwxrwx 1 root root      45 Jun 18 16:12 aot-tests -> /tsi/tsi-sw/sdk/sdk-r.0.4.9/fpga/qa/aot-tests
-rwxr-xr-x 1 root root  214704 Jun 18 16:12 UAP
lrwxrwxrwx 1 root root      31 Jun 18 20:32 tsi-ggml -> /tsi/tsi-sw/anoop_ggml/tsi-ggml
root@tsisim:/usr/bin/tsi/bin# 



############
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
 was Tim. He loved

llama_perf_sampler_print:    sampling time =     106.84 ms /    11 runs   (    9.71 ms per token,   102.96 tokens per second)
llama_perf_context_print:        load time =    5942.99 ms


llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =    3529.33 ms /     4 runs   (  882.33 ms per token,     1.13 tokens per second)
llama_perf_context_print:       total time =    8921.84 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          160             160           4191619          26197.62
  MUL              OPU          170             170           1218886           7169.92
  RMS_NORM         OPU          170             170           1843687          10845.22
  MUL_MAT          CPU         2875               0           1774839            617.34
  CONT             OPU          160               0            117868            736.67
  RESHAPE          CPU          936               0              2887              3.08
  VIEW             CPU          938               0              2246              2.39
  VIEW             OPU          160               0               315              1.97
  PERMUTE          CPU          603               0              1576              2.61
  PERMUTE          OPU          160               0               306              1.91
  TRANSPOSE        CPU          316               0              1172              3.71
  GET_ROWS         OPU           30               0              5778            192.60
  SET_ROWS         CPU          631               0             24736             39.20
  SOFT_MAX         OPU           80               0             96054           1200.67
  ROPE             CPU          618               0             48190             77.98
  GLU              OPU           80              80           1186462          14830.77

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# cd tsi-ggml
root@tsisim:/usr/bin/tsi/bin/tsi-ggml#   ./simple-backend-tsi "add"
load_model: using TSavorite backend 

 TSI deploy yaml=/usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0

 Calculating mem_size 400  2  and creating ggml context 

 Creating input Tensor 

 Creating Backend Buffer 

 Loading Input Tensor Data to Backend Buffer 

Bringing  tensor data from Backend buffer and printing 32  tensor data:
[ 1.10 2.30 3.20 4.00 5.00 6.00 7.00 8.00 9.00 10.00 11.00 12.00 13.00 14.00 15.00 16.00 17.00 18.00 19.00 20.00 21.00 22.00 23.00 24.00 25.00 26.00 27.00 28.00 29.00 30.00 31.00 32.00 ]
main: compute buffer size: 0.5000 KB

 Under Test case for  compute API creating  build_graph  

 Compute Done 

 operation type: add, num of elements 32  

 compute is also done 
Index 0: expected bits 400ccccd, actual bits 400ccccd
Index 1: expected bits 40900000, actual bits 40900000
Index 2: expected bits 40d00000, actual bits 40d00000
Index 3: expected bits 41000000, actual bits 41000000
Index 4: expected bits 41200000, actual bits 41200000
Index 5: expected bits 41400000, actual bits 41400000
Index 6: expected bits 41600000, actual bits 41600000
Index 7: expected bits 41800000, actual bits 41800000
Index 8: expected bits 41900000, actual bits 41900000
Index 9: expected bits 41a00000, actual bits 41a00000
Index 10: expected bits 41b00000, actual bits 41b00000
Index 11: expected bits 41c00000, actual bits 41c00000
Index 12: expected bits 41d00000, actual bits 41d00000
Index 13: expected bits 41e00000, actual bits 41e00000
Index 14: expected bits 41f00000, actual bits 41f00000
Index 15: expected bits 42000000, actual bits 42000000
Index 16: expected bits 42080000, actual bits 42080000
Index 17: expected bits 42100000, actual bits 42100000
Index 18: expected bits 42180000, actual bits 42180000
Index 19: expected bits 42200000, actual bits 42200000
Index 20: expected bits 42280000, actual bits 42280000
Index 21: expected bits 42300000, actual bits 42300000
Index 22: expected bits 42380000, actual bits 42380000
Index 23: expected bits 42400000, actual bits 42400000
Index 24: expected bits 42480000, actual bits 42480000
Index 25: expected bits 42500000, actual bits 42500000
Index 26: expected bits 42580000, actual bits 42580000
Index 27: expected bits 42600000, actual bits 42600000
Index 28: expected bits 42680000, actual bits 42680000
Index 29: expected bits 42700000, actual bits 42700000
Index 30: expected bits 42780000, actual bits 42780000
Index 31: expected bits 42800000, actual bits 42800000


 TEST CASE PASSED 


OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin/tsi-ggml# 
root@tsisim:/usr/bin/tsi/bin/tsi-ggml# 




##########
MULTI_TXE SUPPORT
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=2 multi_thread_enable=1
 was Tim. He loved



llama_perf_sampler_print:    sampling time =     110.88 ms /    11 runs   (   10.08 ms per token,    99.21 tokens per second)
llama_perf_context_print:        load time =    7593.20 ms
llama_perf_context_print: prompt eval time =    2223.65 ms /     6 tokens (  370.61 ms per token,     2.70 tokens per second)
llama_perf_context_print:        eval time =    2248.63 ms /     4 runs   (  562.16 ms per token,     1.78 tokens per second)
llama_perf_context_print:       total time =    9986.56 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          176             246           1796707          10208.56
  MUL              OPU          187             262            407264           2177.88
  RMS_NORM         OPU          187             187            120699            645.45
  MUL_MAT          CPU         3204               0           1456312            454.53
  CONT             OPU          176               0            118156            671.34
  RESHAPE          CPU         1056               0              5929              5.61
  VIEW             CPU         1055               0              1786              1.69
  VIEW             OPU          176               0               280              1.59
  PERMUTE          CPU          704               0              1585              2.25
  PERMUTE          OPU          176               0               246              1.40
  TRANSPOSE        CPU          345               0               749              2.17
  GET_ROWS         OPU           33               0              1425             43.18
  SET_ROWS         CPU          702               0              7765             11.06
  SOFT_MAX         OPU           88               0            131957           1499.51
  ROPE             CPU          704               0             18813             26.72
  GLU              OPU           88             123           1770203          20115.94

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
