### PR TITLE
@FIR-1988: Disable only CPU ROPE operations via Tsavorite Backend

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2091,7 +2091,6 @@ static bool ggml_tsavorite_internal_supports_op(const struct ggml_tensor *op) {
   switch (op->op) {
   case GGML_OP_SET_ROWS:
           return true;
-#ifndef OLLAMA
   case GGML_OP_GET_ROWS:
           return true;
 #ifdef GGML_MUL_MAT_CPU_OPS
@@ -2106,10 +2105,12 @@ static bool ggml_tsavorite_internal_supports_op(const struct ggml_tensor *op) {
           return true;
   case GGML_OP_GET_ROWS_BACK:
           return true;
+#ifndef OLLAMA
   case GGML_OP_ROPE:
           return true;
   case GGML_OP_ROPE_BACK:
           return true;
+#endif
   case GGML_OP_RESHAPE:
           return true;
   case GGML_OP_VIEW:
@@ -2122,7 +2123,6 @@ static bool ggml_tsavorite_internal_supports_op(const struct ggml_tensor *op) {
           return true;
   case GGML_OP_CONT:
           return true;
-#endif
   default:
 	  break;
 	}


### PR DESCRIPTION
The ROPE operation is resulting an assert when being invoked by Tsavorite backend So disabling only ROPE operations and enabling all other operations via Tsavorite backend

here are the test results

Ollama server
22:33:32,095: Jun 22 22:33:31 tsisim ollama[1436]: llama_kv_cache: size =   60.00 MiB (  4096 cells,  15 layers,  1/1 seqs), K (f16):   30.00 MiB, V (f16):   30.00 MiB
22:33:33,598: Jun 22 22:33:33 tsisim ollama[1436]: llama_context:  tsavorite compute buffer size =   171.25 MiB
22:33:33,598: Jun 22 22:33:33 tsisim ollama[1436]: llama_context:        CPU compute buffer size =   513.25 MiB
22:33:33,600: Jun 22 22:33:33 tsisim ollama[1436]: llama_context: graph nodes  = 729
22:33:33,603: Jun 22 22:33:33 tsisim ollama[1436]: llama_context: graph splits = 261
22:33:33,606: Jun 22 22:33:33 tsisim ollama[1436]: time=2026-06-22T22:33:33.364Z level=INFO source=server.go:1312 msg="llama runner started in 12.03 seconds"
22:34:23,595: Jun 22 22:34:23 tsisim ollama[1485]:  TSI deploy yaml=/opt/taos/app/ollama-arm64-release/bin/tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
22:34:23,598: Jun 22 22:34:23 tsisim ollama[1485]:  finalize 4
22:34:23,601: Jun 22 22:34:23 tsisim ollama[1485]: OPU Profiling Results:
22:34:23,603: Jun 22 22:34:23 tsisim ollama[1485]: Profiler disabled
22:34:23,605: Jun 22 22:34:23 tsisim ollama[1436]: [GIN] 2026/06/22 - 22:34:23 | 200 |          1m3s |       127.0.0.1 | POST     "/api/generate"
22:39:23,595: Jun 22 22:39:23 tsisim ollama[1436]: time=2026-06-22T22:39:23.209Z level=WARN source=server.go:1757 msg="llama server stopped" pid=1485



Ollama client
root@tsisim:/opt/taos/app# ollama run Gemma3:270M "Where is Amazon river?"
pulling manifest 
pulling 735af2139dc6: 100% ▕████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏ 291 MB                         
pulling 4b19ac7dd2fb: 100% ▕████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏  476 B                         
pulling 3e2c24001f9e: 100% ▕████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏ 8.4 KB                         
pulling 339e884a40f6: 100% ▕████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏   61 B                         
pulling 74156d92caf6: 100% ▕████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏  490 B                         
verifying sha256 digest 
writing manifest 
success 
Amazon River is located in **South America**.


