### PR TITLE
@FIR-1822 - Triton Kernel: 2-Dimension Matrix multiplication implementation and integrate with TSiSIM

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2000,44 +2000,181 @@ static bool is_op_dtype_consistent_with_src(const struct ggml_tensor *op) {
 
 //TMU Test case
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
+    if (!op) return false;
+
     const struct ggml_tensor *a = op->src[0];
     const struct ggml_tensor *b = op->src[1];
 
     if (!a || !b) return false;
 
+    // Current Triton MAT_MUL path supports only F32/F32/F32.
+    if (a->type  != GGML_TYPE_F32 ||
+        b->type  != GGML_TYPE_F32 ||
+        op->type != GGML_TYPE_F32) {
+        return false;
+    }
+
     // GGML MUL_MAT:
-    //   a/src0: [K, output_cols]
-    //   b/src1: [K, batch]
-    //   op/dst: [output_cols, batch]
-    const int64_t K          = a->ne[0];
-    const int64_t OUT_COLS   = op->ne[0];
-    const int64_t BATCH_COLS = op->ne[1];
+    //   src0/a: [K, M, 1, 1]
+    //   src1/b: [K, N, 1, 1]
+    //   dst/op: [M, N, 1, 1]
+    const int64_t K = a->ne[0];
+    const int64_t M = a->ne[1];
+    const int64_t N = b->ne[1];
 
-    if (K <= 0 || OUT_COLS <= 0 || BATCH_COLS <= 0) return false;
-
-    // Current Triton path only supports F32 path and K decomposed by 32.
-    if ((K % 32) != 0) return false;
+    if (K <= 0 || M <= 0 || N <= 0) return false;
 
     // Reduction dim must match.
     if (b->ne[0] != K) return false;
 
-    // Output shape must match expected GGML MUL_MAT relation.
-    if (a->ne[1] != OUT_COLS) return false;
-    if (b->ne[1] != BATCH_COLS) return false;
+    // Output shape must match.
+    if (op->ne[0] != M) return false;
+    if (op->ne[1] != N) return false;
 
-    // Avoid GEMV / single-column cases for now.
-    // ggml_tsavorite_run_tmu_mul_mat() currently rejects src1->ne[1] == 1.
-    if (b->ne[1] == 1) return false;
-
-    // IMPORTANT:
-    // Keep only simple 2D matmul for now.
-    // Do not enable broadcast / batched 3D/4D shapes yet.
+    // Only 2D for now.
     if (op->ne[2] != 1 || op->ne[3] != 1) return false;
     if (a->ne[2]  != 1 || a->ne[3]  != 1) return false;
     if (b->ne[2]  != 1 || b->ne[3]  != 1) return false;
 
+    // Triton kernel constraint.
+    if ((K % 32) != 0) return false;
+
+    // Safety limits for dynamic packed buffers.
+    static constexpr int64_t TSI_TRITON_MAX_K = 8192;
+    static constexpr int64_t TSI_TRITON_MAX_M = 32768;
+    static constexpr int64_t TSI_TRITON_MAX_N = 4096;
+
+    if (K > TSI_TRITON_MAX_K) return false;
+    if (M > TSI_TRITON_MAX_M) return false;
+    if (N > TSI_TRITON_MAX_N) return false;
+
+    // Local round-up helper because tsi_round_up_i64 is declared later in this file.
+    auto round_up_i64_local = [](int64_t v, int64_t a) -> int64_t {
+        return ((v + a - 1) / a) * a;
+    };
+
+    const int64_t M_pad = round_up_i64_local(M, 8);
+    const int64_t N_pad = round_up_i64_local(N, 64);
+
+    const int64_t elems_A = M_pad * K;
+    const int64_t elems_B = K * N_pad;
+    const int64_t elems_C = M_pad * N_pad;
+
+    // ~512 MB packed workspace guard.
+    static constexpr int64_t TSI_TRITON_MAX_PACKED_FLOATS =
+        (512LL * 1024LL * 1024LL) / (int64_t)sizeof(float);
+
+    if (elems_A <= 0 || elems_B <= 0 || elems_C <= 0) return false;
+
+    if (elems_A + elems_B + elems_C > TSI_TRITON_MAX_PACKED_FLOATS) {
+        return false;
+    }
+
     return true;
 }
+
+
+
+#if phase1
+static bool mul_mat_supported_size(const struct ggml_tensor *op) {
+    const struct ggml_tensor *a = op->src[0];
+    const struct ggml_tensor *b = op->src[1];
+
+    if (!a || !b) return false;
+
+    const int64_t K = a->ne[0];
+    const int64_t M = a->ne[1];
+    const int64_t N = b->ne[1];
+
+    // =====================================================
+    // ✅ BASIC SAFETY (DO NOT CHANGE)
+    // =====================================================
+    if (K <= 0 || M <= 0 || N <= 0) return false;
+
+    if (b->ne[0] != K) return false;
+
+    if (a->ne[1] != op->ne[0]) return false;
+    if (b->ne[1] != op->ne[1]) return false;
+
+    // Only 2D tensors (important)
+    if (op->ne[2] != 1 || op->ne[3] != 1) return false;
+    if (a->ne[2]  != 1 || a->ne[3]  != 1) return false;
+    if (b->ne[2]  != 1 || b->ne[3]  != 1) return false;
+
+    // skip GEMV for now
+    if (N == 1) return false;
+
+    // Triton requirement
+    if ((K % 32) != 0) return false;
+
+    // DEBUG (KEEP ON until stable)
+    //printf("CHECK: K=%ld M=%ld N=%ld\n", K, M, N);
+
+
+    // =====================================================
+    // ✅ PHASE 1 — GUARANTEED HIT (START HERE)
+    // Goal: confirm routing to OPU works again
+    // =====================================================
+#if 1
+    if ((K % 32) == 0 && N != 1) {
+        return true;   // broad allow
+    }
+    return false;
+#endif
+
+
+    // =====================================================
+    // ✅ PHASE 2 — CONTROLLED (REAL SHAPES)
+    // Enable after Phase 1 stable
+    // =====================================================
+#if 1
+    if (K == 576 &&
+        (M == 576 || M == 192 || M == 128 || M == 1) &&
+        (N >= 2 && N <= 64)) {
+        return true;
+    }
+    return false;
+#endif
+
+
+    // =====================================================
+    // ✅ PHASE 3 — ADD LARGE K (1536)
+    // =====================================================
+#if 3
+    if ((K == 576 || K == 1536) &&
+        (M == 576 || M == 192 || M == 1536 || M == 128) &&
+        (N >= 2 && N <= 64)) {
+        return true;
+    }
+    return false;
+#endif
+
+
+    // =====================================================
+    // ✅ PHASE 4 — SMALL SHAPES (attention path)
+    // =====================================================
+#if 4
+    if ((K == 576 || K == 1536 || K == 256 || K == 64) &&
+        (M == 576 || M == 192 || M == 1536 || M == 256 || M == 64 || M == 1) &&
+        (N >= 2 && N <= 128)) {
+        return true;
+    }
+    return false;
+#endif
+
+
+    // =====================================================
+    // ✅ FINAL — ALL SAFE TRITON SHAPES
+    // =====================================================
+#if 5
+    if ((K % 32) == 0 && N != 1) {
+        return true;
+    }
+    return false;
+#endif
+}
+#endif /* phase1 */
+
 
 
 #if 0
@@ -2476,45 +2613,58 @@ static inline int64_t tsi_round_up_i64(int64_t v, int64_t a) {
 static constexpr int32_t TRITON_FULL_M_TILE = 64;
 static constexpr int32_t TRITON_FULL_N_TILE = 64;
 
-static float *g_triton_A_full = nullptr; // [64 x K_cap]
-static float *g_triton_B_full = nullptr; // [K_cap x 64]
-static float *g_triton_C_full = nullptr; // [64 x 64]
+static float *g_triton_A_full = nullptr; // [M_cap x K_cap]
+static float *g_triton_B_full = nullptr; // [K_cap x N_cap]
+static float *g_triton_C_full = nullptr; // [M_cap x N_cap]
+
+static int64_t g_triton_M_cap = 0;
+static int64_t g_triton_N_cap = 0;
 static int64_t g_triton_K_cap = 0;
 
-static inline void ensure_triton_full_buffers(int64_t K) {
+static inline void ensure_triton_full_buffers(int64_t M_pad, int64_t N_pad, int64_t K) {
+    TSAVORITE_GGML_ASSERT(M_pad > 0);
+    TSAVORITE_GGML_ASSERT(N_pad > 0);
     TSAVORITE_GGML_ASSERT(K > 0);
 
+    TSAVORITE_GGML_ASSERT((M_pad % 8) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % 64) == 0);
+    TSAVORITE_GGML_ASSERT((K % 32) == 0);
+
+    const int64_t need_M = M_pad;
+    const int64_t need_N = N_pad;
     const int64_t need_K = tsi_round_up_i64(K, 32);
 
-    // Allocate at least 2048 once so we do not grow/re-allocate for common model K values.
-    const int64_t alloc_K = (need_K > 2048) ? need_K : 2048;
+    if (!g_triton_A_full || !g_triton_B_full || !g_triton_C_full ||
+        need_M > g_triton_M_cap ||
+        need_N > g_triton_N_cap ||
+        need_K > g_triton_K_cap) {
 
-    if (!g_triton_C_full) {
-        g_triton_C_full = (float *) tsi_alloc(
-            (size_t) TRITON_FULL_M_TILE *
-            (size_t) TRITON_FULL_N_TILE *
-            sizeof(float));
-
-        TSAVORITE_GGML_ASSERT(g_triton_C_full);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_C_full) & 127) == 0);
-    }
-
-    if (!g_triton_A_full || !g_triton_B_full || alloc_K > g_triton_K_cap) {
-        g_triton_K_cap = alloc_K;
+        g_triton_M_cap = need_M;
+        g_triton_N_cap = need_N;
+        g_triton_K_cap = need_K;
 
         g_triton_A_full = (float *) tsi_alloc(
-            (size_t) TRITON_FULL_M_TILE *
+            (size_t) g_triton_M_cap *
             (size_t) g_triton_K_cap *
             sizeof(float));
 
         g_triton_B_full = (float *) tsi_alloc(
             (size_t) g_triton_K_cap *
-            (size_t) TRITON_FULL_N_TILE *
+            (size_t) g_triton_N_cap *
             sizeof(float));
 
-        TSAVORITE_GGML_ASSERT(g_triton_A_full && g_triton_B_full);
+        g_triton_C_full = (float *) tsi_alloc(
+            (size_t) g_triton_M_cap *
+            (size_t) g_triton_N_cap *
+            sizeof(float));
+
+        TSAVORITE_GGML_ASSERT(g_triton_A_full);
+        TSAVORITE_GGML_ASSERT(g_triton_B_full);
+        TSAVORITE_GGML_ASSERT(g_triton_C_full);
+
         TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_A_full) & 127) == 0);
         TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_B_full) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_C_full) & 127) == 0);
     }
 }
 
@@ -2819,245 +2969,93 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     if (K <= 0 || M <= 0 || N <= 0) return GGML_STATUS_FAILED;
     if (src1->ne[0] != K) return GGML_STATUS_FAILED;
     if ((K % 32) != 0) return GGML_STATUS_FAILED;
-    if (src1->ne[1] == 1) return GGML_STATUS_FAILED;
 
-    ensure_triton_full_buffers(K);
+    // 2D only.
+    if (node->ne[2] != 1 || node->ne[3] != 1) return GGML_STATUS_FAILED;
+    if (src0->ne[2] != 1 || src0->ne[3] != 1) return GGML_STATUS_FAILED;
+    if (src1->ne[2] != 1 || src1->ne[3] != 1) return GGML_STATUS_FAILED;
 
-#ifdef TMU_DEBUG_VALIDATE
-    static float C_ref_tile[TRITON_FULL_M_TILE * TRITON_FULL_N_TILE];
-#endif
+    if (node->ne[0] != M) return GGML_STATUS_FAILED;
+    if (node->ne[1] != N) return GGML_STATUS_FAILED;
+
+    const int64_t M_pad = tsi_round_up_i64(M, 8);
+    const int64_t N_pad = tsi_round_up_i64(N, 64);
+
+    ensure_triton_full_buffers(M_pad, N_pad, K);
 
     const int64_t a_nb0 = nb_or_default(src0, 0);
     const int64_t a_nb1 = nb_or_default(src0, 1);
-    const int64_t a_nb2 = nb_or_default(src0, 2);
-    const int64_t a_nb3 = nb_or_default(src0, 3);
 
     const int64_t b_nb0 = nb_or_default(src1, 0);
     const int64_t b_nb1 = nb_or_default(src1, 1);
-    const int64_t b_nb2 = nb_or_default(src1, 2);
-    const int64_t b_nb3 = nb_or_default(src1, 3);
 
     const int64_t c_nb0 = nb_or_default(node, 0);
     const int64_t c_nb1 = nb_or_default(node, 1);
-    const int64_t c_nb2 = nb_or_default(node, 2);
-    const int64_t c_nb3 = nb_or_default(node, 3);
 
-    const int64_t A2 = src0->ne[2] ? src0->ne[2] : 1;
-    const int64_t A3 = src0->ne[3] ? src0->ne[3] : 1;
-    const int64_t B2 = src1->ne[2] ? src1->ne[2] : 1;
-    const int64_t B3 = src1->ne[3] ? src1->ne[3] : 1;
+    // Pack A: [M_pad x K]
+    memset(g_triton_A_full, 0, (size_t) M_pad * (size_t) K * sizeof(float));
 
-    const int64_t D2 = (A2 > B2) ? A2 : B2;
-    const int64_t D3 = (A3 > B3) ? A3 : B3;
+    for (int64_t r = 0; r < M; ++r) {
+        const char *src_row = (const char *) src0->data + r * a_nb1;
+        float *dst_row = g_triton_A_full + r * K;
 
-    for (int64_t od3 = 0; od3 < D3; ++od3) {
-        const int64_t a_d3 = map_repeat_i64(od3, A3);
-        const int64_t b_d3 = map_repeat_i64(od3, B3);
+        if (a_nb0 == (int64_t) sizeof(float)) {
+            memcpy(dst_row, src_row, (size_t) K * sizeof(float));
+        } else {
+            for (int64_t kk = 0; kk < K; ++kk) {
+                dst_row[kk] = *(const float *)(src_row + kk * a_nb0);
+            }
+        }
+    }
 
-        for (int64_t od2 = 0; od2 < D2; ++od2) {
-            const int64_t a_d2 = map_repeat_i64(od2, A2);
-            const int64_t b_d2 = map_repeat_i64(od2, B2);
+    // Pack B: [K x N_pad]
+    memset(g_triton_B_full, 0, (size_t) K * (size_t) N_pad * sizeof(float));
 
-            const char *A_base_d23 =
-                (const char *) src0->data + a_d2 * a_nb2 + a_d3 * a_nb3;
+    for (int64_t c = 0; c < N; ++c) {
+        const char *src_col = (const char *) src1->data + c * b_nb1;
 
-            const char *B_base_d23 =
-                (const char *) src1->data + b_d2 * b_nb2 + b_d3 * b_nb3;
+        for (int64_t kk = 0; kk < K; ++kk) {
+            g_triton_B_full[kk * N_pad + c] =
+                *(const float *)(src_col + kk * b_nb0);
+        }
+    }
 
-            for (int64_t m0 = 0; m0 < M; m0 += TRITON_FULL_M_TILE) {
-                const int64_t m_valid =
-                    (M - m0 > TRITON_FULL_M_TILE) ? TRITON_FULL_M_TILE : (M - m0);
+    // C must be zero because Triton kernel does:
+    // acc = load(C); acc += dot(A, B)
+    memset(g_triton_C_full, 0, (size_t) M_pad * (size_t) N_pad * sizeof(float));
 
-                const int64_t M_pad = tsi_round_up_i64(m_valid, 8);
+    // Single Triton call for full 2D MAT_MUL/GEMV.
+    call_triton_matmul_full_packed(
+        g_triton_A_full,
+        g_triton_B_full,
+        g_triton_C_full,
+        (int32_t) M_pad,
+        (int32_t) N_pad,
+        (int32_t) K);
 
-                for (int64_t n0 = 0; n0 < N; n0 += TRITON_FULL_N_TILE) {
-                    const int64_t n_valid =
-                        (N - n0 > TRITON_FULL_N_TILE) ? TRITON_FULL_N_TILE : (N - n0);
+    if (device) {
+        ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
+    }
+    ++node->tsi_kernel_runs;
 
-                    const int64_t N_pad = TRITON_FULL_N_TILE;
+    // Copy back dst [M x N]
+    {
+        char *dst_base = (char *) node->data;
+        const size_t bytes_total = (size_t) ggml_nbytes(node);
 
-                    // ---------------------------------------------------------
-                    // Pack A as Triton-native row-major [M_pad x K].
-                    // Optimization:
-                    // - If rows are contiguous, use memcpy per row.
-                    // - Only memset A when padding rows are needed.
-                    // ---------------------------------------------------------
-                    if (m_valid < M_pad) {
-                        memset(g_triton_A_full, 0,
-                               (size_t) M_pad * (size_t) K * sizeof(float));
-                    }
+        for (int64_t r = 0; r < M; ++r) {
+            for (int64_t c = 0; c < N; ++c) {
+                const int64_t byte_off =
+                    r * c_nb0 +
+                    c * c_nb1;
 
-                    if (a_nb0 == (int64_t) sizeof(float)) {
-                        for (int64_t r = 0; r < m_valid; ++r) {
-                            const int64_t m_idx = m0 + r;
-
-                            const char *src_row =
-                                A_base_d23 + m_idx * a_nb1;
-
-                            float *dst_row =
-                                g_triton_A_full + r * K;
-
-                            memcpy(dst_row, src_row, (size_t) K * sizeof(float));
-                        }
-                    } else {
-                        if (m_valid == M_pad) {
-                            // No padding rows, but non-contiguous K stride.
-                            // Every valid element is written below, so no memset required.
-                        }
-
-                        for (int64_t r = 0; r < m_valid; ++r) {
-                            const int64_t m_idx = m0 + r;
-
-                            const char *src_row =
-                                A_base_d23 + m_idx * a_nb1;
-
-                            float *dst_row =
-                                g_triton_A_full + r * K;
-
-                            for (int64_t kk = 0; kk < K; ++kk) {
-                                dst_row[kk] =
-                                    *(const float *)(src_row + kk * a_nb0);
-                            }
-                        }
-                    }
-
-                    // ---------------------------------------------------------
-                    // Pack B as Triton-native row-major [K x N_pad].
-                    // Optimization:
-                    // - If full N tile, every B element is written, so skip memset.
-                    // - If tail N tile, memset is required to zero padded columns.
-                    // ---------------------------------------------------------
-                    if (n_valid < N_pad) {
-                        memset(g_triton_B_full, 0,
-                               (size_t) K * (size_t) N_pad * sizeof(float));
-                    }
-
-                    for (int64_t c = 0; c < n_valid; ++c) {
-                        const int64_t n_idx = n0 + c;
-
-                        const char *src_col =
-                            B_base_d23 + n_idx * b_nb1;
-
-                        for (int64_t kk = 0; kk < K; ++kk) {
-                            g_triton_B_full[kk * N_pad + c] =
-                                *(const float *)(src_col + kk * b_nb0);
-                        }
-                    }
-
-                    // ---------------------------------------------------------
-                    // C must be zero because Triton does:
-                    //   acc = load(C)
-                    //   acc += dot(A,B)
-                    // ---------------------------------------------------------
-                    memset(g_triton_C_full, 0,
-                           (size_t) M_pad * (size_t) N_pad * sizeof(float));
-
-                    call_triton_matmul_full_packed(
-                        g_triton_A_full,
-                        g_triton_B_full,
-                        g_triton_C_full,
-                        (int32_t) M_pad,
-                        (int32_t) N_pad,
-                        (int32_t) K);
-
-                    if (device) {
-                        ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
-                    }
-                    ++node->tsi_kernel_runs;
-
-#ifdef TMU_DEBUG_VALIDATE
-                    memset(C_ref_tile, 0, sizeof(C_ref_tile));
-
-                    for (int64_t rr = 0; rr < m_valid; ++rr) {
-                        const int64_t m_idx = m0 + rr;
-                        const char *a_row =
-                            A_base_d23 + m_idx * a_nb1;
-
-                        for (int64_t cc = 0; cc < n_valid; ++cc) {
-                            const int64_t n_idx = n0 + cc;
-                            const char *b_col =
-                                B_base_d23 + n_idx * b_nb1;
-
-                            float acc = 0.0f;
-
-                            for (int64_t kk = 0; kk < K; ++kk) {
-                                const float av =
-                                    *(const float *)(a_row + kk * a_nb0);
-                                const float bv =
-                                    *(const float *)(b_col + kk * b_nb0);
-                                acc += av * bv;
-                            }
-
-                            C_ref_tile[rr * N_pad + cc] = acc;
-                        }
-                    }
-
-                    for (int64_t rr = 0; rr < m_valid; ++rr) {
-                        for (int64_t cc = 0; cc < n_valid; ++cc) {
-                            const float tmu_v =
-                                g_triton_C_full[rr * N_pad + cc];
-
-                            const float ref_v =
-                                C_ref_tile[rr * N_pad + cc];
-
-                            const float abs_err = fabsf(tmu_v - ref_v);
-                            const float rel_err =
-                                abs_err / fmaxf(1.0f, fabsf(ref_v));
-
-                            if (abs_err > 1e-3f && rel_err > 1e-5f) {
-                                fprintf(stderr,
-                                        "\nTRITON FULL MATMUL MISMATCH\n"
-                                        "m0=%ld n0=%ld K=%ld\n"
-                                        "r=%ld c=%ld TRITON=%f REF=%f ABS=%e REL=%e\n",
-                                        (long)m0,
-                                        (long)n0,
-                                        (long)K,
-                                        (long)rr,
-                                        (long)cc,
-                                        tmu_v,
-                                        ref_v,
-                                        abs_err,
-                                        rel_err);
-
-                                tsi_cleanup();
-                                abort();
-                            }
-                        }
-                    }
-#endif
-
-                    // ---------------------------------------------------------
-                    // Copy valid result back to GGML output.
-                    // Keep element-wise copy because GGML output layout/stride
-                    // is not row-major [M x N] in the same physical order.
-                    // ---------------------------------------------------------
-                    {
-                        char *dst_base = (char *) node->data;
-                        const size_t bytes_total = (size_t) ggml_nbytes(node);
-
-                        for (int64_t rr = 0; rr < m_valid; ++rr) {
-                            const int64_t m_idx = m0 + rr;
-
-                            for (int64_t cc = 0; cc < n_valid; ++cc) {
-                                const int64_t n_idx = n0 + cc;
-
-                                const int64_t byte_off =
-                                    m_idx * c_nb0 +
-                                    n_idx * c_nb1 +
-                                    od2   * c_nb2 +
-                                    od3   * c_nb3;
-
-                                if (byte_off < 0 ||
-                                    (size_t) byte_off + sizeof(float) > bytes_total) {
-                                    continue;
-                                }
-
-                                *(float *)(dst_base + byte_off) =
-                                    g_triton_C_full[rr * N_pad + cc];
-                            }
-                        }
-                    }
+                if (byte_off < 0 ||
+                    (size_t) byte_off + sizeof(float) > bytes_total) {
+                    continue;
                 }
+
+                *(float *)(dst_base + byte_off) =
+                    g_triton_C_full[r * N_pad + c];
             }
         }
     }

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -59,6 +59,7 @@ using namespace tsi::runtime;
 // This will  go in deployment file at next PR
 #define NUM_OF_TXES 2
 
+
 // ggml-tsavorite.cpp
 namespace {
 
@@ -1998,7 +1999,8 @@ static bool is_op_dtype_consistent_with_src(const struct ggml_tensor *op) {
   return true;
 }
 
-//TMU Test case
+
+#if TRITON_MAT_MUL
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     if (!op) return false;
 
@@ -2067,6 +2069,7 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
          * Temporary debug for SS-1345:
          * Print each rejected shape only once to avoid flooding logs.
          */
+#if TRITON_DEBUG
         static std::mutex s_reject_log_mutex;
         static std::vector<std::string> s_reject_log_keys;
 
@@ -2077,7 +2080,6 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
                  (long) M_pad, (long) N_pad,
                  (long) total_bytes);
 
-#if 0
         bool already_logged = false;
         {
             std::lock_guard<std::mutex> lock(s_reject_log_mutex);
@@ -2106,7 +2108,7 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
                     (long) b->ne[0],  (long) b->ne[1],  (long) b->ne[2],  (long) b->ne[3],
                     (long) op->ne[0], (long) op->ne[1], (long) op->ne[2], (long) op->ne[3]);
         }
-#endif /* 0 */
+#endif /* TRITON_DEBUG */
 
         return false;
     }
@@ -2148,7 +2150,7 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
         N == 1) {
 
         if (K == 64 && M == 256) {
-#if 0
+#if TRITON_DEBUG
             fprintf(stderr,
                     "MUL_MAT_4D_ENABLE_PHASE1: K=%ld M=%ld N=%ld "
                     "a=[%ld,%ld,%ld,%ld] b=[%ld,%ld,%ld,%ld] op=[%ld,%ld,%ld,%ld]\n",
@@ -2156,12 +2158,12 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
                     (long) a->ne[0],  (long) a->ne[1],  (long) a->ne[2],  (long) a->ne[3],
                     (long) b->ne[0],  (long) b->ne[1],  (long) b->ne[2],  (long) b->ne[3],
                     (long) op->ne[0], (long) op->ne[1], (long) op->ne[2], (long) op->ne[3]);
-#endif /* 0 */
+#endif /* TRITON_DEBUG */
             return true;
         }
 
         if (K == 256 && M == 64) {
-#if 0
+#if TRITON_DEBUG
             fprintf(stderr,
                     "MUL_MAT_4D_ENABLE_PHASE1: K=%ld M=%ld N=%ld "
                     "a=[%ld,%ld,%ld,%ld] b=[%ld,%ld,%ld,%ld] op=[%ld,%ld,%ld,%ld]\n",
@@ -2169,7 +2171,7 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
                     (long) a->ne[0],  (long) a->ne[1],  (long) a->ne[2],  (long) a->ne[3],
                     (long) b->ne[0],  (long) b->ne[1],  (long) b->ne[2],  (long) b->ne[3],
                     (long) op->ne[0], (long) op->ne[1], (long) op->ne[2], (long) op->ne[3]);
-#endif /* 0 */
+#endif /* TRITON_DEBUG */
             return true;
         }
     }
@@ -2177,85 +2179,7 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     return false;
 }
 
-
-
-
-#if 0
-static bool mul_mat_supported_size(const struct ggml_tensor *op) {
-    if (!op) return false;
-
-    const struct ggml_tensor *a = op->src[0];
-    const struct ggml_tensor *b = op->src[1];
-    if (!a || !b) return false;
-
-    // Only F32 Triton MAT_MUL path for now.
-    if (a->type != GGML_TYPE_F32 ||
-        b->type != GGML_TYPE_F32 ||
-        op->type != GGML_TYPE_F32) {
-        return false;
-    }
-
-    // GGML MUL_MAT:
-    //   a/src0: [K, M, 1, 1]
-    //   b/src1: [K, N, 1, 1]
-    //   op/dst: [M, N, 1, 1]
-    const int64_t K = a->ne[0];
-    const int64_t M = a->ne[1];
-    const int64_t N = b->ne[1];
-
-    if (K <= 0 || M <= 0 || N <= 0) return false;
-
-    // Shape correctness.
-    if (b->ne[0]  != K) return false;
-    if (op->ne[0] != M) return false;
-    if (op->ne[1] != N) return false;
-
-    // STRICT 2D ONLY. Do not enable 3D/4D/broadcast yet.
-    if (op->ne[2] != 1 || op->ne[3] != 1) return false;
-    if (a->ne[2]  != 1 || a->ne[3]  != 1) return false;
-    if (b->ne[2]  != 1 || b->ne[3]  != 1) return false;
-
-    // Triton requirement.
-    if ((K % 32) != 0) return false;
-
-    // Skip GEMV/single-column for now.
-    if (N == 1) return false;
-
-    // Restore wider yesterday-like limits, but still bounded.
-    static constexpr int64_t TSI_TRITON_MAX_K = 8192;
-    static constexpr int64_t TSI_TRITON_MAX_M = 32768;
-    static constexpr int64_t TSI_TRITON_MAX_N = 4096;
-
-    if (K > TSI_TRITON_MAX_K) return false;
-    if (M > TSI_TRITON_MAX_M) return false;
-    if (N > TSI_TRITON_MAX_N) return false;
-
-    const int64_t M_pad = ((M + 7)  / 8)  * 8;
-    const int64_t N_pad = ((N + 63) / 64) * 64;
-
-    const int64_t elems_A = M_pad * K;
-    const int64_t elems_B = K * N_pad;
-    const int64_t elems_C = M_pad * N_pad;
-
-    if (elems_A <= 0 || elems_B <= 0 || elems_C <= 0) return false;
-
-    const int64_t total_bytes =
-        (elems_A + elems_B + elems_C) * (int64_t) sizeof(float);
-
-    /*
-     * With USER_DRAM_SIZE=8192, 46MB allocation succeeds.
-     * Keep a guard to avoid accidental huge OPU workspace.
-     */
-    static constexpr int64_t MAX_PACKED_BYTES =
-        128LL * 1024LL * 1024LL;   // 128 MB
-
-    if (total_bytes > MAX_PACKED_BYTES) {
-        return false;
-    }
-
-    return true;
-}
-
+#else
 
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     const struct ggml_tensor *a = op->src[0];
@@ -2332,7 +2256,7 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     // Default: not supported (prevents CMA from trying to hold most of the model)
     return false;
 }
-#endif /* 0 */
+#endif /* TRITON_MAT_MUL */
 
 static bool ggml_tsavorite_internal_supports_op(const struct ggml_tensor *op) {
 
@@ -2627,8 +2551,6 @@ void _mlir_ciface_txe_mul_mat_tile_f32_k2048_host  (void *A_tile, void *B_tile, 
 	return;
 }
 
-
-// ANOOP TRITION CODE
 // -----------------------------------------------------------------------------
 // Triton MATMUL minimal wrapper for static K=32
 // Keeps existing ggml_tsavorite_run_tmu_mul_mat() packing/copyback unchanged.
@@ -2648,6 +2570,8 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper(
     void *M_scalar, void *N_scalar, void *K_scalar,
     void *grid1_scalar, void *grid2_scalar, void *grid3_scalar);
 
+
+// ANOOP
 // -----------------------------------------------------------------------------
 // Triton MAT_MUL ABI helpers
 // IMPORTANT:
@@ -2656,6 +2580,7 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper(
 // - Descriptor and scalar payload must both be device-visible and 128B aligned
 // -----------------------------------------------------------------------------
 
+#if TRITON_MAT_MUL
 template<int N>
 static inline void init_rank1_memref_flat(
     MemRefDescriptor<N> *d,
@@ -2834,36 +2759,11 @@ static inline void call_triton_matmul_full_packed(
         M_desc, N_desc, K_desc,
         grid1_desc, grid2_desc, grid3_desc);
 }
+#endif /* TRITON_MAT_MUL */
 
-
-#if 0
-// Replace ONLY k32 first
-extern "C" void tmu_mul_mat_k32(const void *A, const void *B, void *C) {
-    call_triton_matmul_blob_k<32>(
-        A, B, C,
-        g_triton_cur_M_tile,
-        g_triton_cur_N_tile);
-}
-#endif /* 0 */
-
-extern "C" void tmu_mul_mat_k32(const void *A, const void *B, void *C) {
-    (void) A;
-    (void) B;
-    (void) C;
-
-    fprintf(stderr,
-            "ERROR: legacy tmu_mul_mat_k32 path should not be called "
-            "after enabling full dynamic Triton MAT_MUL path\n");
-    abort();
-}
-
-
-#if BLOB_CODE
 extern "C" void tmu_mul_mat_k32 (const void *A, const void *B, void *C) {
     call_tmu_blob<32>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k32_host);
 }
-#endif /* BLOB_CODE */
-
 extern "C" void tmu_mul_mat_k64 (const void *A, const void *B, void *C) {
     call_tmu_blob<64>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k64_host);
 }
@@ -3014,6 +2914,9 @@ static inline void ensure_tmu_pack_buffers() {
     });
 }
 
+
+#if TRITON_MAT_MUL
+
 // -----------------------------------------------------------------------------
 // TMU MUL_MAT runner (called from ggml_tsavorite_graph_compute)
 // FIXES:
@@ -3021,6 +2924,7 @@ static inline void ensure_tmu_pack_buffers() {
 //  - meaningful validation (pack correctness + full tile reference)
 //  - increments node->tsi_kernel_runs and device stats for MUL_MAT
 // -----------------------------------------------------------------------------
+
 static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     struct ggml_backend_tsavorite_context * ctx,
     txe_device_s device,
@@ -3081,7 +2985,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     char *C_base = (char *) node->data;
 
     // =========================================================
-    // 🔥 MAIN FIX: loop over batch dims (instead of expanding)
+    //  MAIN FIX: loop over batch dims (instead of expanding)
     // =========================================================
     for (int64_t d3 = 0; d3 < D3; ++d3) {
         for (int64_t d2 = 0; d2 < D2; ++d2) {
@@ -3158,15 +3062,297 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     return GGML_STATUS_SUCCESS;
 }
 
+
+#else
+static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
+    struct ggml_backend_tsavorite_context * /*ctx*/,
+    txe_device_s device,
+    struct ggml_tensor * node,
+    enum ggml_tsavorite_kernel_type kernel_type,
+    int /*kernel_sub_type*/) {
+
+    if (!node || !node->src[0] || !node->src[1] || !node->data) {
+        return GGML_STATUS_FAILED;
+    }
+
+    const struct ggml_tensor * src0 = node->src[0];
+    const struct ggml_tensor * src1 = node->src[1];
+
+    if (src0->type != GGML_TYPE_F32 || src1->type != GGML_TYPE_F32 || node->type != GGML_TYPE_F32) {
+        return GGML_STATUS_FAILED;
+    }
+
+    ensure_tmu_pack_buffers();
+
+    // -------------------------------------------------------------------------
+    // Host-only buffer to save previous partial C between K buckets.
+    // IMPORTANT: This buffer is NOT passed to the TMU blob, so DO NOT use tsi_alloc
+    // (tsi_alloc comes from CMA and is not freed until tsi_finalize).
+    // Allocate once from normal host heap and reuse.
+    // -------------------------------------------------------------------------
+    static float *g_C_prev = nullptr;
+    static std::once_flag g_prev_once;
+    auto host_alloc_aligned = [](size_t bytes) -> void * {
+        void *p = nullptr;
+        if (posix_memalign(&p, 64, bytes) != 0) {
+            p = malloc(bytes);
+        }
+        return p;
+    };
+    std::call_once(g_prev_once, [&]() {
+        const size_t bytes = (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float);
+        g_C_prev = (float *) host_alloc_aligned(bytes);
+        TSAVORITE_GGML_ASSERT(g_C_prev);
+        memset(g_C_prev, 0, bytes);
+    });
+
+#ifdef TMU_DEBUG_VALIDATE
+    // -------------------------------------------------------------------------
+    // PR comment fix #1 + your request:
+    // 1) Make CPU reference helper take MemRefDescriptor-like structs
+    // 2) Actually CALL it here (it was dead previously)
+    // -------------------------------------------------------------------------
+    static void cpu_ref_mul_mat_f32(
+        const MemRefDescriptor<4> *A_desc,
+        const MemRefDescriptor<4> *B_desc,
+        MemRefDescriptor<4>       *C_desc
+    ) {
+        if (!A_desc || !B_desc || !C_desc) return;
+        if (!A_desc->data || !B_desc->data || !C_desc->data) return;
+
+        const int64_t M = A_desc->shape[2];
+        const int64_t K = A_desc->shape[3];
+        const int64_t N = B_desc->shape[2];
+
+        if (M <= 0 || N <= 0 || K <= 0) return;
+        if (B_desc->shape[3] != K) return;
+        if (C_desc->shape[2] != M) return;
+        if (C_desc->shape[3] != N) return;
+
+        const float *A = (const float *) A_desc->data;
+        const float *B = (const float *) B_desc->data;
+        float       *C = (float       *) C_desc->data;
+
+        const int64_t a_s2 = A_desc->strides[2];
+        const int64_t a_s3 = A_desc->strides[3];
+        const int64_t b_s2 = B_desc->strides[2];
+        const int64_t b_s3 = B_desc->strides[3];
+        const int64_t c_s2 = C_desc->strides[2];
+        const int64_t c_s3 = C_desc->strides[3];
+
+        const int64_t a_off = A_desc->offset;
+        const int64_t b_off = B_desc->offset;
+        const int64_t c_off = C_desc->offset;
+
+        for (int64_t r = 0; r < M; ++r) {
+            const int64_t a_row = a_off + r * a_s2;
+            const int64_t c_row = c_off + r * c_s2;
+
+            for (int64_t n = 0; n < N; ++n) {
+                const int64_t b_row = b_off + n * b_s2;   // B packed as [N,K]
+
+                float acc = 0.0f;
+                for (int64_t kk = 0; kk < K; ++kk) {
+                    acc += A[a_row + kk * a_s3] * B[b_row + kk * b_s3];
+                }
+                C[c_row + n * c_s3] = acc;
+            }
+        }
+    }
+
+    // CPU reference buffers: accumulate chunk-by-chunk in packed space
+    static float C_ref_chunk[TMU_M_TILE_MAX * TMU_N_BLOCK];
+    static float C_ref_accum[TMU_M_TILE_MAX * TMU_N_BLOCK];
+#endif
+
+    const int64_t K = src0->ne[0];
+    const int64_t M = src0->ne[1];
+    const int64_t N = src1->ne[1];
+
+    if (src1->ne[0] != K) return GGML_STATUS_FAILED;
+    if ((K % TMU_K_MULTIPLE) != 0) return GGML_STATUS_FAILED;
+    if (src1->ne[1] == 1) return GGML_STATUS_FAILED; // avoid GEMV
+
+    const int64_t a_nb0 = nb_or_default(src0, 0);
+    const int64_t a_nb1 = nb_or_default(src0, 1);
+    const int64_t a_nb2 = nb_or_default(src0, 2);
+    const int64_t a_nb3 = nb_or_default(src0, 3);
+
+    const int64_t b_nb0 = nb_or_default(src1, 0);
+    const int64_t b_nb1 = nb_or_default(src1, 1);
+    const int64_t b_nb2 = nb_or_default(src1, 2);
+    const int64_t b_nb3 = nb_or_default(src1, 3);
+
+    const int64_t c_nb0 = nb_or_default(node, 0);
+    const int64_t c_nb1 = nb_or_default(node, 1);
+    const int64_t c_nb2 = nb_or_default(node, 2);
+    const int64_t c_nb3 = nb_or_default(node, 3);
+
+    // broadcast dims must come from inputs
+    const int64_t A2 = src0->ne[2] ? src0->ne[2] : 1;
+    const int64_t A3 = src0->ne[3] ? src0->ne[3] : 1;
+    const int64_t B2 = src1->ne[2] ? src1->ne[2] : 1;
+    const int64_t B3 = src1->ne[3] ? src1->ne[3] : 1;
+
+    const int64_t D2 = (A2 > B2) ? A2 : B2;
+    const int64_t D3 = (A3 > B3) ? A3 : B3;
+
+    if (device) {
+        ++device->stats.op_run_count[kernel_type].total_tensor_count;
+    }
+
+    for (int64_t od3 = 0; od3 < D3; ++od3) {
+        const int64_t a_d3 = map_repeat_i64(od3, A3);
+        const int64_t b_d3 = map_repeat_i64(od3, B3);
+
+        for (int64_t od2 = 0; od2 < D2; ++od2) {
+            const int64_t a_d2 = map_repeat_i64(od2, A2);
+            const int64_t b_d2 = map_repeat_i64(od2, B2);
+
+            const char *A_base_d23 = (const char *) src0->data + a_d2 * a_nb2 + a_d3 * a_nb3;
+            const char *B_base_d23 = (const char *) src1->data + b_d2 * b_nb2 + b_d3 * b_nb3;
+
+            for (int64_t m0 = 0; m0 < M; m0 += TMU_M_TILE_MAX) {
+                const int64_t m_tile = (M - m0 > TMU_M_TILE_MAX) ? TMU_M_TILE_MAX : (M - m0);
+
+                for (int64_t n0 = 0; n0 < N; n0 += TMU_N_BLOCK) {
+                    const int64_t n_valid = (N - n0 >= TMU_N_BLOCK) ? TMU_N_BLOCK : (N - n0);
+
+                    memset(g_C_tile, 0, (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+
+#ifdef TMU_DEBUG_VALIDATE
+                    // reset CPU ref accumulator for THIS output tile
+                    memset(C_ref_accum, 0, sizeof(C_ref_accum));
+#endif
+
+                    int parts[128];
+                    const int np = tmu_decompose_k(K, parts, (int)(sizeof(parts)/sizeof(parts[0])));
+                    if (np < 0) return GGML_STATUS_FAILED;
+
+                    int64_t k0 = 0;
+
+                    for (int pi = 0; pi < np; ++pi) {
+                        const int K_chunk = parts[pi];
+                        const tmu_bucket_dispatch *bucket = tmu_find_bucket(K_chunk);
+                        if (!bucket || !bucket->fn) return GGML_STATUS_FAILED;
+
+                        pack_A_tile_f32(g_A_pack, A_base_d23, m0, m_tile, k0, K_chunk, a_nb0, a_nb1);
+                        pack_B_tile_f32(g_B_pack, B_base_d23, n0, n_valid, k0, K_chunk, b_nb0, b_nb1);
+
+                        // Save previous partial before calling blob (because blob overwrites)
+                        if (pi > 0) {
+                            memcpy(g_C_prev, g_C_tile,
+                                   (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+                        }
+
+                        // Run blob
+                        bucket->fn(g_A_pack, g_B_pack, g_C_tile);
+
+                        // Accumulate back (host-side workaround)
+                        if (pi > 0) {
+                            const int total = TMU_M_TILE_MAX * TMU_N_BLOCK;
+                            for (int i = 0; i < total; ++i) {
+                                g_C_tile[i] += g_C_prev[i];
+                            }
+                        }
+
+                        // Stats per kernel call
+                        if (device) ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
+                        ++node->tsi_kernel_runs;
+
+#ifdef TMU_DEBUG_VALIDATE
+                        // -----------------------------------------------------------------
+                        // CPU reference for THIS K_chunk computed from PACKED tiles
+                        // and accumulated into C_ref_accum, then compared with g_C_tile.
+                        // This makes cpu_ref_mul_mat_f32() actually USED.
+                        // -----------------------------------------------------------------
+                        memset(C_ref_chunk, 0, sizeof(C_ref_chunk));
+
+                        MemRefDescriptor<4> Aref, Bref, Cref;
+                        init_memref_4d(Aref, (void*)g_A_pack, 1, 1, TMU_M_TILE_MAX, (int64_t)K_chunk);
+                        init_memref_4d(Bref, (void*)g_B_pack, 1, 1, TMU_N_BLOCK,   (int64_t)K_chunk);
+                        init_memref_4d(Cref, (void*)C_ref_chunk, 1, 1, TMU_M_TILE_MAX, TMU_N_BLOCK);
+
+                        cpu_ref_mul_mat_f32(&Aref, &Bref, &Cref);
+
+                        // accumulate CPU reference chunks (only valid region is needed)
+                        for (int64_t rr = 0; rr < m_tile; ++rr) {
+                            for (int64_t cc = 0; cc < n_valid; ++cc) {
+                                C_ref_accum[rr * TMU_N_BLOCK + cc] +=
+                                    C_ref_chunk[rr * TMU_N_BLOCK + cc];
+                            }
+                        }
+
+                        // Compare after each chunk (same tolerance you used before)
+                        for (int64_t rr = 0; rr < m_tile; ++rr) {
+                            for (int64_t cc = 0; cc < n_valid; ++cc) {
+                                const float tmu_v = g_C_tile[rr * TMU_N_BLOCK + cc];
+                                const float ref_v = C_ref_accum[rr * TMU_N_BLOCK + cc];
+                                if (fabsf(tmu_v - ref_v) > 1e-4f) {
+                                    fprintf(stderr,
+                                        "\nTMU MISMATCH (packed-ref)\n"
+                                        "m0=%ld n0=%ld k0=%ld K_chunk=%d pi=%d\n"
+                                        "r=%ld c=%ld TMU=%f REF=%f\n",
+                                        (long)m0, (long)n0, (long)k0, K_chunk, pi,
+                                        (long)rr, (long)cc, tmu_v, ref_v);
+                                    tsi_cleanup();
+                                    abort();
+                                }
+                            }
+                        }
+#endif
+
+                        k0 += K_chunk;
+                    }
+
+                    // Copy tile back to ggml output
+                    {
+                        char *dst_base = (char *) node->data;
+                        const size_t bytes_total = (size_t) ggml_nbytes(node);
+
+                        for (int64_t rr = 0; rr < m_tile; ++rr) {
+                            const int64_t m_idx = m0 + rr;
+                            const float *src_row = g_C_tile + rr * TMU_N_BLOCK;
+
+                            for (int64_t cc = 0; cc < n_valid; ++cc) {
+                                const int64_t n_idx = n0 + cc;
+
+                                const int64_t byte_off =
+                                    m_idx * c_nb0 +
+                                    n_idx * c_nb1 +
+                                    od2  * c_nb2 +
+                                    od3  * c_nb3;
+
+                                if (byte_off < 0 ||
+                                    (size_t)byte_off + sizeof(float) > bytes_total) {
+                                    continue;
+                                }
+                                *(float *)(dst_base + byte_off) = src_row[cc];
+                            }
+                        }
+                    }
+
+                    // If you decide to USE copy_tileC_to_ggml_f32 instead of inline copy-back:
+                    // copy_tileC_to_ggml_f32(g_C_tile, m_tile, 0, node, m0, n0, od2, od3);
+                }
+            }
+        }
+    }
+
+    return GGML_STATUS_SUCCESS;
+}
+#endif /* TRITON_MAT_MUL */
+
+
+static std::mutex g_tsavorite_compute_mutex;
+
 // nodes are intermediate which has multiple src tensors & operation
 // Here we create multiple thread
 // Each Thread run the command buffer & pick Tensor and execute and get the result back base on
 // async or sync all Compute wil finish all tensors execution
 static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
                                                      struct ggml_cgraph *cgraph) {
-static std::mutex g_tsavorite_compute_mutex;
 std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
-
 #if 0
     GGML_LOG_INFO("Start %s\n", __func__);
     struct ggml_backend_tsavorite_context        * ctx     = backend->context;
@@ -3628,8 +3814,8 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
                     srcP1->data =  srcP1->base = (void *)(src1_ptr);
                     srcP0->data =  srcP0->base = (void *)(src0_ptr + r * ne10);
                     nodeP->data =  nodeP->base = (void *)(dst_ptr + r * ne10);
-#if TRITON_ADD
                     // kernel call
+#if TRITON_ADD
                     if (kernel_type == GGML_TSAVORITE_KERNEL_TYPE_ADD) {
                         // MemRefDescriptor
                         int32_t *scalar_val; 
@@ -3685,7 +3871,7 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
                     } else {
 #endif /* TRITON_ADD */
                         ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, srcP1, nodeP);
-#if  TRITON_ADD
+#if TRITON_ADD
                     }
 #endif /* TRITON_ADD */
                     ++device->stats.op_run_count[kernel_type].num_of_kernel_call;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2472,7 +2472,6 @@ static inline void call_triton_matmul_blob_k(
     void *C_tile,         // blob-style: [TMU_M_TILE_MAX x TMU_N_BLOCK], row-major
     int32_t M_tile,       // actual valid rows
     int32_t N_tile) {     // actual valid cols
-
     constexpr int32_t TRITON_M_TILE = 8;
     constexpr int32_t TRITON_N_TILE = 64;
 
@@ -2499,6 +2498,7 @@ static inline void call_triton_matmul_blob_k(
     static int32_t *grid3_payload = nullptr;
 
     static bool inited = false;
+
     if (!inited) {
         A_triton = (float *) tsi_alloc((size_t) TRITON_M_TILE * (size_t) K * sizeof(float));
         B_triton = (float *) tsi_alloc((size_t) K * (size_t) TRITON_N_TILE * sizeof(float));
@@ -2536,6 +2536,7 @@ static inline void call_triton_matmul_blob_k(
         TSAVORITE_GGML_ASSERT((((uintptr_t) A_desc) & 127) == 0);
         TSAVORITE_GGML_ASSERT((((uintptr_t) B_desc) & 127) == 0);
         TSAVORITE_GGML_ASSERT((((uintptr_t) C_desc) & 127) == 0);
+
         TSAVORITE_GGML_ASSERT((((uintptr_t) M_desc) & 127) == 0);
         TSAVORITE_GGML_ASSERT((((uintptr_t) N_desc) & 127) == 0);
         TSAVORITE_GGML_ASSERT((((uintptr_t) K_desc) & 127) == 0);
@@ -2555,12 +2556,19 @@ static inline void call_triton_matmul_blob_k(
 
     const float *A_blob = (const float *) A_tile;   // [TMU_M_TILE_MAX x K]
     const float *B_blob = (const float *) B_tile;   // [TMU_N_BLOCK    x K] == [N x K]
-    float       *C_blob = (float *) C_tile;         // [TMU_M_TILE_MAX x TMU_N_BLOCK]
+    float       *C_blob = (float       *) C_tile;   // [TMU_M_TILE_MAX x TMU_N_BLOCK]
 
-    // B: blob-style [N x K] -> Triton physical [K x 64], padded
+    // -------------------------------------------------------------------------
+    // B adapter:
+    // Blob-style B is [N x K].
+    // Triton expects B as row-major [K x N].
+    // Physical N stride is always TRITON_N_TILE = 64.
+    // -------------------------------------------------------------------------
     memset(B_triton, 0, (size_t) K * (size_t) TRITON_N_TILE * sizeof(float));
+
     for (int32_t n = 0; n < N_tile; ++n) {
         const float *src_row = B_blob + (size_t) n * (size_t) K;
+
         for (int32_t kk = 0; kk < K; ++kk) {
             B_triton[(size_t) kk * (size_t) TRITON_N_TILE + (size_t) n] = src_row[kk];
         }
@@ -2570,31 +2578,68 @@ static inline void call_triton_matmul_blob_k(
         const int32_t m_valid =
             (M_tile - m0 > TRITON_M_TILE) ? TRITON_M_TILE : (M_tile - m0);
 
-        // A: blob row-major -> Triton physical [8 x K], padded
+        // ---------------------------------------------------------------------
+        // A adapter:
+        // Blob-style A is [M x K].
+        // Triton expects A as [8 x K].
+        // Zero-pad invalid rows.
+        // ---------------------------------------------------------------------
         memset(A_triton, 0, (size_t) TRITON_M_TILE * (size_t) K * sizeof(float));
+
         for (int32_t r = 0; r < m_valid; ++r) {
             const float *src_row = A_blob + (size_t) (m0 + r) * (size_t) K;
-            float *dst_row = A_triton + (size_t) r * (size_t) K;
+            float       *dst_row = A_triton + (size_t) r * (size_t) K;
+
             memcpy(dst_row, src_row, (size_t) K * sizeof(float));
         }
 
-        // C carry-in
+        // ---------------------------------------------------------------------
+        // C carry-in:
+        // Blob-style C is [M x TMU_N_BLOCK].
+        // Triton physical C is [8 x 64].
+        // Copy only valid rows/cols into padded C_triton.
+        // ---------------------------------------------------------------------
         memset(C_triton, 0, (size_t) TRITON_M_TILE * (size_t) TRITON_N_TILE * sizeof(float));
+
         for (int32_t r = 0; r < m_valid; ++r) {
             const float *src_row = C_blob + (size_t) (m0 + r) * (size_t) TMU_N_BLOCK;
-            float *dst_row = C_triton + (size_t) r * (size_t) TRITON_N_TILE;
+            float       *dst_row = C_triton + (size_t) r * (size_t) TRITON_N_TILE;
+
             for (int32_t n = 0; n < N_tile; ++n) {
                 dst_row[n] = src_row[n];
             }
         }
 
-        // IMPORTANT: logical flattened lengths, not padded physical lengths
-        init_rank1_memref_flat(A_desc, (void *) A_triton, (int64_t) m_valid * (int64_t) K);
-        init_rank1_memref_flat(B_desc, (void *) B_triton, (int64_t) N_tile * (int64_t) K);
-        init_rank1_memref_flat(C_desc, (void *) C_triton, (int64_t) m_valid * (int64_t) N_tile);
+        // ---------------------------------------------------------------------
+        // IMPORTANT FIX:
+        //
+        // Triton kernel creates block pointers using:
+        //   A strides = (K, 1)
+        //   B strides = (N, 1)
+        //   C strides = (N, 1)
+        //
+        // Since B_triton/C_triton are physically padded with N stride = 64,
+        // we must pass N = 64 to Triton, not logical N_tile.
+        //
+        // Copy-back below still copies only logical N_tile columns.
+        // ---------------------------------------------------------------------
+        init_rank1_memref_flat(
+            A_desc,
+            (void *) A_triton,
+            (int64_t) TRITON_M_TILE * (int64_t) K);
 
-        init_scalar_i32_memref_aligned(M_desc,     M_payload,     m_valid);
-        init_scalar_i32_memref_aligned(N_desc,     N_payload,     N_tile);
+        init_rank1_memref_flat(
+            B_desc,
+            (void *) B_triton,
+            (int64_t) K * (int64_t) TRITON_N_TILE);
+
+        init_rank1_memref_flat(
+            C_desc,
+            (void *) C_triton,
+            (int64_t) TRITON_M_TILE * (int64_t) TRITON_N_TILE);
+
+        init_scalar_i32_memref_aligned(M_desc,     M_payload,     TRITON_M_TILE);
+        init_scalar_i32_memref_aligned(N_desc,     N_payload,     TRITON_N_TILE);
         init_scalar_i32_memref_aligned(K_desc,     K_payload,     K);
         init_scalar_i32_memref_aligned(grid1_desc, grid1_payload, 1);
         init_scalar_i32_memref_aligned(grid2_desc, grid2_payload, 1);
@@ -2605,10 +2650,14 @@ static inline void call_triton_matmul_blob_k(
             M_desc, N_desc, K_desc,
             grid1_desc, grid2_desc, grid3_desc);
 
-        // copy valid result back
+        // ---------------------------------------------------------------------
+        // Copy valid logical result back to blob-style C tile.
+        // Only copy m_valid rows and N_tile valid columns.
+        // ---------------------------------------------------------------------
         for (int32_t r = 0; r < m_valid; ++r) {
-            float *dst_row = C_blob + (size_t) (m0 + r) * (size_t) TMU_N_BLOCK;
+            float       *dst_row = C_blob + (size_t) (m0 + r) * (size_t) TMU_N_BLOCK;
             const float *src_row = C_triton + (size_t) r * (size_t) TRITON_N_TILE;
+
             for (int32_t n = 0; n < N_tile; ++n) {
                 dst_row[n] = src_row[n];
             }

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2005,33 +2005,38 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
 
     if (!a || !b) return false;
 
-    const int64_t K = a->ne[0];
-    const int64_t N = op->ne[0];
-    const int64_t M = op->ne[1];
+    // GGML MUL_MAT:
+    //   a/src0: [K, output_cols]
+    //   b/src1: [K, batch]
+    //   op/dst: [output_cols, batch]
+    const int64_t K          = a->ne[0];
+    const int64_t OUT_COLS   = op->ne[0];
+    const int64_t BATCH_COLS = op->ne[1];
 
-    if (K <= 0 || N <= 0 || M <= 0) return false;
-    if ((K % TMU_K_MULTIPLE) != 0) return false;
+    if (K <= 0 || OUT_COLS <= 0 || BATCH_COLS <= 0) return false;
+
+    // Current Triton path only supports F32 path and K decomposed by 32.
+    if ((K % 32) != 0) return false;
+
+    // Reduction dim must match.
     if (b->ne[0] != K) return false;
 
-    // ✅ ENABLE ONLY WORKING OPU SHAPE
-    // dst  = [576, 5]
-    // src0 = [576, 576]
-    // src1 = [576, 5]
-    if (K == 576 &&
-        N == 576 &&
-        M == 5 &&
-        op->ne[2] == 1 &&
-        op->ne[3] == 1 &&
-        a->ne[1] == 576 &&
-        b->ne[1] == 5) {
+    // Output shape must match expected GGML MUL_MAT relation.
+    if (a->ne[1] != OUT_COLS) return false;
+    if (b->ne[1] != BATCH_COLS) return false;
 
-        fprintf(stderr,
-                "\nTSI DEBUG: ENABLE OPU MAT_MUL (576x576 * 576x5)\n");
+    // Avoid GEMV / single-column cases for now.
+    // ggml_tsavorite_run_tmu_mul_mat() currently rejects src1->ne[1] == 1.
+    if (b->ne[1] == 1) return false;
 
-        return true;
-    }
+    // IMPORTANT:
+    // Keep only simple 2D matmul for now.
+    // Do not enable broadcast / batched 3D/4D shapes yet.
+    if (op->ne[2] != 1 || op->ne[3] != 1) return false;
+    if (a->ne[2]  != 1 || a->ne[3]  != 1) return false;
+    if (b->ne[2]  != 1 || b->ne[3]  != 1) return false;
 
-    return false;
+    return true;
 }
 
 
@@ -2844,7 +2849,6 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     struct ggml_tensor * node,
     enum ggml_tsavorite_kernel_type kernel_type,
     int /*kernel_sub_type*/) {
-
     if (!node || !node->src[0] || !node->src[1] || !node->data) {
         return GGML_STATUS_FAILED;
     }
@@ -2870,14 +2874,14 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     //   src1: [K, N]
     //   dst : [M, N]
     //
-    // In your currently enabled case:
+    // Example:
     //   src0 = [576, 576]
     //   src1 = [576, 5]
     //   dst  = [576, 5]
     // so:
     //   K = 576
-    //   M = 576   (dst->ne[0])
-    //   N = 5     (dst->ne[1])
+    //   M = 576
+    //   N = 5
     // -------------------------------------------------------------------------
     const int64_t K = src0->ne[0];
     const int64_t M = src0->ne[1];
@@ -2931,12 +2935,14 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                         (N - n0 >= TMU_N_BLOCK) ? TMU_N_BLOCK : (N - n0);
 
                     // -----------------------------------------------------------------
-                    // IMPORTANT:
-                    // Zero C ONCE per output tile.
-                    // Triton wrapper must preserve/consume carry-in C across K buckets.
+                    // Zero C once per output tile.
+                    // Triton wrapper preloads current g_C_tile into C_triton and
+                    // accumulates each K chunk.
                     // -----------------------------------------------------------------
                     memset(g_C_tile, 0,
-                           (size_t) TMU_M_TILE_MAX * (size_t) TMU_N_BLOCK * sizeof(float));
+                           (size_t) TMU_M_TILE_MAX *
+                           (size_t) TMU_N_BLOCK *
+                           sizeof(float));
 
 #ifdef TMU_DEBUG_VALIDATE
                     memset(C_ref_accum, 0, sizeof(C_ref_accum));
@@ -2950,6 +2956,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
                     for (int pi = 0; pi < np; ++pi) {
                         const int K_chunk = parts[pi];
+
                         const tmu_bucket_dispatch * bucket = tmu_find_bucket(K_chunk);
                         if (!bucket || !bucket->fn) return GGML_STATUS_FAILED;
 
@@ -2968,9 +2975,8 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
                         // -------------------------------------------------------------
                         // Pack B -> blob-style row-major [TMU_N_BLOCK x K_chunk]
-                        // Existing helper already does:
-                        //   dst row = output column n
-                        //   dst[kk]  = B(k0+kk, n0+n)
+                        // dst row = output column n
+                        // dst[kk] = B(k0 + kk, n0 + n)
                         // -------------------------------------------------------------
                         pack_B_tile_f32(
                             g_B_pack,
@@ -2985,13 +2991,11 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                         g_triton_cur_M_tile = (int32_t) m_tile;
                         g_triton_cur_N_tile = (int32_t) n_valid;
 
-                        // -----------------------------------------------------------------
-                        // IMPORTANT:
-                        // No host-side g_C_prev workaround here.
-                        // call_triton_matmul_blob_k() must preload current g_C_tile into
-                        // Triton C buffer and Triton does:
-                        //   acc = load(C); acc += dot(A, B); store(C)
-                        // -----------------------------------------------------------------
+                        // -------------------------------------------------------------
+                        // Triton MAT_MUL call through selected K bucket.
+                        // Current working path:
+                        //   bucket->fn -> tmu_mul_mat_k32 -> call_triton_matmul_blob_k<32>
+                        // -------------------------------------------------------------
                         bucket->fn(g_A_pack, g_B_pack, g_C_tile);
 
                         // Stats per kernel call
@@ -3002,17 +3006,43 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
 #ifdef TMU_DEBUG_VALIDATE
                         // -------------------------------------------------------------
-                        // CPU reference for THIS K_chunk on packed tiles
-                        // accumulate chunk-by-chunk and compare against g_C_tile
+                        // CPU reference for THIS K_chunk on packed tiles.
+                        // Accumulate chunk-by-chunk and compare against g_C_tile.
+                        //
+                        // IMPORTANT:
+                        // Use abs + relative tolerance. FP32 dot accumulation can differ
+                        // slightly due to accumulation order. Example:
+                        //   TMU=325.606201 REF=325.606079
+                        // is acceptable and should not abort.
                         // -------------------------------------------------------------
                         memset(C_ref_chunk, 0, sizeof(C_ref_chunk));
 
                         MemRefDescriptor<4> Aref, Bref, Cref;
-                        init_memref_4d(Aref, (void *) g_A_pack, 1, 1, TMU_M_TILE_MAX, (int64_t) K_chunk);
-                        init_memref_4d(Bref, (void *) g_B_pack, 1, 1, TMU_N_BLOCK,   (int64_t) K_chunk);
-                        init_memref_4d(Cref, (void *) C_ref_chunk, 1, 1, TMU_M_TILE_MAX, TMU_N_BLOCK);
 
-                        // Use the EXISTING top-level helper already present in the file
+                        init_memref_4d(
+                            Aref,
+                            (void *) g_A_pack,
+                            1,
+                            1,
+                            TMU_M_TILE_MAX,
+                            (int64_t) K_chunk);
+
+                        init_memref_4d(
+                            Bref,
+                            (void *) g_B_pack,
+                            1,
+                            1,
+                            TMU_N_BLOCK,
+                            (int64_t) K_chunk);
+
+                        init_memref_4d(
+                            Cref,
+                            (void *) C_ref_chunk,
+                            1,
+                            1,
+                            TMU_M_TILE_MAX,
+                            TMU_N_BLOCK);
+
                         cpu_ref_mul_mat_f32(&Aref, &Bref, &Cref);
 
                         for (int64_t rr = 0; rr < m_tile; ++rr) {
@@ -3026,13 +3056,27 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                             for (int64_t cc = 0; cc < n_valid; ++cc) {
                                 const float tmu_v = g_C_tile[rr * TMU_N_BLOCK + cc];
                                 const float ref_v = C_ref_accum[rr * TMU_N_BLOCK + cc];
-                                if (fabsf(tmu_v - ref_v) > 1e-4f) {
+
+                                const float abs_err = fabsf(tmu_v - ref_v);
+                                const float rel_err = abs_err / fmaxf(1.0f, fabsf(ref_v));
+
+                                if (abs_err > 1e-3f && rel_err > 1e-5f) {
                                     fprintf(stderr,
                                             "\nTMU/TRITON MISMATCH (packed-ref)\n"
                                             "m0=%ld n0=%ld k0=%ld K_chunk=%d pi=%d\n"
-                                            "r=%ld c=%ld TMU=%f REF=%f\n",
-                                            (long)m0, (long)n0, (long)k0, K_chunk, pi,
-                                            (long)rr, (long)cc, tmu_v, ref_v);
+                                            "r=%ld c=%ld TMU=%f REF=%f ABS=%e REL=%e\n",
+                                            (long)m0,
+                                            (long)n0,
+                                            (long)k0,
+                                            K_chunk,
+                                            pi,
+                                            (long)rr,
+                                            (long)cc,
+                                            tmu_v,
+                                            ref_v,
+                                            abs_err,
+                                            rel_err);
+
                                     tsi_cleanup();
                                     abort();
                                 }
@@ -3049,7 +3093,9 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                     }
 
                     // -------------------------------------------------------------
-                    // Copy tile back to GGML output
+                    // Copy valid tile back to GGML output.
+                    // g_C_tile is packed row-major [TMU_M_TILE_MAX x TMU_N_BLOCK].
+                    // GGML output uses byte strides.
                     // -------------------------------------------------------------
                     {
                         char *dst_base = (char *) node->data;
@@ -3065,8 +3111,8 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                                 const int64_t byte_off =
                                     m_idx * c_nb0 +
                                     n_idx * c_nb1 +
-                                    od2  * c_nb2 +
-                                    od3  * c_nb3;
+                                    od2   * c_nb2 +
+                                    od3   * c_nb3;
 
                                 if (byte_off < 0 ||
                                     (size_t) byte_off + sizeof(float) > bytes_total) {
@@ -3085,15 +3131,15 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     return GGML_STATUS_SUCCESS;
 }
 
-static std::mutex g_tsavorite_compute_mutex;
-
 // nodes are intermediate which has multiple src tensors & operation
 // Here we create multiple thread
 // Each Thread run the command buffer & pick Tensor and execute and get the result back base on
 // async or sync all Compute wil finish all tensors execution
 static enum ggml_status ggml_tsavorite_graph_compute(ggml_backend_t backend,
                                                      struct ggml_cgraph *cgraph) {
+static std::mutex g_tsavorite_compute_mutex;
 std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
+
 #if 0
     GGML_LOG_INFO("Start %s\n", __func__);
     struct ggml_backend_tsavorite_context        * ctx     = backend->context;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2476,45 +2476,58 @@ static inline int64_t tsi_round_up_i64(int64_t v, int64_t a) {
 static constexpr int32_t TRITON_FULL_M_TILE = 64;
 static constexpr int32_t TRITON_FULL_N_TILE = 64;
 
-static float *g_triton_A_full = nullptr; // [64 x K_cap]
-static float *g_triton_B_full = nullptr; // [K_cap x 64]
-static float *g_triton_C_full = nullptr; // [64 x 64]
+static float *g_triton_A_full = nullptr; // [M_cap x K_cap]
+static float *g_triton_B_full = nullptr; // [K_cap x N_cap]
+static float *g_triton_C_full = nullptr; // [M_cap x N_cap]
+
+static int64_t g_triton_M_cap = 0;
+static int64_t g_triton_N_cap = 0;
 static int64_t g_triton_K_cap = 0;
 
-static inline void ensure_triton_full_buffers(int64_t K) {
+static inline void ensure_triton_full_buffers(int64_t M_pad, int64_t N_pad, int64_t K) {
+    TSAVORITE_GGML_ASSERT(M_pad > 0);
+    TSAVORITE_GGML_ASSERT(N_pad > 0);
     TSAVORITE_GGML_ASSERT(K > 0);
 
+    TSAVORITE_GGML_ASSERT((M_pad % 8) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % 64) == 0);
+    TSAVORITE_GGML_ASSERT((K % 32) == 0);
+
+    const int64_t need_M = M_pad;
+    const int64_t need_N = N_pad;
     const int64_t need_K = tsi_round_up_i64(K, 32);
 
-    // Allocate at least 2048 once so we do not grow/re-allocate for common model K values.
-    const int64_t alloc_K = (need_K > 2048) ? need_K : 2048;
+    if (!g_triton_A_full || !g_triton_B_full || !g_triton_C_full ||
+        need_M > g_triton_M_cap ||
+        need_N > g_triton_N_cap ||
+        need_K > g_triton_K_cap) {
 
-    if (!g_triton_C_full) {
-        g_triton_C_full = (float *) tsi_alloc(
-            (size_t) TRITON_FULL_M_TILE *
-            (size_t) TRITON_FULL_N_TILE *
-            sizeof(float));
-
-        TSAVORITE_GGML_ASSERT(g_triton_C_full);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_C_full) & 127) == 0);
-    }
-
-    if (!g_triton_A_full || !g_triton_B_full || alloc_K > g_triton_K_cap) {
-        g_triton_K_cap = alloc_K;
+        g_triton_M_cap = need_M;
+        g_triton_N_cap = need_N;
+        g_triton_K_cap = need_K;
 
         g_triton_A_full = (float *) tsi_alloc(
-            (size_t) TRITON_FULL_M_TILE *
+            (size_t) g_triton_M_cap *
             (size_t) g_triton_K_cap *
             sizeof(float));
 
         g_triton_B_full = (float *) tsi_alloc(
             (size_t) g_triton_K_cap *
-            (size_t) TRITON_FULL_N_TILE *
+            (size_t) g_triton_N_cap *
             sizeof(float));
 
-        TSAVORITE_GGML_ASSERT(g_triton_A_full && g_triton_B_full);
+        g_triton_C_full = (float *) tsi_alloc(
+            (size_t) g_triton_M_cap *
+            (size_t) g_triton_N_cap *
+            sizeof(float));
+
+        TSAVORITE_GGML_ASSERT(g_triton_A_full);
+        TSAVORITE_GGML_ASSERT(g_triton_B_full);
+        TSAVORITE_GGML_ASSERT(g_triton_C_full);
+
         TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_A_full) & 127) == 0);
         TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_B_full) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_C_full) & 127) == 0);
     }
 }
 

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2000,79 +2000,58 @@ static bool is_op_dtype_consistent_with_src(const struct ggml_tensor *op) {
 
 //TMU Test case
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
-    if (!op) return false;
-
     const struct ggml_tensor *a = op->src[0];
     const struct ggml_tensor *b = op->src[1];
 
     if (!a || !b) return false;
 
-    // Current Triton MAT_MUL path supports only F32/F32/F32.
-    if (a->type  != GGML_TYPE_F32 ||
-        b->type  != GGML_TYPE_F32 ||
+    // =====================================================
+    // TYPE FILTER (ONLY F32 FOR NOW)
+    // =====================================================
+    if (a->type != GGML_TYPE_F32 ||
+        b->type != GGML_TYPE_F32 ||
         op->type != GGML_TYPE_F32) {
         return false;
     }
 
-    // GGML MUL_MAT:
-    //   src0/a: [K, M, 1, 1]
-    //   src1/b: [K, N, 1, 1]
-    //   dst/op: [M, N, 1, 1]
     const int64_t K = a->ne[0];
     const int64_t M = a->ne[1];
     const int64_t N = b->ne[1];
 
+    // =====================================================
+    // BASIC VALIDATION
+    // =====================================================
     if (K <= 0 || M <= 0 || N <= 0) return false;
 
-    // Reduction dim must match.
     if (b->ne[0] != K) return false;
 
-    // Output shape must match.
-    if (op->ne[0] != M) return false;
-    if (op->ne[1] != N) return false;
+    if (a->ne[1] != op->ne[0]) return false;
+    if (b->ne[1] != op->ne[1]) return false;
 
-    // Only 2D for now.
+    // Only pure 2D (REQUIRED for Triton path right now)
     if (op->ne[2] != 1 || op->ne[3] != 1) return false;
     if (a->ne[2]  != 1 || a->ne[3]  != 1) return false;
     if (b->ne[2]  != 1 || b->ne[3]  != 1) return false;
 
-    // Triton kernel constraint.
+    // Skip GEMV for now (can enable later)
+    if (N == 1) return false;
+
+    // Triton tiling requirement
     if ((K % 32) != 0) return false;
 
-    // Safety limits for dynamic packed buffers.
-    static constexpr int64_t TSI_TRITON_MAX_K = 8192;
-    static constexpr int64_t TSI_TRITON_MAX_M = 32768;
-    static constexpr int64_t TSI_TRITON_MAX_N = 4096;
+    // =====================================================
+    // GENERIC SAFE FILTER
+    // =====================================================
 
-    if (K > TSI_TRITON_MAX_K) return false;
-    if (M > TSI_TRITON_MAX_M) return false;
-    if (N > TSI_TRITON_MAX_N) return false;
+    // Avoid extremely tiny cases (overhead > compute)
+    if (M < 16 || N < 2) return false;
 
-    // Local round-up helper because tsi_round_up_i64 is declared later in this file.
-    auto round_up_i64_local = [](int64_t v, int64_t a) -> int64_t {
-        return ((v + a - 1) / a) * a;
-    };
+    // Avoid extremely large pathological cases (optional safety)
+    if (M > 4096 || N > 4096 || K > 8192) return false;
 
-    const int64_t M_pad = round_up_i64_local(M, 8);
-    const int64_t N_pad = round_up_i64_local(N, 64);
-
-    const int64_t elems_A = M_pad * K;
-    const int64_t elems_B = K * N_pad;
-    const int64_t elems_C = M_pad * N_pad;
-
-    // ~512 MB packed workspace guard.
-    static constexpr int64_t TSI_TRITON_MAX_PACKED_FLOATS =
-        (512LL * 1024LL * 1024LL) / (int64_t)sizeof(float);
-
-    if (elems_A <= 0 || elems_B <= 0 || elems_C <= 0) return false;
-
-    if (elems_A + elems_B + elems_C > TSI_TRITON_MAX_PACKED_FLOATS) {
-        return false;
-    }
-
+    // Allow everything else
     return true;
 }
-
 
 
 #if phase1
@@ -2949,12 +2928,15 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     enum ggml_tsavorite_kernel_type kernel_type,
     int /*kernel_sub_type*/) {
 
+    // ---------------------------------------------------------
+    // Basic validation
+    // ---------------------------------------------------------
     if (!node || !node->src[0] || !node->src[1] || !node->data) {
         return GGML_STATUS_FAILED;
     }
 
-    const struct ggml_tensor *src0 = node->src[0];
-    const struct ggml_tensor *src1 = node->src[1];
+    const struct ggml_tensor *src0 = node->src[0]; // A
+    const struct ggml_tensor *src1 = node->src[1]; // B
 
     if (src0->type != GGML_TYPE_F32 ||
         src1->type != GGML_TYPE_F32 ||
@@ -2969,20 +2951,20 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     if (K <= 0 || M <= 0 || N <= 0) return GGML_STATUS_FAILED;
     if (src1->ne[0] != K) return GGML_STATUS_FAILED;
     if ((K % 32) != 0) return GGML_STATUS_FAILED;
+    if (src1->ne[1] == 1) return GGML_STATUS_FAILED;
 
-    // 2D only.
-    if (node->ne[2] != 1 || node->ne[3] != 1) return GGML_STATUS_FAILED;
-    if (src0->ne[2] != 1 || src0->ne[3] != 1) return GGML_STATUS_FAILED;
-    if (src1->ne[2] != 1 || src1->ne[3] != 1) return GGML_STATUS_FAILED;
-
-    if (node->ne[0] != M) return GGML_STATUS_FAILED;
-    if (node->ne[1] != N) return GGML_STATUS_FAILED;
-
+    // ---------------------------------------------------------
+    // Ensure Triton buffers
+    // Padding
+    // ---------------------------------------------------------
     const int64_t M_pad = tsi_round_up_i64(M, 8);
     const int64_t N_pad = tsi_round_up_i64(N, 64);
 
     ensure_triton_full_buffers(M_pad, N_pad, K);
 
+    // ---------------------------------------------------------
+    // Strides
+    // ---------------------------------------------------------
     const int64_t a_nb0 = nb_or_default(src0, 0);
     const int64_t a_nb1 = nb_or_default(src0, 1);
 
@@ -2992,15 +2974,19 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     const int64_t c_nb0 = nb_or_default(node, 0);
     const int64_t c_nb1 = nb_or_default(node, 1);
 
-    // Pack A: [M_pad x K]
-    memset(g_triton_A_full, 0, (size_t) M_pad * (size_t) K * sizeof(float));
+
+    // ---------------------------------------------------------
+    // Pack FULL A → [M_pad x K]
+    // ---------------------------------------------------------
+    memset(g_triton_A_full, 0, (size_t)M_pad * K * sizeof(float));
 
     for (int64_t r = 0; r < M; ++r) {
-        const char *src_row = (const char *) src0->data + r * a_nb1;
+        const char *src_row = (const char *)src0->data + r * a_nb1;
+
         float *dst_row = g_triton_A_full + r * K;
 
-        if (a_nb0 == (int64_t) sizeof(float)) {
-            memcpy(dst_row, src_row, (size_t) K * sizeof(float));
+        if (a_nb0 == sizeof(float)) {
+            memcpy(dst_row, src_row, (size_t)K * sizeof(float));
         } else {
             for (int64_t kk = 0; kk < K; ++kk) {
                 dst_row[kk] = *(const float *)(src_row + kk * a_nb0);
@@ -3008,11 +2994,13 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
         }
     }
 
-    // Pack B: [K x N_pad]
-    memset(g_triton_B_full, 0, (size_t) K * (size_t) N_pad * sizeof(float));
+    // ---------------------------------------------------------
+    // Pack FULL B → [K x N_pad]
+    // ---------------------------------------------------------
+    memset(g_triton_B_full, 0, (size_t)K * N_pad * sizeof(float));
 
     for (int64_t c = 0; c < N; ++c) {
-        const char *src_col = (const char *) src1->data + c * b_nb1;
+        const char *src_col = (const char *)src1->data + c * b_nb1;
 
         for (int64_t kk = 0; kk < K; ++kk) {
             g_triton_B_full[kk * N_pad + c] =
@@ -3020,37 +3008,46 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
         }
     }
 
-    // C must be zero because Triton kernel does:
-    // acc = load(C); acc += dot(A, B)
-    memset(g_triton_C_full, 0, (size_t) M_pad * (size_t) N_pad * sizeof(float));
+    // ---------------------------------------------------------
+    // Zero C
+    // ---------------------------------------------------------
+    memset(g_triton_C_full, 0, (size_t)M_pad * N_pad * sizeof(float));
 
-    // Single Triton call for full 2D MAT_MUL/GEMV.
+    // ---------------------------------------------------------
+    // SINGLE Triton call (FULL MATMUL)
+    // ---------------------------------------------------------
     call_triton_matmul_full_packed(
         g_triton_A_full,
         g_triton_B_full,
         g_triton_C_full,
-        (int32_t) M_pad,
-        (int32_t) N_pad,
-        (int32_t) K);
+        (int32_t)M_pad,
+        (int32_t)N_pad,
+        (int32_t)K);
 
+    // ---------------------------------------------------------
+    // Stats update (IMPORTANT)
+    // ---------------------------------------------------------
     if (device) {
         ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
     }
     ++node->tsi_kernel_runs;
 
-    // Copy back dst [M x N]
+    // ---------------------------------------------------------
+    // Copy back to GGML tensor
+    // ---------------------------------------------------------
     {
-        char *dst_base = (char *) node->data;
+        char *dst_base = (char *)node->data;
         const size_t bytes_total = (size_t) ggml_nbytes(node);
 
         for (int64_t r = 0; r < M; ++r) {
             for (int64_t c = 0; c < N; ++c) {
+
                 const int64_t byte_off =
                     r * c_nb0 +
                     c * c_nb1;
 
                 if (byte_off < 0 ||
-                    (size_t) byte_off + sizeof(float) > bytes_total) {
+                    (size_t)byte_off + sizeof(float) > bytes_total) {
                     continue;
                 }
 

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2005,155 +2005,39 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
 
     if (!a || !b) return false;
 
-    // =====================================================
-    // TYPE FILTER (ONLY F32 FOR NOW)
-    // =====================================================
-    if (a->type != GGML_TYPE_F32 ||
-        b->type != GGML_TYPE_F32 ||
-        op->type != GGML_TYPE_F32) {
-        return false;
-    }
+    // GGML MUL_MAT:
+    //   a/src0: [K, output_cols]
+    //   b/src1: [K, batch]
+    //   op/dst: [output_cols, batch]
+    const int64_t K          = a->ne[0];
+    const int64_t OUT_COLS   = op->ne[0];
+    const int64_t BATCH_COLS = op->ne[1];
 
-    const int64_t K = a->ne[0];
-    const int64_t M = a->ne[1];
-    const int64_t N = b->ne[1];
+    if (K <= 0 || OUT_COLS <= 0 || BATCH_COLS <= 0) return false;
 
-    // =====================================================
-    // BASIC VALIDATION
-    // =====================================================
-    if (K <= 0 || M <= 0 || N <= 0) return false;
+    // Current Triton path only supports F32 path and K decomposed by 32.
+    if ((K % 32) != 0) return false;
 
+    // Reduction dim must match.
     if (b->ne[0] != K) return false;
 
-    if (a->ne[1] != op->ne[0]) return false;
-    if (b->ne[1] != op->ne[1]) return false;
+    // Output shape must match expected GGML MUL_MAT relation.
+    if (a->ne[1] != OUT_COLS) return false;
+    if (b->ne[1] != BATCH_COLS) return false;
 
-    // Only pure 2D (REQUIRED for Triton path right now)
+    // Avoid GEMV / single-column cases for now.
+    // ggml_tsavorite_run_tmu_mul_mat() currently rejects src1->ne[1] == 1.
+    if (b->ne[1] == 1) return false;
+
+    // IMPORTANT:
+    // Keep only simple 2D matmul for now.
+    // Do not enable broadcast / batched 3D/4D shapes yet.
     if (op->ne[2] != 1 || op->ne[3] != 1) return false;
     if (a->ne[2]  != 1 || a->ne[3]  != 1) return false;
     if (b->ne[2]  != 1 || b->ne[3]  != 1) return false;
 
-    // Skip GEMV for now (can enable later)
-    if (N == 1) return false;
-
-    // Triton tiling requirement
-    if ((K % 32) != 0) return false;
-
-    // =====================================================
-    // GENERIC SAFE FILTER
-    // =====================================================
-
-    // Avoid extremely tiny cases (overhead > compute)
-    if (M < 16 || N < 2) return false;
-
-    // Avoid extremely large pathological cases (optional safety)
-    if (M > 4096 || N > 4096 || K > 8192) return false;
-
-    // Allow everything else
     return true;
 }
-
-
-#if phase1
-static bool mul_mat_supported_size(const struct ggml_tensor *op) {
-    const struct ggml_tensor *a = op->src[0];
-    const struct ggml_tensor *b = op->src[1];
-
-    if (!a || !b) return false;
-
-    const int64_t K = a->ne[0];
-    const int64_t M = a->ne[1];
-    const int64_t N = b->ne[1];
-
-    // =====================================================
-    // ✅ BASIC SAFETY (DO NOT CHANGE)
-    // =====================================================
-    if (K <= 0 || M <= 0 || N <= 0) return false;
-
-    if (b->ne[0] != K) return false;
-
-    if (a->ne[1] != op->ne[0]) return false;
-    if (b->ne[1] != op->ne[1]) return false;
-
-    // Only 2D tensors (important)
-    if (op->ne[2] != 1 || op->ne[3] != 1) return false;
-    if (a->ne[2]  != 1 || a->ne[3]  != 1) return false;
-    if (b->ne[2]  != 1 || b->ne[3]  != 1) return false;
-
-    // skip GEMV for now
-    if (N == 1) return false;
-
-    // Triton requirement
-    if ((K % 32) != 0) return false;
-
-    // DEBUG (KEEP ON until stable)
-    //printf("CHECK: K=%ld M=%ld N=%ld\n", K, M, N);
-
-
-    // =====================================================
-    // ✅ PHASE 1 — GUARANTEED HIT (START HERE)
-    // Goal: confirm routing to OPU works again
-    // =====================================================
-#if 1
-    if ((K % 32) == 0 && N != 1) {
-        return true;   // broad allow
-    }
-    return false;
-#endif
-
-
-    // =====================================================
-    // ✅ PHASE 2 — CONTROLLED (REAL SHAPES)
-    // Enable after Phase 1 stable
-    // =====================================================
-#if 1
-    if (K == 576 &&
-        (M == 576 || M == 192 || M == 128 || M == 1) &&
-        (N >= 2 && N <= 64)) {
-        return true;
-    }
-    return false;
-#endif
-
-
-    // =====================================================
-    // ✅ PHASE 3 — ADD LARGE K (1536)
-    // =====================================================
-#if 3
-    if ((K == 576 || K == 1536) &&
-        (M == 576 || M == 192 || M == 1536 || M == 128) &&
-        (N >= 2 && N <= 64)) {
-        return true;
-    }
-    return false;
-#endif
-
-
-    // =====================================================
-    // ✅ PHASE 4 — SMALL SHAPES (attention path)
-    // =====================================================
-#if 4
-    if ((K == 576 || K == 1536 || K == 256 || K == 64) &&
-        (M == 576 || M == 192 || M == 1536 || M == 256 || M == 64 || M == 1) &&
-        (N >= 2 && N <= 128)) {
-        return true;
-    }
-    return false;
-#endif
-
-
-    // =====================================================
-    // ✅ FINAL — ALL SAFE TRITON SHAPES
-    // =====================================================
-#if 5
-    if ((K % 32) == 0 && N != 1) {
-        return true;
-    }
-    return false;
-#endif
-}
-#endif /* phase1 */
-
 
 
 #if 0
@@ -2592,58 +2476,45 @@ static inline int64_t tsi_round_up_i64(int64_t v, int64_t a) {
 static constexpr int32_t TRITON_FULL_M_TILE = 64;
 static constexpr int32_t TRITON_FULL_N_TILE = 64;
 
-static float *g_triton_A_full = nullptr; // [M_cap x K_cap]
-static float *g_triton_B_full = nullptr; // [K_cap x N_cap]
-static float *g_triton_C_full = nullptr; // [M_cap x N_cap]
-
-static int64_t g_triton_M_cap = 0;
-static int64_t g_triton_N_cap = 0;
+static float *g_triton_A_full = nullptr; // [64 x K_cap]
+static float *g_triton_B_full = nullptr; // [K_cap x 64]
+static float *g_triton_C_full = nullptr; // [64 x 64]
 static int64_t g_triton_K_cap = 0;
 
-static inline void ensure_triton_full_buffers(int64_t M_pad, int64_t N_pad, int64_t K) {
-    TSAVORITE_GGML_ASSERT(M_pad > 0);
-    TSAVORITE_GGML_ASSERT(N_pad > 0);
+static inline void ensure_triton_full_buffers(int64_t K) {
     TSAVORITE_GGML_ASSERT(K > 0);
 
-    TSAVORITE_GGML_ASSERT((M_pad % 8) == 0);
-    TSAVORITE_GGML_ASSERT((N_pad % 64) == 0);
-    TSAVORITE_GGML_ASSERT((K % 32) == 0);
-
-    const int64_t need_M = M_pad;
-    const int64_t need_N = N_pad;
     const int64_t need_K = tsi_round_up_i64(K, 32);
 
-    if (!g_triton_A_full || !g_triton_B_full || !g_triton_C_full ||
-        need_M > g_triton_M_cap ||
-        need_N > g_triton_N_cap ||
-        need_K > g_triton_K_cap) {
+    // Allocate at least 2048 once so we do not grow/re-allocate for common model K values.
+    const int64_t alloc_K = (need_K > 2048) ? need_K : 2048;
 
-        g_triton_M_cap = need_M;
-        g_triton_N_cap = need_N;
-        g_triton_K_cap = need_K;
+    if (!g_triton_C_full) {
+        g_triton_C_full = (float *) tsi_alloc(
+            (size_t) TRITON_FULL_M_TILE *
+            (size_t) TRITON_FULL_N_TILE *
+            sizeof(float));
+
+        TSAVORITE_GGML_ASSERT(g_triton_C_full);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_C_full) & 127) == 0);
+    }
+
+    if (!g_triton_A_full || !g_triton_B_full || alloc_K > g_triton_K_cap) {
+        g_triton_K_cap = alloc_K;
 
         g_triton_A_full = (float *) tsi_alloc(
-            (size_t) g_triton_M_cap *
+            (size_t) TRITON_FULL_M_TILE *
             (size_t) g_triton_K_cap *
             sizeof(float));
 
         g_triton_B_full = (float *) tsi_alloc(
             (size_t) g_triton_K_cap *
-            (size_t) g_triton_N_cap *
+            (size_t) TRITON_FULL_N_TILE *
             sizeof(float));
 
-        g_triton_C_full = (float *) tsi_alloc(
-            (size_t) g_triton_M_cap *
-            (size_t) g_triton_N_cap *
-            sizeof(float));
-
-        TSAVORITE_GGML_ASSERT(g_triton_A_full);
-        TSAVORITE_GGML_ASSERT(g_triton_B_full);
-        TSAVORITE_GGML_ASSERT(g_triton_C_full);
-
+        TSAVORITE_GGML_ASSERT(g_triton_A_full && g_triton_B_full);
         TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_A_full) & 127) == 0);
         TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_B_full) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_C_full) & 127) == 0);
     }
 }
 
@@ -2922,140 +2793,138 @@ static inline void ensure_tmu_pack_buffers() {
 //  - increments node->tsi_kernel_runs and device stats for MUL_MAT
 // -----------------------------------------------------------------------------
 static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
-    struct ggml_backend_tsavorite_context * /*ctx*/,
+    struct ggml_backend_tsavorite_context * ctx,
     txe_device_s device,
     struct ggml_tensor * node,
     enum ggml_tsavorite_kernel_type kernel_type,
-    int /*kernel_sub_type*/) {
+    int kernel_sub_type) {
 
-    // ---------------------------------------------------------
-    // Basic validation
-    // ---------------------------------------------------------
-    if (!node || !node->src[0] || !node->src[1] || !node->data) {
+    if (!node || !node->src[0] || !node->src[1]) {
         return GGML_STATUS_FAILED;
     }
 
-    const struct ggml_tensor *src0 = node->src[0]; // A
-    const struct ggml_tensor *src1 = node->src[1]; // B
+    const struct ggml_tensor *A = node->src[0];
+    const struct ggml_tensor *B = node->src[1];
 
-    if (src0->type != GGML_TYPE_F32 ||
-        src1->type != GGML_TYPE_F32 ||
-        node->type != GGML_TYPE_F32) {
-        return GGML_STATUS_FAILED;
-    }
-
-    const int64_t K = src0->ne[0];
-    const int64_t M = src0->ne[1];
-    const int64_t N = src1->ne[1];
+    // -----------------------------
+    // Base dims
+    // -----------------------------
+    const int64_t K = A->ne[0];
+    const int64_t M = A->ne[1];
+    const int64_t N = B->ne[1];
 
     if (K <= 0 || M <= 0 || N <= 0) return GGML_STATUS_FAILED;
-    if (src1->ne[0] != K) return GGML_STATUS_FAILED;
+    if (B->ne[0] != K) return GGML_STATUS_FAILED;
     if ((K % 32) != 0) return GGML_STATUS_FAILED;
-    if (src1->ne[1] == 1) return GGML_STATUS_FAILED;
 
-    // ---------------------------------------------------------
-    // Ensure Triton buffers
-    // Padding
-    // ---------------------------------------------------------
-    const int64_t M_pad = tsi_round_up_i64(M, 8);
-    const int64_t N_pad = tsi_round_up_i64(N, 64);
+    // -----------------------------
+    // Batch dims (NEW)
+    // -----------------------------
+    const int64_t D2 = node->ne[2];
+    const int64_t D3 = node->ne[3];
 
+    // -----------------------------
+    // Padding (same for all slices)
+    // -----------------------------
+    const int64_t M_pad = ((M + 7) / 8) * 8;
+    const int64_t N_pad = ((N + 63) / 64) * 64;
+
+    // Allocate ONCE (no growth per slice)
     ensure_triton_full_buffers(M_pad, N_pad, K);
 
-    // ---------------------------------------------------------
-    // Strides
-    // ---------------------------------------------------------
-    const int64_t a_nb0 = nb_or_default(src0, 0);
-    const int64_t a_nb1 = nb_or_default(src0, 1);
+    const int64_t a_nb0 = nb_or_default(A, 0);
+    const int64_t a_nb1 = nb_or_default(A, 1);
+    const int64_t a_nb2 = nb_or_default(A, 2);
+    const int64_t a_nb3 = nb_or_default(A, 3);
 
-    const int64_t b_nb0 = nb_or_default(src1, 0);
-    const int64_t b_nb1 = nb_or_default(src1, 1);
+    const int64_t b_nb0 = nb_or_default(B, 0);
+    const int64_t b_nb1 = nb_or_default(B, 1);
+    const int64_t b_nb2 = nb_or_default(B, 2);
+    const int64_t b_nb3 = nb_or_default(B, 3);
 
     const int64_t c_nb0 = nb_or_default(node, 0);
     const int64_t c_nb1 = nb_or_default(node, 1);
+    const int64_t c_nb2 = nb_or_default(node, 2);
+    const int64_t c_nb3 = nb_or_default(node, 3);
 
+    char *A_base = (char *) A->data;
+    char *B_base = (char *) B->data;
+    char *C_base = (char *) node->data;
 
-    // ---------------------------------------------------------
-    // Pack FULL A → [M_pad x K]
-    // ---------------------------------------------------------
-    memset(g_triton_A_full, 0, (size_t)M_pad * K * sizeof(float));
+    // =========================================================
+    // 🔥 MAIN FIX: loop over batch dims (instead of expanding)
+    // =========================================================
+    for (int64_t d3 = 0; d3 < D3; ++d3) {
+        for (int64_t d2 = 0; d2 < D2; ++d2) {
 
-    for (int64_t r = 0; r < M; ++r) {
-        const char *src_row = (const char *)src0->data + r * a_nb1;
+            char *A_ptr = A_base + d2 * a_nb2 + d3 * a_nb3;
+            char *B_ptr = B_base + d2 * b_nb2 + d3 * b_nb3;
+            char *C_ptr = C_base + d2 * c_nb2 + d3 * c_nb3;
 
-        float *dst_row = g_triton_A_full + r * K;
+            // -----------------------
+            // Pack A
+            // -----------------------
+            memset(g_triton_A_full, 0, M_pad * K * sizeof(float));
 
-        if (a_nb0 == sizeof(float)) {
-            memcpy(dst_row, src_row, (size_t)K * sizeof(float));
-        } else {
-            for (int64_t kk = 0; kk < K; ++kk) {
-                dst_row[kk] = *(const float *)(src_row + kk * a_nb0);
+            for (int64_t r = 0; r < M; ++r) {
+                const char *row = A_ptr + r * a_nb1;
+                float *dst = g_triton_A_full + r * K;
+
+                if (a_nb0 == sizeof(float)) {
+                    memcpy(dst, row, K * sizeof(float));
+                } else {
+                    for (int64_t k = 0; k < K; ++k) {
+                        dst[k] = *(float *)(row + k * a_nb0);
+                    }
+                }
+            }
+
+            // -----------------------
+            // Pack B
+            // -----------------------
+            memset(g_triton_B_full, 0, K * N_pad * sizeof(float));
+
+            for (int64_t c = 0; c < N; ++c) {
+                const char *col = B_ptr + c * b_nb1;
+                for (int64_t k = 0; k < K; ++k) {
+                    g_triton_B_full[k * N_pad + c] =
+                        *(float *)(col + k * b_nb0);
+                }
+            }
+
+            // -----------------------
+            // Clear C
+            // -----------------------
+            memset(g_triton_C_full, 0, M_pad * N_pad * sizeof(float));
+
+            // -----------------------
+            // Kernel call
+            // -----------------------
+            call_triton_matmul_full_packed(
+                g_triton_A_full,
+                g_triton_B_full,
+                g_triton_C_full,
+                (int32_t)M_pad,
+                (int32_t)N_pad,
+                (int32_t)K);
+
+            // -----------------------
+            // Copy back
+            // -----------------------
+            for (int64_t r = 0; r < M; ++r) {
+                for (int64_t c = 0; c < N; ++c) {
+                    *(float *)(C_ptr + r*c_nb0 + c*c_nb1) =
+                        g_triton_C_full[r * N_pad + c];
+                }
             }
         }
     }
 
-    // ---------------------------------------------------------
-    // Pack FULL B → [K x N_pad]
-    // ---------------------------------------------------------
-    memset(g_triton_B_full, 0, (size_t)K * N_pad * sizeof(float));
-
-    for (int64_t c = 0; c < N; ++c) {
-        const char *src_col = (const char *)src1->data + c * b_nb1;
-
-        for (int64_t kk = 0; kk < K; ++kk) {
-            g_triton_B_full[kk * N_pad + c] =
-                *(const float *)(src_col + kk * b_nb0);
-        }
-    }
-
-    // ---------------------------------------------------------
-    // Zero C
-    // ---------------------------------------------------------
-    memset(g_triton_C_full, 0, (size_t)M_pad * N_pad * sizeof(float));
-
-    // ---------------------------------------------------------
-    // SINGLE Triton call (FULL MATMUL)
-    // ---------------------------------------------------------
-    call_triton_matmul_full_packed(
-        g_triton_A_full,
-        g_triton_B_full,
-        g_triton_C_full,
-        (int32_t)M_pad,
-        (int32_t)N_pad,
-        (int32_t)K);
-
-    // ---------------------------------------------------------
-    // Stats update (IMPORTANT)
-    // ---------------------------------------------------------
     if (device) {
         ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
     }
+
     ++node->tsi_kernel_runs;
-
-    // ---------------------------------------------------------
-    // Copy back to GGML tensor
-    // ---------------------------------------------------------
-    {
-        char *dst_base = (char *)node->data;
-        const size_t bytes_total = (size_t) ggml_nbytes(node);
-
-        for (int64_t r = 0; r < M; ++r) {
-            for (int64_t c = 0; c < N; ++c) {
-
-                const int64_t byte_off =
-                    r * c_nb0 +
-                    c * c_nb1;
-
-                if (byte_off < 0 ||
-                    (size_t)byte_off + sizeof(float) > bytes_total) {
-                    continue;
-                }
-
-                *(float *)(dst_base + byte_off) =
-                    g_triton_C_full[r * N_pad + c];
-            }
-        }
-    }
 
     return GGML_STATUS_SUCCESS;
 }

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -1998,6 +1998,44 @@ static bool is_op_dtype_consistent_with_src(const struct ggml_tensor *op) {
   return true;
 }
 
+//TMU Test case
+static bool mul_mat_supported_size(const struct ggml_tensor *op) {
+    const struct ggml_tensor *a = op->src[0];
+    const struct ggml_tensor *b = op->src[1];
+
+    if (!a || !b) return false;
+
+    const int64_t K = a->ne[0];
+    const int64_t N = op->ne[0];
+    const int64_t M = op->ne[1];
+
+    if (K <= 0 || N <= 0 || M <= 0) return false;
+    if ((K % TMU_K_MULTIPLE) != 0) return false;
+    if (b->ne[0] != K) return false;
+
+    // ✅ ENABLE ONLY WORKING OPU SHAPE
+    // dst  = [576, 5]
+    // src0 = [576, 576]
+    // src1 = [576, 5]
+    if (K == 576 &&
+        N == 576 &&
+        M == 5 &&
+        op->ne[2] == 1 &&
+        op->ne[3] == 1 &&
+        a->ne[1] == 576 &&
+        b->ne[1] == 5) {
+
+        fprintf(stderr,
+                "\nTSI DEBUG: ENABLE OPU MAT_MUL (576x576 * 576x5)\n");
+
+        return true;
+    }
+
+    return false;
+}
+
+
+#if 0
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     const struct ggml_tensor *a = op->src[0];
     const struct ggml_tensor *b = op->src[1];
@@ -2073,6 +2111,7 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     // Default: not supported (prevents CMA from trying to hold most of the model)
     return false;
 }
+#endif /* 0 */
 
 static bool ggml_tsavorite_internal_supports_op(const struct ggml_tensor *op) {
 
@@ -2367,9 +2406,232 @@ void _mlir_ciface_txe_mul_mat_tile_f32_k2048_host  (void *A_tile, void *B_tile, 
 	return;
 }
 
+
+// ANOOP TRITION CODE
+// -----------------------------------------------------------------------------
+// Triton MATMUL minimal wrapper for static K=32
+// Keeps existing ggml_tsavorite_run_tmu_mul_mat() packing/copyback unchanged.
+// A pack : [1,1,TMU_M_TILE_MAX,32]
+// B pack : [1,1,TMU_N_BLOCK,32]   // row-major packed as N x K (same as current TMU path)
+// C tile : [1,1,TMU_M_TILE_MAX,TMU_N_BLOCK]
+// Scalars: M, N, K, grid1, grid2, grid3 (all memref-of-1xi32 style)
+// -----------------------------------------------------------------------------
+//
+
+static int32_t g_triton_cur_M_tile = TMU_M_TILE_MAX;
+static int32_t g_triton_cur_N_tile = TMU_N_BLOCK;
+
+
+extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper(
+    void *A, void *B, void *C,
+    void *M_scalar, void *N_scalar, void *K_scalar,
+    void *grid1_scalar, void *grid2_scalar, void *grid3_scalar);
+
+// -----------------------------------------------------------------------------
+// Triton MAT_MUL ABI helpers
+// IMPORTANT:
+// - Triton matmul wrapper wants flattened rank-1 memrefs for A/B/C
+// - M/N/K and grid{1,2,3} are separate scalar memrefs
+// - Descriptor and scalar payload must both be device-visible and 128B aligned
+// -----------------------------------------------------------------------------
+
+template<int N>
+static inline void init_rank1_memref_flat(
+    MemRefDescriptor<N> *d,
+    void *ptr,
+    int64_t len
+) {
+    memset(d, 0, sizeof(MemRefDescriptor<N>));
+    d->base       = ptr;
+    d->data       = ptr;
+    d->offset     = 0;
+    d->shape[0]   = len;
+    d->strides[0] = 1;
+}
+
+template<int N>
+static inline void init_scalar_i32_memref_aligned(
+    MemRefDescriptor<N> *d,
+    void *payload_ptr,
+    int32_t v
+) {
+    memset(d, 0, sizeof(MemRefDescriptor<N>));
+    d->base       = payload_ptr;
+    d->data       = payload_ptr;
+    d->offset     = 0;
+    d->shape[0]   = 1;
+    d->strides[0] = 1;
+    *((int32_t *) payload_ptr) = v;
+}
+
+
+template<int K>
+static inline void call_triton_matmul_blob_k(
+    const void *A_tile,   // blob-style: [TMU_M_TILE_MAX x K], row-major
+    const void *B_tile,   // blob-style: [TMU_N_BLOCK    x K], row-major as N x K
+    void *C_tile,         // blob-style: [TMU_M_TILE_MAX x TMU_N_BLOCK], row-major
+    int32_t M_tile,       // actual valid rows
+    int32_t N_tile) {     // actual valid cols
+
+    constexpr int32_t TRITON_M_TILE = 8;
+    constexpr int32_t TRITON_N_TILE = 64;
+
+    static float *A_triton = nullptr;   // physical [8 x K]
+    static float *B_triton = nullptr;   // physical [K x 64]
+    static float *C_triton = nullptr;   // physical [8 x 64]
+
+    static MemRefDescriptor<Rank> *A_desc = nullptr;
+    static MemRefDescriptor<Rank> *B_desc = nullptr;
+    static MemRefDescriptor<Rank> *C_desc = nullptr;
+
+    static MemRefDescriptor<Rank> *M_desc     = nullptr;
+    static MemRefDescriptor<Rank> *N_desc     = nullptr;
+    static MemRefDescriptor<Rank> *K_desc     = nullptr;
+    static MemRefDescriptor<Rank> *grid1_desc = nullptr;
+    static MemRefDescriptor<Rank> *grid2_desc = nullptr;
+    static MemRefDescriptor<Rank> *grid3_desc = nullptr;
+
+    static int32_t *M_payload     = nullptr;
+    static int32_t *N_payload     = nullptr;
+    static int32_t *K_payload     = nullptr;
+    static int32_t *grid1_payload = nullptr;
+    static int32_t *grid2_payload = nullptr;
+    static int32_t *grid3_payload = nullptr;
+
+    static bool inited = false;
+    if (!inited) {
+        A_triton = (float *) tsi_alloc((size_t) TRITON_M_TILE * (size_t) K * sizeof(float));
+        B_triton = (float *) tsi_alloc((size_t) K * (size_t) TRITON_N_TILE * sizeof(float));
+        C_triton = (float *) tsi_alloc((size_t) TRITON_M_TILE * (size_t) TRITON_N_TILE * sizeof(float));
+
+        A_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        B_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        C_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+
+        M_desc     = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        N_desc     = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        K_desc     = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        grid1_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        grid2_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        grid3_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+
+        M_payload     = (int32_t *) tsi_alloc(128);
+        N_payload     = (int32_t *) tsi_alloc(128);
+        K_payload     = (int32_t *) tsi_alloc(128);
+        grid1_payload = (int32_t *) tsi_alloc(128);
+        grid2_payload = (int32_t *) tsi_alloc(128);
+        grid3_payload = (int32_t *) tsi_alloc(128);
+
+        TSAVORITE_GGML_ASSERT(A_triton && B_triton && C_triton);
+        TSAVORITE_GGML_ASSERT(A_desc && B_desc && C_desc);
+        TSAVORITE_GGML_ASSERT(M_desc && N_desc && K_desc);
+        TSAVORITE_GGML_ASSERT(grid1_desc && grid2_desc && grid3_desc);
+        TSAVORITE_GGML_ASSERT(M_payload && N_payload && K_payload);
+        TSAVORITE_GGML_ASSERT(grid1_payload && grid2_payload && grid3_payload);
+
+        TSAVORITE_GGML_ASSERT((((uintptr_t) A_triton) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) B_triton) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) C_triton) & 127) == 0);
+
+        TSAVORITE_GGML_ASSERT((((uintptr_t) A_desc) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) B_desc) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) C_desc) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) M_desc) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) N_desc) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) K_desc) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) grid1_desc) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) grid2_desc) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) grid3_desc) & 127) == 0);
+
+        TSAVORITE_GGML_ASSERT((((uintptr_t) M_payload) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) N_payload) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) K_payload) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) grid1_payload) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) grid2_payload) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) grid3_payload) & 127) == 0);
+
+        inited = true;
+    }
+
+    const float *A_blob = (const float *) A_tile;   // [TMU_M_TILE_MAX x K]
+    const float *B_blob = (const float *) B_tile;   // [TMU_N_BLOCK    x K] == [N x K]
+    float       *C_blob = (float *) C_tile;         // [TMU_M_TILE_MAX x TMU_N_BLOCK]
+
+    // B: blob-style [N x K] -> Triton physical [K x 64], padded
+    memset(B_triton, 0, (size_t) K * (size_t) TRITON_N_TILE * sizeof(float));
+    for (int32_t n = 0; n < N_tile; ++n) {
+        const float *src_row = B_blob + (size_t) n * (size_t) K;
+        for (int32_t kk = 0; kk < K; ++kk) {
+            B_triton[(size_t) kk * (size_t) TRITON_N_TILE + (size_t) n] = src_row[kk];
+        }
+    }
+
+    for (int32_t m0 = 0; m0 < M_tile; m0 += TRITON_M_TILE) {
+        const int32_t m_valid =
+            (M_tile - m0 > TRITON_M_TILE) ? TRITON_M_TILE : (M_tile - m0);
+
+        // A: blob row-major -> Triton physical [8 x K], padded
+        memset(A_triton, 0, (size_t) TRITON_M_TILE * (size_t) K * sizeof(float));
+        for (int32_t r = 0; r < m_valid; ++r) {
+            const float *src_row = A_blob + (size_t) (m0 + r) * (size_t) K;
+            float *dst_row = A_triton + (size_t) r * (size_t) K;
+            memcpy(dst_row, src_row, (size_t) K * sizeof(float));
+        }
+
+        // C carry-in
+        memset(C_triton, 0, (size_t) TRITON_M_TILE * (size_t) TRITON_N_TILE * sizeof(float));
+        for (int32_t r = 0; r < m_valid; ++r) {
+            const float *src_row = C_blob + (size_t) (m0 + r) * (size_t) TMU_N_BLOCK;
+            float *dst_row = C_triton + (size_t) r * (size_t) TRITON_N_TILE;
+            for (int32_t n = 0; n < N_tile; ++n) {
+                dst_row[n] = src_row[n];
+            }
+        }
+
+        // IMPORTANT: logical flattened lengths, not padded physical lengths
+        init_rank1_memref_flat(A_desc, (void *) A_triton, (int64_t) m_valid * (int64_t) K);
+        init_rank1_memref_flat(B_desc, (void *) B_triton, (int64_t) N_tile * (int64_t) K);
+        init_rank1_memref_flat(C_desc, (void *) C_triton, (int64_t) m_valid * (int64_t) N_tile);
+
+        init_scalar_i32_memref_aligned(M_desc,     M_payload,     m_valid);
+        init_scalar_i32_memref_aligned(N_desc,     N_payload,     N_tile);
+        init_scalar_i32_memref_aligned(K_desc,     K_payload,     K);
+        init_scalar_i32_memref_aligned(grid1_desc, grid1_payload, 1);
+        init_scalar_i32_memref_aligned(grid2_desc, grid2_payload, 1);
+        init_scalar_i32_memref_aligned(grid3_desc, grid3_payload, 1);
+
+        _mlir_ciface_matmul_kernel_memory_wrapper(
+            A_desc, B_desc, C_desc,
+            M_desc, N_desc, K_desc,
+            grid1_desc, grid2_desc, grid3_desc);
+
+        // copy valid result back
+        for (int32_t r = 0; r < m_valid; ++r) {
+            float *dst_row = C_blob + (size_t) (m0 + r) * (size_t) TMU_N_BLOCK;
+            const float *src_row = C_triton + (size_t) r * (size_t) TRITON_N_TILE;
+            for (int32_t n = 0; n < N_tile; ++n) {
+                dst_row[n] = src_row[n];
+            }
+        }
+    }
+}
+
+
+// Replace ONLY k32 first
+extern "C" void tmu_mul_mat_k32(const void *A, const void *B, void *C) {
+    call_triton_matmul_blob_k<32>(
+        A, B, C,
+        g_triton_cur_M_tile,
+        g_triton_cur_N_tile);
+}
+
+
+#if BLOB_CODE
 extern "C" void tmu_mul_mat_k32 (const void *A, const void *B, void *C) {
     call_tmu_blob<32>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k32_host);
 }
+#endif /* BLOB_CODE */
+
 extern "C" void tmu_mul_mat_k64 (const void *A, const void *B, void *C) {
     call_tmu_blob<64>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k64_host);
 }
@@ -2547,87 +2809,27 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
     ensure_tmu_pack_buffers();
 
-    // -------------------------------------------------------------------------
-    // Host-only buffer to save previous partial C between K buckets.
-    // IMPORTANT: This buffer is NOT passed to the TMU blob, so DO NOT use tsi_alloc
-    // (tsi_alloc comes from CMA and is not freed until tsi_finalize).
-    // Allocate once from normal host heap and reuse.
-    // -------------------------------------------------------------------------
-    static float *g_C_prev = nullptr;
-    static std::once_flag g_prev_once;
-    auto host_alloc_aligned = [](size_t bytes) -> void * {
-        void *p = nullptr;
-        if (posix_memalign(&p, 64, bytes) != 0) {
-            p = malloc(bytes);
-        }
-        return p;
-    };
-    std::call_once(g_prev_once, [&]() {
-        const size_t bytes = (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float);
-        g_C_prev = (float *) host_alloc_aligned(bytes);
-        TSAVORITE_GGML_ASSERT(g_C_prev);
-        memset(g_C_prev, 0, bytes);
-    });
-
 #ifdef TMU_DEBUG_VALIDATE
-    // -------------------------------------------------------------------------
-    // PR comment fix #1 + your request:
-    // 1) Make CPU reference helper take MemRefDescriptor-like structs
-    // 2) Actually CALL it here (it was dead previously)
-    // -------------------------------------------------------------------------
-    static void cpu_ref_mul_mat_f32(
-        const MemRefDescriptor<4> *A_desc,
-        const MemRefDescriptor<4> *B_desc,
-        MemRefDescriptor<4>       *C_desc
-    ) {
-        if (!A_desc || !B_desc || !C_desc) return;
-        if (!A_desc->data || !B_desc->data || !C_desc->data) return;
-
-        const int64_t M = A_desc->shape[2];
-        const int64_t K = A_desc->shape[3];
-        const int64_t N = B_desc->shape[2];
-
-        if (M <= 0 || N <= 0 || K <= 0) return;
-        if (B_desc->shape[3] != K) return;
-        if (C_desc->shape[2] != M) return;
-        if (C_desc->shape[3] != N) return;
-
-        const float *A = (const float *) A_desc->data;
-        const float *B = (const float *) B_desc->data;
-        float       *C = (float       *) C_desc->data;
-
-        const int64_t a_s2 = A_desc->strides[2];
-        const int64_t a_s3 = A_desc->strides[3];
-        const int64_t b_s2 = B_desc->strides[2];
-        const int64_t b_s3 = B_desc->strides[3];
-        const int64_t c_s2 = C_desc->strides[2];
-        const int64_t c_s3 = C_desc->strides[3];
-
-        const int64_t a_off = A_desc->offset;
-        const int64_t b_off = B_desc->offset;
-        const int64_t c_off = C_desc->offset;
-
-        for (int64_t r = 0; r < M; ++r) {
-            const int64_t a_row = a_off + r * a_s2;
-            const int64_t c_row = c_off + r * c_s2;
-
-            for (int64_t n = 0; n < N; ++n) {
-                const int64_t b_row = b_off + n * b_s2;   // B packed as [N,K]
-
-                float acc = 0.0f;
-                for (int64_t kk = 0; kk < K; ++kk) {
-                    acc += A[a_row + kk * a_s3] * B[b_row + kk * b_s3];
-                }
-                C[c_row + n * c_s3] = acc;
-            }
-        }
-    }
-
     // CPU reference buffers: accumulate chunk-by-chunk in packed space
     static float C_ref_chunk[TMU_M_TILE_MAX * TMU_N_BLOCK];
     static float C_ref_accum[TMU_M_TILE_MAX * TMU_N_BLOCK];
 #endif
 
+    // -------------------------------------------------------------------------
+    // GGML MUL_MAT convention used here:
+    //   src0: [K, M]
+    //   src1: [K, N]
+    //   dst : [M, N]
+    //
+    // In your currently enabled case:
+    //   src0 = [576, 576]
+    //   src1 = [576, 5]
+    //   dst  = [576, 5]
+    // so:
+    //   K = 576
+    //   M = 576   (dst->ne[0])
+    //   N = 5     (dst->ne[1])
+    // -------------------------------------------------------------------------
     const int64_t K = src0->ne[0];
     const int64_t M = src0->ne[1];
     const int64_t N = src1->ne[1];
@@ -2651,7 +2853,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     const int64_t c_nb2 = nb_or_default(node, 2);
     const int64_t c_nb3 = nb_or_default(node, 3);
 
-    // broadcast dims must come from inputs
+    // broadcast dims from inputs
     const int64_t A2 = src0->ne[2] ? src0->ne[2] : 1;
     const int64_t A3 = src0->ne[3] ? src0->ne[3] : 1;
     const int64_t B2 = src1->ne[2] ? src1->ne[2] : 1;
@@ -2659,10 +2861,6 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
     const int64_t D2 = (A2 > B2) ? A2 : B2;
     const int64_t D3 = (A3 > B3) ? A3 : B3;
-
-    if (device) {
-        ++device->stats.op_run_count[kernel_type].total_tensor_count;
-    }
 
     for (int64_t od3 = 0; od3 < D3; ++od3) {
         const int64_t a_d3 = map_repeat_i64(od3, A3);
@@ -2676,69 +2874,98 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
             const char *B_base_d23 = (const char *) src1->data + b_d2 * b_nb2 + b_d3 * b_nb3;
 
             for (int64_t m0 = 0; m0 < M; m0 += TMU_M_TILE_MAX) {
-                const int64_t m_tile = (M - m0 > TMU_M_TILE_MAX) ? TMU_M_TILE_MAX : (M - m0);
+                const int64_t m_tile =
+                    (M - m0 > TMU_M_TILE_MAX) ? TMU_M_TILE_MAX : (M - m0);
 
                 for (int64_t n0 = 0; n0 < N; n0 += TMU_N_BLOCK) {
-                    const int64_t n_valid = (N - n0 >= TMU_N_BLOCK) ? TMU_N_BLOCK : (N - n0);
+                    const int64_t n_valid =
+                        (N - n0 >= TMU_N_BLOCK) ? TMU_N_BLOCK : (N - n0);
 
-                    memset(g_C_tile, 0, (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+                    // -----------------------------------------------------------------
+                    // IMPORTANT:
+                    // Zero C ONCE per output tile.
+                    // Triton wrapper must preserve/consume carry-in C across K buckets.
+                    // -----------------------------------------------------------------
+                    memset(g_C_tile, 0,
+                           (size_t) TMU_M_TILE_MAX * (size_t) TMU_N_BLOCK * sizeof(float));
 
 #ifdef TMU_DEBUG_VALIDATE
-                    // reset CPU ref accumulator for THIS output tile
                     memset(C_ref_accum, 0, sizeof(C_ref_accum));
 #endif
 
                     int parts[128];
-                    const int np = tmu_decompose_k(K, parts, (int)(sizeof(parts)/sizeof(parts[0])));
+                    const int np = tmu_decompose_k(K, parts, (int)(sizeof(parts) / sizeof(parts[0])));
                     if (np < 0) return GGML_STATUS_FAILED;
 
                     int64_t k0 = 0;
 
                     for (int pi = 0; pi < np; ++pi) {
                         const int K_chunk = parts[pi];
-                        const tmu_bucket_dispatch *bucket = tmu_find_bucket(K_chunk);
+                        const tmu_bucket_dispatch * bucket = tmu_find_bucket(K_chunk);
                         if (!bucket || !bucket->fn) return GGML_STATUS_FAILED;
 
-                        pack_A_tile_f32(g_A_pack, A_base_d23, m0, m_tile, k0, K_chunk, a_nb0, a_nb1);
-                        pack_B_tile_f32(g_B_pack, B_base_d23, n0, n_valid, k0, K_chunk, b_nb0, b_nb1);
+                        // -------------------------------------------------------------
+                        // Pack A -> blob-style row-major [TMU_M_TILE_MAX x K_chunk]
+                        // -------------------------------------------------------------
+                        pack_A_tile_f32(
+                            g_A_pack,
+                            A_base_d23,
+                            m0,
+                            m_tile,
+                            k0,
+                            K_chunk,
+                            a_nb0,
+                            a_nb1);
 
-                        // Save previous partial before calling blob (because blob overwrites)
-                        if (pi > 0) {
-                            memcpy(g_C_prev, g_C_tile,
-                                   (size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
-                        }
+                        // -------------------------------------------------------------
+                        // Pack B -> blob-style row-major [TMU_N_BLOCK x K_chunk]
+                        // Existing helper already does:
+                        //   dst row = output column n
+                        //   dst[kk]  = B(k0+kk, n0+n)
+                        // -------------------------------------------------------------
+                        pack_B_tile_f32(
+                            g_B_pack,
+                            B_base_d23,
+                            n0,
+                            n_valid,
+                            k0,
+                            K_chunk,
+                            b_nb0,
+                            b_nb1);
 
-                        // Run blob
+                        g_triton_cur_M_tile = (int32_t) m_tile;
+                        g_triton_cur_N_tile = (int32_t) n_valid;
+
+                        // -----------------------------------------------------------------
+                        // IMPORTANT:
+                        // No host-side g_C_prev workaround here.
+                        // call_triton_matmul_blob_k() must preload current g_C_tile into
+                        // Triton C buffer and Triton does:
+                        //   acc = load(C); acc += dot(A, B); store(C)
+                        // -----------------------------------------------------------------
                         bucket->fn(g_A_pack, g_B_pack, g_C_tile);
 
-                        // Accumulate back (host-side workaround)
-                        if (pi > 0) {
-                            const int total = TMU_M_TILE_MAX * TMU_N_BLOCK;
-                            for (int i = 0; i < total; ++i) {
-                                g_C_tile[i] += g_C_prev[i];
-                            }
-                        }
-
                         // Stats per kernel call
-                        if (device) ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
+                        if (device) {
+                            ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
+                        }
                         ++node->tsi_kernel_runs;
 
 #ifdef TMU_DEBUG_VALIDATE
-                        // -----------------------------------------------------------------
-                        // CPU reference for THIS K_chunk computed from PACKED tiles
-                        // and accumulated into C_ref_accum, then compared with g_C_tile.
-                        // This makes cpu_ref_mul_mat_f32() actually USED.
-                        // -----------------------------------------------------------------
+                        // -------------------------------------------------------------
+                        // CPU reference for THIS K_chunk on packed tiles
+                        // accumulate chunk-by-chunk and compare against g_C_tile
+                        // -------------------------------------------------------------
                         memset(C_ref_chunk, 0, sizeof(C_ref_chunk));
 
                         MemRefDescriptor<4> Aref, Bref, Cref;
-                        init_memref_4d(Aref, (void*)g_A_pack, 1, 1, TMU_M_TILE_MAX, (int64_t)K_chunk);
-                        init_memref_4d(Bref, (void*)g_B_pack, 1, 1, TMU_N_BLOCK,   (int64_t)K_chunk);
-                        init_memref_4d(Cref, (void*)C_ref_chunk, 1, 1, TMU_M_TILE_MAX, TMU_N_BLOCK);
+                        init_memref_4d(Aref, (void *) g_A_pack, 1, 1, TMU_M_TILE_MAX, (int64_t) K_chunk);
+                        init_memref_4d(Bref, (void *) g_B_pack, 1, 1, TMU_N_BLOCK,   (int64_t) K_chunk);
+                        init_memref_4d(Cref, (void *) C_ref_chunk, 1, 1, TMU_M_TILE_MAX, TMU_N_BLOCK);
 
+                        // Use the EXISTING top-level helper already present in the file
                         cpu_ref_mul_mat_f32(&Aref, &Bref, &Cref);
 
-                        // accumulate CPU reference chunks (only valid region is needed)
                         for (int64_t rr = 0; rr < m_tile; ++rr) {
                             for (int64_t cc = 0; cc < n_valid; ++cc) {
                                 C_ref_accum[rr * TMU_N_BLOCK + cc] +=
@@ -2746,18 +2973,17 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                             }
                         }
 
-                        // Compare after each chunk (same tolerance you used before)
                         for (int64_t rr = 0; rr < m_tile; ++rr) {
                             for (int64_t cc = 0; cc < n_valid; ++cc) {
                                 const float tmu_v = g_C_tile[rr * TMU_N_BLOCK + cc];
                                 const float ref_v = C_ref_accum[rr * TMU_N_BLOCK + cc];
                                 if (fabsf(tmu_v - ref_v) > 1e-4f) {
                                     fprintf(stderr,
-                                        "\nTMU MISMATCH (packed-ref)\n"
-                                        "m0=%ld n0=%ld k0=%ld K_chunk=%d pi=%d\n"
-                                        "r=%ld c=%ld TMU=%f REF=%f\n",
-                                        (long)m0, (long)n0, (long)k0, K_chunk, pi,
-                                        (long)rr, (long)cc, tmu_v, ref_v);
+                                            "\nTMU/TRITON MISMATCH (packed-ref)\n"
+                                            "m0=%ld n0=%ld k0=%ld K_chunk=%d pi=%d\n"
+                                            "r=%ld c=%ld TMU=%f REF=%f\n",
+                                            (long)m0, (long)n0, (long)k0, K_chunk, pi,
+                                            (long)rr, (long)cc, tmu_v, ref_v);
                                     tsi_cleanup();
                                     abort();
                                 }
@@ -2768,7 +2994,14 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                         k0 += K_chunk;
                     }
 
-                    // Copy tile back to ggml output
+                    // exact K coverage required
+                    if (k0 != K) {
+                        return GGML_STATUS_FAILED;
+                    }
+
+                    // -------------------------------------------------------------
+                    // Copy tile back to GGML output
+                    // -------------------------------------------------------------
                     {
                         char *dst_base = (char *) node->data;
                         const size_t bytes_total = (size_t) ggml_nbytes(node);
@@ -2787,16 +3020,14 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                                     od3  * c_nb3;
 
                                 if (byte_off < 0 ||
-                                    (size_t)byte_off + sizeof(float) > bytes_total) {
+                                    (size_t) byte_off + sizeof(float) > bytes_total) {
                                     continue;
                                 }
+
                                 *(float *)(dst_base + byte_off) = src_row[cc];
                             }
                         }
                     }
-
-                    // If you decide to USE copy_tileC_to_ggml_f32 instead of inline copy-back:
-                    // copy_tileC_to_ggml_f32(g_C_tile, m_tile, 0, node, m0, n0, od2, od3);
                 }
             }
         }
@@ -2804,7 +3035,6 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
     return GGML_STATUS_SUCCESS;
 }
-
 
 static std::mutex g_tsavorite_compute_mutex;
 
@@ -3276,6 +3506,7 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
                     srcP1->data =  srcP1->base = (void *)(src1_ptr);
                     srcP0->data =  srcP0->base = (void *)(src0_ptr + r * ne10);
                     nodeP->data =  nodeP->base = (void *)(dst_ptr + r * ne10);
+#if TRITON_ADD
                     // kernel call
                     if (kernel_type == GGML_TSAVORITE_KERNEL_TYPE_ADD) {
                         // MemRefDescriptor
@@ -3330,8 +3561,11 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
                         _mlir_ciface_add_kernel_memory_wrapper(srcP0, srcP1, nodeP,
                                         scalar_loop, scalar_grid1, scalar_grid2, scalar_grid3);
                     } else {
+#endif /* TRITON_ADD */
                         ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, srcP1, nodeP);
+#if  TRITON_ADD
                     }
+#endif /* TRITON_ADD */
                     ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
                     ++node->tsi_kernel_runs;
                 }

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2000,47 +2000,263 @@ static bool is_op_dtype_consistent_with_src(const struct ggml_tensor *op) {
 
 //TMU Test case
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
+    if (!op) return false;
+
     const struct ggml_tensor *a = op->src[0];
     const struct ggml_tensor *b = op->src[1];
-
     if (!a || !b) return false;
 
+    // Only safe F32 Triton MAT_MUL path.
+    if (a->type != GGML_TYPE_F32 ||
+        b->type != GGML_TYPE_F32 ||
+        op->type != GGML_TYPE_F32) {
+        return false;
+    }
+
     // GGML MUL_MAT:
-    //   a/src0: [K, output_cols]
-    //   b/src1: [K, batch]
-    //   op/dst: [output_cols, batch]
-    const int64_t K          = a->ne[0];
-    const int64_t OUT_COLS   = op->ne[0];
-    const int64_t BATCH_COLS = op->ne[1];
+    //   a/src0: [K, M, d2, d3]
+    //   b/src1: [K, N, d2, d3]
+    //   op/dst: [M, N, d2, d3]
+    const int64_t K = a->ne[0];
+    const int64_t M = a->ne[1];
+    const int64_t N = b->ne[1];
 
-    if (K <= 0 || OUT_COLS <= 0 || BATCH_COLS <= 0) return false;
+    if (K <= 0 || M <= 0 || N <= 0) return false;
 
-    // Current Triton path only supports F32 path and K decomposed by 32.
+    // Shape correctness.
+    if (b->ne[0]  != K) return false;
+    if (op->ne[0] != M) return false;
+    if (op->ne[1] != N) return false;
+
+    // Triton MAT_MUL K requirement.
     if ((K % 32) != 0) return false;
 
-    // Reduction dim must match.
-    if (b->ne[0] != K) return false;
+    const int64_t M_pad = ((M + 7)  / 8)  * 8;
+    const int64_t N_pad = ((N + 63) / 64) * 64;
 
-    // Output shape must match expected GGML MUL_MAT relation.
-    if (a->ne[1] != OUT_COLS) return false;
-    if (b->ne[1] != BATCH_COLS) return false;
+    const int64_t elems_A = M_pad * K;
+    const int64_t elems_B = K * N_pad;
+    const int64_t elems_C = M_pad * N_pad;
 
-    // Avoid GEMV / single-column cases for now.
-    // ggml_tsavorite_run_tmu_mul_mat() currently rejects src1->ne[1] == 1.
-    if (b->ne[1] == 1) return false;
+    if (elems_A <= 0 || elems_B <= 0 || elems_C <= 0) {
+        return false;
+    }
 
-    // IMPORTANT:
-    // Keep only simple 2D matmul for now.
-    // Do not enable broadcast / batched 3D/4D shapes yet.
+    const int64_t total_bytes =
+        (elems_A + elems_B + elems_C) * (int64_t) sizeof(float);
+
+    /*
+     * Workaround for SS-1345:
+     *
+     * Current crash:
+     *   Failed to allocate 46137344 in DRAM_xxx
+     *
+     * Stack:
+     *   _mlir_ciface_matmul_kernel_memory_wrapper
+     *     -> matmul_kernel_memory_wrapper
+     *     -> matmul_kernel
+     *     -> tsi_alloc
+     *
+     * Keep limit below the crashing range.
+     */
+    static constexpr int64_t MAX_SAFE_PACKED_BYTES =
+        44LL * 1024LL * 1024LL;
+
+    if (total_bytes >= MAX_SAFE_PACKED_BYTES) {
+        /*
+         * Temporary debug for SS-1345:
+         * Print each rejected shape only once to avoid flooding logs.
+         */
+        static std::mutex s_reject_log_mutex;
+        static std::vector<std::string> s_reject_log_keys;
+
+        char key_buf[256];
+        snprintf(key_buf, sizeof(key_buf),
+                 "K=%ld M=%ld N=%ld M_pad=%ld N_pad=%ld total_bytes=%ld",
+                 (long) K, (long) M, (long) N,
+                 (long) M_pad, (long) N_pad,
+                 (long) total_bytes);
+
+#if 0
+        bool already_logged = false;
+        {
+            std::lock_guard<std::mutex> lock(s_reject_log_mutex);
+            for (const std::string &k : s_reject_log_keys) {
+                if (k == key_buf) {
+                    already_logged = true;
+                    break;
+                }
+            }
+
+            if (!already_logged) {
+                s_reject_log_keys.push_back(std::string(key_buf));
+            }
+        }
+
+        if (!already_logged) {
+            fprintf(stderr,
+                    "MUL_MAT_REJECT_SS1345: K=%ld M=%ld N=%ld "
+                    "M_pad=%ld N_pad=%ld total_bytes=%ld limit=%ld "
+                    "a=[%ld,%ld,%ld,%ld] b=[%ld,%ld,%ld,%ld] op=[%ld,%ld,%ld,%ld]\n",
+                    (long) K, (long) M, (long) N,
+                    (long) M_pad, (long) N_pad,
+                    (long) total_bytes,
+                    (long) MAX_SAFE_PACKED_BYTES,
+                    (long) a->ne[0],  (long) a->ne[1],  (long) a->ne[2],  (long) a->ne[3],
+                    (long) b->ne[0],  (long) b->ne[1],  (long) b->ne[2],  (long) b->ne[3],
+                    (long) op->ne[0], (long) op->ne[1], (long) op->ne[2], (long) op->ne[3]);
+        }
+#endif /* 0 */
+
+        return false;
+    }
+
+    // Extra sanity caps.
+    if (K > 8192)  return false;
+    if (M > 32768) return false;
+    if (N > 4096)  return false;
+
+    // ============================================================
+    // PHASE 0: current stable path — strict logical 2D only.
+    // ============================================================
+    if (op->ne[2] == 1 && op->ne[3] == 1 &&
+        a->ne[2]  == 1 && a->ne[3]  == 1 &&
+        b->ne[2]  == 1 && b->ne[3]  == 1) {
+        // Avoid GEMV/single-column path for current 2D Triton path.
+        if (N == 1) return false;
+        return true;
+    }
+
+    // ============================================================
+    // PHASE 1: enable only known small Tiny-Llama 4D shapes.
+    //
+    // Current known-safe 4D shapes from shape log:
+    //   op=[256,1,32,1], src0=[64,256,4,1],  src1=[64,1,32,1]
+    //   op=[64,1,32,1],  src0=[256,64,4,1],  src1=[256,1,32,1]
+    //
+    // NOTE:
+    // Runner must use broadcast mapping:
+    //   a_d2 = d2 % a->ne[2]
+    //   b_d2 = d2 % b->ne[2]
+    //
+    // Do not enable any other 4D shape yet.
+    // ============================================================
+    if (op->ne[3] == 1 && a->ne[3] == 1 && b->ne[3] == 1 &&
+        op->ne[2] == 32 &&
+        b->ne[2]  == 32 &&
+        a->ne[2]  == 4 &&
+        N == 1) {
+
+        if (K == 64 && M == 256) {
+#if 0
+            fprintf(stderr,
+                    "MUL_MAT_4D_ENABLE_PHASE1: K=%ld M=%ld N=%ld "
+                    "a=[%ld,%ld,%ld,%ld] b=[%ld,%ld,%ld,%ld] op=[%ld,%ld,%ld,%ld]\n",
+                    (long) K, (long) M, (long) N,
+                    (long) a->ne[0],  (long) a->ne[1],  (long) a->ne[2],  (long) a->ne[3],
+                    (long) b->ne[0],  (long) b->ne[1],  (long) b->ne[2],  (long) b->ne[3],
+                    (long) op->ne[0], (long) op->ne[1], (long) op->ne[2], (long) op->ne[3]);
+#endif /* 0 */
+            return true;
+        }
+
+        if (K == 256 && M == 64) {
+#if 0
+            fprintf(stderr,
+                    "MUL_MAT_4D_ENABLE_PHASE1: K=%ld M=%ld N=%ld "
+                    "a=[%ld,%ld,%ld,%ld] b=[%ld,%ld,%ld,%ld] op=[%ld,%ld,%ld,%ld]\n",
+                    (long) K, (long) M, (long) N,
+                    (long) a->ne[0],  (long) a->ne[1],  (long) a->ne[2],  (long) a->ne[3],
+                    (long) b->ne[0],  (long) b->ne[1],  (long) b->ne[2],  (long) b->ne[3],
+                    (long) op->ne[0], (long) op->ne[1], (long) op->ne[2], (long) op->ne[3]);
+#endif /* 0 */
+            return true;
+        }
+    }
+
+    return false;
+}
+
+
+
+
+#if 0
+static bool mul_mat_supported_size(const struct ggml_tensor *op) {
+    if (!op) return false;
+
+    const struct ggml_tensor *a = op->src[0];
+    const struct ggml_tensor *b = op->src[1];
+    if (!a || !b) return false;
+
+    // Only F32 Triton MAT_MUL path for now.
+    if (a->type != GGML_TYPE_F32 ||
+        b->type != GGML_TYPE_F32 ||
+        op->type != GGML_TYPE_F32) {
+        return false;
+    }
+
+    // GGML MUL_MAT:
+    //   a/src0: [K, M, 1, 1]
+    //   b/src1: [K, N, 1, 1]
+    //   op/dst: [M, N, 1, 1]
+    const int64_t K = a->ne[0];
+    const int64_t M = a->ne[1];
+    const int64_t N = b->ne[1];
+
+    if (K <= 0 || M <= 0 || N <= 0) return false;
+
+    // Shape correctness.
+    if (b->ne[0]  != K) return false;
+    if (op->ne[0] != M) return false;
+    if (op->ne[1] != N) return false;
+
+    // STRICT 2D ONLY. Do not enable 3D/4D/broadcast yet.
     if (op->ne[2] != 1 || op->ne[3] != 1) return false;
     if (a->ne[2]  != 1 || a->ne[3]  != 1) return false;
     if (b->ne[2]  != 1 || b->ne[3]  != 1) return false;
+
+    // Triton requirement.
+    if ((K % 32) != 0) return false;
+
+    // Skip GEMV/single-column for now.
+    if (N == 1) return false;
+
+    // Restore wider yesterday-like limits, but still bounded.
+    static constexpr int64_t TSI_TRITON_MAX_K = 8192;
+    static constexpr int64_t TSI_TRITON_MAX_M = 32768;
+    static constexpr int64_t TSI_TRITON_MAX_N = 4096;
+
+    if (K > TSI_TRITON_MAX_K) return false;
+    if (M > TSI_TRITON_MAX_M) return false;
+    if (N > TSI_TRITON_MAX_N) return false;
+
+    const int64_t M_pad = ((M + 7)  / 8)  * 8;
+    const int64_t N_pad = ((N + 63) / 64) * 64;
+
+    const int64_t elems_A = M_pad * K;
+    const int64_t elems_B = K * N_pad;
+    const int64_t elems_C = M_pad * N_pad;
+
+    if (elems_A <= 0 || elems_B <= 0 || elems_C <= 0) return false;
+
+    const int64_t total_bytes =
+        (elems_A + elems_B + elems_C) * (int64_t) sizeof(float);
+
+    /*
+     * With USER_DRAM_SIZE=8192, 46MB allocation succeeds.
+     * Keep a guard to avoid accidental huge OPU workspace.
+     */
+    static constexpr int64_t MAX_PACKED_BYTES =
+        128LL * 1024LL * 1024LL;   // 128 MB
+
+    if (total_bytes > MAX_PACKED_BYTES) {
+        return false;
+    }
 
     return true;
 }
 
 
-#if 0
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     const struct ggml_tensor *a = op->src[0];
     const struct ggml_tensor *b = op->src[1];

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2469,20 +2469,59 @@ static inline void init_scalar_i32_memref_aligned(
     *((int32_t *) payload_ptr) = v;
 }
 
+static inline int64_t tsi_round_up_i64(int64_t v, int64_t a) {
+    return ((v + a - 1) / a) * a;
+}
 
-template<int K>
-static inline void call_triton_matmul_blob_k(
-    const void *A_tile,   // blob-style: [TMU_M_TILE_MAX x K], row-major
-    const void *B_tile,   // blob-style: [TMU_N_BLOCK    x K], row-major as N x K
-    void *C_tile,         // blob-style: [TMU_M_TILE_MAX x TMU_N_BLOCK], row-major
-    int32_t M_tile,       // actual valid rows
-    int32_t N_tile) {     // actual valid cols
-    constexpr int32_t TRITON_M_TILE = 8;
-    constexpr int32_t TRITON_N_TILE = 64;
+static constexpr int32_t TRITON_FULL_M_TILE = 64;
+static constexpr int32_t TRITON_FULL_N_TILE = 64;
 
-    static float *A_triton = nullptr;   // physical [8 x K]
-    static float *B_triton = nullptr;   // physical [K x 64]
-    static float *C_triton = nullptr;   // physical [8 x 64]
+static float *g_triton_A_full = nullptr; // [64 x K_cap]
+static float *g_triton_B_full = nullptr; // [K_cap x 64]
+static float *g_triton_C_full = nullptr; // [64 x 64]
+static int64_t g_triton_K_cap = 0;
+
+static inline void ensure_triton_full_buffers(int64_t K) {
+    TSAVORITE_GGML_ASSERT(K > 0);
+
+    const int64_t need_K = tsi_round_up_i64(K, 32);
+
+    if (!g_triton_C_full) {
+        g_triton_C_full = (float *) tsi_alloc(
+            (size_t) TRITON_FULL_M_TILE *
+            (size_t) TRITON_FULL_N_TILE *
+            sizeof(float));
+
+        TSAVORITE_GGML_ASSERT(g_triton_C_full);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_C_full) & 127) == 0);
+    }
+
+    if (need_K > g_triton_K_cap) {
+        g_triton_K_cap = need_K;
+
+        g_triton_A_full = (float *) tsi_alloc(
+            (size_t) TRITON_FULL_M_TILE *
+            (size_t) g_triton_K_cap *
+            sizeof(float));
+
+        g_triton_B_full = (float *) tsi_alloc(
+            (size_t) g_triton_K_cap *
+            (size_t) TRITON_FULL_N_TILE *
+            sizeof(float));
+
+        TSAVORITE_GGML_ASSERT(g_triton_A_full && g_triton_B_full);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_A_full) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_B_full) & 127) == 0);
+    }
+}
+
+static inline void call_triton_matmul_full_packed(
+    float *A_full,     // physical [M_pad x K]
+    float *B_full,     // physical [K x N_pad]
+    float *C_full,     // physical [M_pad x N_pad]
+    int32_t M_pad,
+    int32_t N_pad,
+    int32_t K) {
 
     static MemRefDescriptor<Rank> *A_desc = nullptr;
     static MemRefDescriptor<Rank> *B_desc = nullptr;
@@ -2505,10 +2544,6 @@ static inline void call_triton_matmul_blob_k(
     static bool inited = false;
 
     if (!inited) {
-        A_triton = (float *) tsi_alloc((size_t) TRITON_M_TILE * (size_t) K * sizeof(float));
-        B_triton = (float *) tsi_alloc((size_t) K * (size_t) TRITON_N_TILE * sizeof(float));
-        C_triton = (float *) tsi_alloc((size_t) TRITON_M_TILE * (size_t) TRITON_N_TILE * sizeof(float));
-
         A_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
         B_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
         C_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
@@ -2527,156 +2562,67 @@ static inline void call_triton_matmul_blob_k(
         grid2_payload = (int32_t *) tsi_alloc(128);
         grid3_payload = (int32_t *) tsi_alloc(128);
 
-        TSAVORITE_GGML_ASSERT(A_triton && B_triton && C_triton);
         TSAVORITE_GGML_ASSERT(A_desc && B_desc && C_desc);
         TSAVORITE_GGML_ASSERT(M_desc && N_desc && K_desc);
         TSAVORITE_GGML_ASSERT(grid1_desc && grid2_desc && grid3_desc);
         TSAVORITE_GGML_ASSERT(M_payload && N_payload && K_payload);
         TSAVORITE_GGML_ASSERT(grid1_payload && grid2_payload && grid3_payload);
 
-        TSAVORITE_GGML_ASSERT((((uintptr_t) A_triton) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) B_triton) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) C_triton) & 127) == 0);
-
-        TSAVORITE_GGML_ASSERT((((uintptr_t) A_desc) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) B_desc) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) C_desc) & 127) == 0);
-
-        TSAVORITE_GGML_ASSERT((((uintptr_t) M_desc) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) N_desc) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) K_desc) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) grid1_desc) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) grid2_desc) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) grid3_desc) & 127) == 0);
-
-        TSAVORITE_GGML_ASSERT((((uintptr_t) M_payload) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) N_payload) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) K_payload) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) grid1_payload) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) grid2_payload) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) grid3_payload) & 127) == 0);
-
         inited = true;
     }
 
-    const float *A_blob = (const float *) A_tile;   // [TMU_M_TILE_MAX x K]
-    const float *B_blob = (const float *) B_tile;   // [TMU_N_BLOCK    x K] == [N x K]
-    float       *C_blob = (float       *) C_tile;   // [TMU_M_TILE_MAX x TMU_N_BLOCK]
+    TSAVORITE_GGML_ASSERT((M_pad % 8) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % 64) == 0);
+    TSAVORITE_GGML_ASSERT((K % 32) == 0);
 
-    // -------------------------------------------------------------------------
-    // B adapter:
-    // Blob-style B is [N x K].
-    // Triton expects B as row-major [K x N].
-    // Physical N stride is always TRITON_N_TILE = 64.
-    // -------------------------------------------------------------------------
-    memset(B_triton, 0, (size_t) K * (size_t) TRITON_N_TILE * sizeof(float));
+    init_rank1_memref_flat(
+        A_desc,
+        (void *) A_full,
+        (int64_t) M_pad * (int64_t) K);
 
-    for (int32_t n = 0; n < N_tile; ++n) {
-        const float *src_row = B_blob + (size_t) n * (size_t) K;
+    init_rank1_memref_flat(
+        B_desc,
+        (void *) B_full,
+        (int64_t) K * (int64_t) N_pad);
 
-        for (int32_t kk = 0; kk < K; ++kk) {
-            B_triton[(size_t) kk * (size_t) TRITON_N_TILE + (size_t) n] = src_row[kk];
-        }
-    }
+    init_rank1_memref_flat(
+        C_desc,
+        (void *) C_full,
+        (int64_t) M_pad * (int64_t) N_pad);
 
-    for (int32_t m0 = 0; m0 < M_tile; m0 += TRITON_M_TILE) {
-        const int32_t m_valid =
-            (M_tile - m0 > TRITON_M_TILE) ? TRITON_M_TILE : (M_tile - m0);
+    init_scalar_i32_memref_aligned(M_desc,     M_payload,     M_pad);
+    init_scalar_i32_memref_aligned(N_desc,     N_payload,     N_pad);
+    init_scalar_i32_memref_aligned(K_desc,     K_payload,     K);
+    init_scalar_i32_memref_aligned(grid1_desc, grid1_payload, 1);
+    init_scalar_i32_memref_aligned(grid2_desc, grid2_payload, 1);
+    init_scalar_i32_memref_aligned(grid3_desc, grid3_payload, 1);
 
-        // ---------------------------------------------------------------------
-        // A adapter:
-        // Blob-style A is [M x K].
-        // Triton expects A as [8 x K].
-        // Zero-pad invalid rows.
-        // ---------------------------------------------------------------------
-        memset(A_triton, 0, (size_t) TRITON_M_TILE * (size_t) K * sizeof(float));
-
-        for (int32_t r = 0; r < m_valid; ++r) {
-            const float *src_row = A_blob + (size_t) (m0 + r) * (size_t) K;
-            float       *dst_row = A_triton + (size_t) r * (size_t) K;
-
-            memcpy(dst_row, src_row, (size_t) K * sizeof(float));
-        }
-
-        // ---------------------------------------------------------------------
-        // C carry-in:
-        // Blob-style C is [M x TMU_N_BLOCK].
-        // Triton physical C is [8 x 64].
-        // Copy only valid rows/cols into padded C_triton.
-        // ---------------------------------------------------------------------
-        memset(C_triton, 0, (size_t) TRITON_M_TILE * (size_t) TRITON_N_TILE * sizeof(float));
-
-        for (int32_t r = 0; r < m_valid; ++r) {
-            const float *src_row = C_blob + (size_t) (m0 + r) * (size_t) TMU_N_BLOCK;
-            float       *dst_row = C_triton + (size_t) r * (size_t) TRITON_N_TILE;
-
-            for (int32_t n = 0; n < N_tile; ++n) {
-                dst_row[n] = src_row[n];
-            }
-        }
-
-        // ---------------------------------------------------------------------
-        // IMPORTANT FIX:
-        //
-        // Triton kernel creates block pointers using:
-        //   A strides = (K, 1)
-        //   B strides = (N, 1)
-        //   C strides = (N, 1)
-        //
-        // Since B_triton/C_triton are physically padded with N stride = 64,
-        // we must pass N = 64 to Triton, not logical N_tile.
-        //
-        // Copy-back below still copies only logical N_tile columns.
-        // ---------------------------------------------------------------------
-        init_rank1_memref_flat(
-            A_desc,
-            (void *) A_triton,
-            (int64_t) TRITON_M_TILE * (int64_t) K);
-
-        init_rank1_memref_flat(
-            B_desc,
-            (void *) B_triton,
-            (int64_t) K * (int64_t) TRITON_N_TILE);
-
-        init_rank1_memref_flat(
-            C_desc,
-            (void *) C_triton,
-            (int64_t) TRITON_M_TILE * (int64_t) TRITON_N_TILE);
-
-        init_scalar_i32_memref_aligned(M_desc,     M_payload,     TRITON_M_TILE);
-        init_scalar_i32_memref_aligned(N_desc,     N_payload,     TRITON_N_TILE);
-        init_scalar_i32_memref_aligned(K_desc,     K_payload,     K);
-        init_scalar_i32_memref_aligned(grid1_desc, grid1_payload, 1);
-        init_scalar_i32_memref_aligned(grid2_desc, grid2_payload, 1);
-        init_scalar_i32_memref_aligned(grid3_desc, grid3_payload, 1);
-
-        _mlir_ciface_matmul_kernel_memory_wrapper(
-            A_desc, B_desc, C_desc,
-            M_desc, N_desc, K_desc,
-            grid1_desc, grid2_desc, grid3_desc);
-
-        // ---------------------------------------------------------------------
-        // Copy valid logical result back to blob-style C tile.
-        // Only copy m_valid rows and N_tile valid columns.
-        // ---------------------------------------------------------------------
-        for (int32_t r = 0; r < m_valid; ++r) {
-            float       *dst_row = C_blob + (size_t) (m0 + r) * (size_t) TMU_N_BLOCK;
-            const float *src_row = C_triton + (size_t) r * (size_t) TRITON_N_TILE;
-
-            for (int32_t n = 0; n < N_tile; ++n) {
-                dst_row[n] = src_row[n];
-            }
-        }
-    }
+    _mlir_ciface_matmul_kernel_memory_wrapper(
+        A_desc, B_desc, C_desc,
+        M_desc, N_desc, K_desc,
+        grid1_desc, grid2_desc, grid3_desc);
 }
 
 
+#if 0
 // Replace ONLY k32 first
 extern "C" void tmu_mul_mat_k32(const void *A, const void *B, void *C) {
     call_triton_matmul_blob_k<32>(
         A, B, C,
         g_triton_cur_M_tile,
         g_triton_cur_N_tile);
+}
+#endif /* 0 */
+
+extern "C" void tmu_mul_mat_k32(const void *A, const void *B, void *C) {
+    (void) A;
+    (void) B;
+    (void) C;
+
+    fprintf(stderr,
+            "ERROR: legacy tmu_mul_mat_k32 path should not be called "
+            "after enabling full dynamic Triton MAT_MUL path\n");
+    abort();
 }
 
 
@@ -2849,47 +2795,34 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     struct ggml_tensor * node,
     enum ggml_tsavorite_kernel_type kernel_type,
     int /*kernel_sub_type*/) {
+
     if (!node || !node->src[0] || !node->src[1] || !node->data) {
         return GGML_STATUS_FAILED;
     }
 
-    const struct ggml_tensor * src0 = node->src[0];
-    const struct ggml_tensor * src1 = node->src[1];
+    const struct ggml_tensor *src0 = node->src[0];
+    const struct ggml_tensor *src1 = node->src[1];
 
-    if (src0->type != GGML_TYPE_F32 || src1->type != GGML_TYPE_F32 || node->type != GGML_TYPE_F32) {
+    if (src0->type != GGML_TYPE_F32 ||
+        src1->type != GGML_TYPE_F32 ||
+        node->type != GGML_TYPE_F32) {
         return GGML_STATUS_FAILED;
     }
 
-    ensure_tmu_pack_buffers();
-
-#ifdef TMU_DEBUG_VALIDATE
-    // CPU reference buffers: accumulate chunk-by-chunk in packed space
-    static float C_ref_chunk[TMU_M_TILE_MAX * TMU_N_BLOCK];
-    static float C_ref_accum[TMU_M_TILE_MAX * TMU_N_BLOCK];
-#endif
-
-    // -------------------------------------------------------------------------
-    // GGML MUL_MAT convention used here:
-    //   src0: [K, M]
-    //   src1: [K, N]
-    //   dst : [M, N]
-    //
-    // Example:
-    //   src0 = [576, 576]
-    //   src1 = [576, 5]
-    //   dst  = [576, 5]
-    // so:
-    //   K = 576
-    //   M = 576
-    //   N = 5
-    // -------------------------------------------------------------------------
     const int64_t K = src0->ne[0];
     const int64_t M = src0->ne[1];
     const int64_t N = src1->ne[1];
 
+    if (K <= 0 || M <= 0 || N <= 0) return GGML_STATUS_FAILED;
     if (src1->ne[0] != K) return GGML_STATUS_FAILED;
-    if ((K % TMU_K_MULTIPLE) != 0) return GGML_STATUS_FAILED;
-    if (src1->ne[1] == 1) return GGML_STATUS_FAILED; // avoid GEMV
+    if ((K % 32) != 0) return GGML_STATUS_FAILED;
+    if (src1->ne[1] == 1) return GGML_STATUS_FAILED;
+
+    ensure_triton_full_buffers(K);
+
+#ifdef TMU_DEBUG_VALIDATE
+    static float C_ref_tile[TRITON_FULL_M_TILE * TRITON_FULL_N_TILE];
+#endif
 
     const int64_t a_nb0 = nb_or_default(src0, 0);
     const int64_t a_nb1 = nb_or_default(src0, 1);
@@ -2906,7 +2839,6 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     const int64_t c_nb2 = nb_or_default(node, 2);
     const int64_t c_nb3 = nb_or_default(node, 3);
 
-    // broadcast dims from inputs
     const int64_t A2 = src0->ne[2] ? src0->ne[2] : 1;
     const int64_t A3 = src0->ne[3] ? src0->ne[3] : 1;
     const int64_t B2 = src1->ne[2] ? src1->ne[2] : 1;
@@ -2923,187 +2855,155 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
             const int64_t a_d2 = map_repeat_i64(od2, A2);
             const int64_t b_d2 = map_repeat_i64(od2, B2);
 
-            const char *A_base_d23 = (const char *) src0->data + a_d2 * a_nb2 + a_d3 * a_nb3;
-            const char *B_base_d23 = (const char *) src1->data + b_d2 * b_nb2 + b_d3 * b_nb3;
+            const char *A_base_d23 =
+                (const char *) src0->data + a_d2 * a_nb2 + a_d3 * a_nb3;
 
-            for (int64_t m0 = 0; m0 < M; m0 += TMU_M_TILE_MAX) {
-                const int64_t m_tile =
-                    (M - m0 > TMU_M_TILE_MAX) ? TMU_M_TILE_MAX : (M - m0);
+            const char *B_base_d23 =
+                (const char *) src1->data + b_d2 * b_nb2 + b_d3 * b_nb3;
 
-                for (int64_t n0 = 0; n0 < N; n0 += TMU_N_BLOCK) {
+            for (int64_t m0 = 0; m0 < M; m0 += TRITON_FULL_M_TILE) {
+                const int64_t m_valid =
+                    (M - m0 > TRITON_FULL_M_TILE) ? TRITON_FULL_M_TILE : (M - m0);
+
+                const int64_t M_pad = tsi_round_up_i64(m_valid, 8);
+
+                for (int64_t n0 = 0; n0 < N; n0 += TRITON_FULL_N_TILE) {
                     const int64_t n_valid =
-                        (N - n0 >= TMU_N_BLOCK) ? TMU_N_BLOCK : (N - n0);
+                        (N - n0 > TRITON_FULL_N_TILE) ? TRITON_FULL_N_TILE : (N - n0);
 
-                    // -----------------------------------------------------------------
-                    // Zero C once per output tile.
-                    // Triton wrapper preloads current g_C_tile into C_triton and
-                    // accumulates each K chunk.
-                    // -----------------------------------------------------------------
-                    memset(g_C_tile, 0,
-                           (size_t) TMU_M_TILE_MAX *
-                           (size_t) TMU_N_BLOCK *
-                           sizeof(float));
+                    const int64_t N_pad = TRITON_FULL_N_TILE;
 
-#ifdef TMU_DEBUG_VALIDATE
-                    memset(C_ref_accum, 0, sizeof(C_ref_accum));
-#endif
+                    // ---------------------------------------------------------
+                    // Pack A as Triton-native row-major:
+                    //   A_full = [M_pad x K]
+                    // ---------------------------------------------------------
+                    memset(g_triton_A_full, 0,
+                           (size_t) M_pad * (size_t) K * sizeof(float));
 
-                    int parts[128];
-                    const int np = tmu_decompose_k(K, parts, (int)(sizeof(parts) / sizeof(parts[0])));
-                    if (np < 0) return GGML_STATUS_FAILED;
+                    for (int64_t r = 0; r < m_valid; ++r) {
+                        const int64_t m_idx = m0 + r;
+                        float *dst_row = g_triton_A_full + r * K;
 
-                    int64_t k0 = 0;
+                        const char *src_row =
+                            A_base_d23 + m_idx * a_nb1;
 
-                    for (int pi = 0; pi < np; ++pi) {
-                        const int K_chunk = parts[pi];
-
-                        const tmu_bucket_dispatch * bucket = tmu_find_bucket(K_chunk);
-                        if (!bucket || !bucket->fn) return GGML_STATUS_FAILED;
-
-                        // -------------------------------------------------------------
-                        // Pack A -> blob-style row-major [TMU_M_TILE_MAX x K_chunk]
-                        // -------------------------------------------------------------
-                        pack_A_tile_f32(
-                            g_A_pack,
-                            A_base_d23,
-                            m0,
-                            m_tile,
-                            k0,
-                            K_chunk,
-                            a_nb0,
-                            a_nb1);
-
-                        // -------------------------------------------------------------
-                        // Pack B -> blob-style row-major [TMU_N_BLOCK x K_chunk]
-                        // dst row = output column n
-                        // dst[kk] = B(k0 + kk, n0 + n)
-                        // -------------------------------------------------------------
-                        pack_B_tile_f32(
-                            g_B_pack,
-                            B_base_d23,
-                            n0,
-                            n_valid,
-                            k0,
-                            K_chunk,
-                            b_nb0,
-                            b_nb1);
-
-                        g_triton_cur_M_tile = (int32_t) m_tile;
-                        g_triton_cur_N_tile = (int32_t) n_valid;
-
-                        // -------------------------------------------------------------
-                        // Triton MAT_MUL call through selected K bucket.
-                        // Current working path:
-                        //   bucket->fn -> tmu_mul_mat_k32 -> call_triton_matmul_blob_k<32>
-                        // -------------------------------------------------------------
-                        bucket->fn(g_A_pack, g_B_pack, g_C_tile);
-
-                        // Stats per kernel call
-                        if (device) {
-                            ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
+                        for (int64_t kk = 0; kk < K; ++kk) {
+                            dst_row[kk] =
+                                *(const float *)(src_row + kk * a_nb0);
                         }
-                        ++node->tsi_kernel_runs;
-
-#ifdef TMU_DEBUG_VALIDATE
-                        // -------------------------------------------------------------
-                        // CPU reference for THIS K_chunk on packed tiles.
-                        // Accumulate chunk-by-chunk and compare against g_C_tile.
-                        //
-                        // IMPORTANT:
-                        // Use abs + relative tolerance. FP32 dot accumulation can differ
-                        // slightly due to accumulation order. Example:
-                        //   TMU=325.606201 REF=325.606079
-                        // is acceptable and should not abort.
-                        // -------------------------------------------------------------
-                        memset(C_ref_chunk, 0, sizeof(C_ref_chunk));
-
-                        MemRefDescriptor<4> Aref, Bref, Cref;
-
-                        init_memref_4d(
-                            Aref,
-                            (void *) g_A_pack,
-                            1,
-                            1,
-                            TMU_M_TILE_MAX,
-                            (int64_t) K_chunk);
-
-                        init_memref_4d(
-                            Bref,
-                            (void *) g_B_pack,
-                            1,
-                            1,
-                            TMU_N_BLOCK,
-                            (int64_t) K_chunk);
-
-                        init_memref_4d(
-                            Cref,
-                            (void *) C_ref_chunk,
-                            1,
-                            1,
-                            TMU_M_TILE_MAX,
-                            TMU_N_BLOCK);
-
-                        cpu_ref_mul_mat_f32(&Aref, &Bref, &Cref);
-
-                        for (int64_t rr = 0; rr < m_tile; ++rr) {
-                            for (int64_t cc = 0; cc < n_valid; ++cc) {
-                                C_ref_accum[rr * TMU_N_BLOCK + cc] +=
-                                    C_ref_chunk[rr * TMU_N_BLOCK + cc];
-                            }
-                        }
-
-                        for (int64_t rr = 0; rr < m_tile; ++rr) {
-                            for (int64_t cc = 0; cc < n_valid; ++cc) {
-                                const float tmu_v = g_C_tile[rr * TMU_N_BLOCK + cc];
-                                const float ref_v = C_ref_accum[rr * TMU_N_BLOCK + cc];
-
-                                const float abs_err = fabsf(tmu_v - ref_v);
-                                const float rel_err = abs_err / fmaxf(1.0f, fabsf(ref_v));
-
-                                if (abs_err > 1e-3f && rel_err > 1e-5f) {
-                                    fprintf(stderr,
-                                            "\nTMU/TRITON MISMATCH (packed-ref)\n"
-                                            "m0=%ld n0=%ld k0=%ld K_chunk=%d pi=%d\n"
-                                            "r=%ld c=%ld TMU=%f REF=%f ABS=%e REL=%e\n",
-                                            (long)m0,
-                                            (long)n0,
-                                            (long)k0,
-                                            K_chunk,
-                                            pi,
-                                            (long)rr,
-                                            (long)cc,
-                                            tmu_v,
-                                            ref_v,
-                                            abs_err,
-                                            rel_err);
-
-                                    tsi_cleanup();
-                                    abort();
-                                }
-                            }
-                        }
-#endif
-
-                        k0 += K_chunk;
                     }
 
-                    // exact K coverage required
-                    if (k0 != K) {
-                        return GGML_STATUS_FAILED;
+                    // ---------------------------------------------------------
+                    // Pack B as Triton-native row-major:
+                    //   B_full = [K x N_pad]
+                    // GGML/src1 is logically [K, N].
+                    // ---------------------------------------------------------
+                    memset(g_triton_B_full, 0,
+                           (size_t) K * (size_t) N_pad * sizeof(float));
+
+                    for (int64_t c = 0; c < n_valid; ++c) {
+                        const int64_t n_idx = n0 + c;
+
+                        const char *src_col =
+                            B_base_d23 + n_idx * b_nb1;
+
+                        for (int64_t kk = 0; kk < K; ++kk) {
+                            g_triton_B_full[kk * N_pad + c] =
+                                *(const float *)(src_col + kk * b_nb0);
+                        }
                     }
 
-                    // -------------------------------------------------------------
-                    // Copy valid tile back to GGML output.
-                    // g_C_tile is packed row-major [TMU_M_TILE_MAX x TMU_N_BLOCK].
-                    // GGML output uses byte strides.
-                    // -------------------------------------------------------------
+                    // ---------------------------------------------------------
+                    // C starts from zero for the full K matmul.
+                    // Triton kernel does:
+                    //   acc = load(C)
+                    //   acc += dot(A, B)
+                    //   store(C)
+                    // ---------------------------------------------------------
+                    memset(g_triton_C_full, 0,
+                           (size_t) M_pad * (size_t) N_pad * sizeof(float));
+
+                    call_triton_matmul_full_packed(
+                        g_triton_A_full,
+                        g_triton_B_full,
+                        g_triton_C_full,
+                        (int32_t) M_pad,
+                        (int32_t) N_pad,
+                        (int32_t) K);
+
+                    if (device) {
+                        ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
+                    }
+                    ++node->tsi_kernel_runs;
+
+#ifdef TMU_DEBUG_VALIDATE
+                    memset(C_ref_tile, 0, sizeof(C_ref_tile));
+
+                    for (int64_t rr = 0; rr < m_valid; ++rr) {
+                        const int64_t m_idx = m0 + rr;
+                        const char *a_row =
+                            A_base_d23 + m_idx * a_nb1;
+
+                        for (int64_t cc = 0; cc < n_valid; ++cc) {
+                            const int64_t n_idx = n0 + cc;
+                            const char *b_col =
+                                B_base_d23 + n_idx * b_nb1;
+
+                            float acc = 0.0f;
+                            for (int64_t kk = 0; kk < K; ++kk) {
+                                const float av =
+                                    *(const float *)(a_row + kk * a_nb0);
+                                const float bv =
+                                    *(const float *)(b_col + kk * b_nb0);
+                                acc += av * bv;
+                            }
+
+                            C_ref_tile[rr * N_pad + cc] = acc;
+                        }
+                    }
+
+                    for (int64_t rr = 0; rr < m_valid; ++rr) {
+                        for (int64_t cc = 0; cc < n_valid; ++cc) {
+                            const float tmu_v =
+                                g_triton_C_full[rr * N_pad + cc];
+                            const float ref_v =
+                                C_ref_tile[rr * N_pad + cc];
+
+                            const float abs_err = fabsf(tmu_v - ref_v);
+                            const float rel_err =
+                                abs_err / fmaxf(1.0f, fabsf(ref_v));
+
+                            if (abs_err > 1e-3f && rel_err > 1e-5f) {
+                                fprintf(stderr,
+                                        "\nTRITON FULL MATMUL MISMATCH\n"
+                                        "m0=%ld n0=%ld K=%ld\n"
+                                        "r=%ld c=%ld TRITON=%f REF=%f ABS=%e REL=%e\n",
+                                        (long)m0,
+                                        (long)n0,
+                                        (long)K,
+                                        (long)rr,
+                                        (long)cc,
+                                        tmu_v,
+                                        ref_v,
+                                        abs_err,
+                                        rel_err);
+
+                                tsi_cleanup();
+                                abort();
+                            }
+                        }
+                    }
+#endif
+
+                    // ---------------------------------------------------------
+                    // Copy valid result back to GGML output.
+                    // ---------------------------------------------------------
                     {
                         char *dst_base = (char *) node->data;
                         const size_t bytes_total = (size_t) ggml_nbytes(node);
 
-                        for (int64_t rr = 0; rr < m_tile; ++rr) {
+                        for (int64_t rr = 0; rr < m_valid; ++rr) {
                             const int64_t m_idx = m0 + rr;
-                            const float *src_row = g_C_tile + rr * TMU_N_BLOCK;
 
                             for (int64_t cc = 0; cc < n_valid; ++cc) {
                                 const int64_t n_idx = n0 + cc;
@@ -3119,7 +3019,8 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                                     continue;
                                 }
 
-                                *(float *)(dst_base + byte_off) = src_row[cc];
+                                *(float *)(dst_base + byte_off) =
+                                    g_triton_C_full[rr * N_pad + cc];
                             }
                         }
                     }

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2486,6 +2486,9 @@ static inline void ensure_triton_full_buffers(int64_t K) {
 
     const int64_t need_K = tsi_round_up_i64(K, 32);
 
+    // Allocate at least 2048 once so we do not grow/re-allocate for common model K values.
+    const int64_t alloc_K = (need_K > 2048) ? need_K : 2048;
+
     if (!g_triton_C_full) {
         g_triton_C_full = (float *) tsi_alloc(
             (size_t) TRITON_FULL_M_TILE *
@@ -2496,8 +2499,8 @@ static inline void ensure_triton_full_buffers(int64_t K) {
         TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_C_full) & 127) == 0);
     }
 
-    if (need_K > g_triton_K_cap) {
-        g_triton_K_cap = need_K;
+    if (!g_triton_A_full || !g_triton_B_full || alloc_K > g_triton_K_cap) {
+        g_triton_K_cap = alloc_K;
 
         g_triton_A_full = (float *) tsi_alloc(
             (size_t) TRITON_FULL_M_TILE *
@@ -2874,32 +2877,60 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                     const int64_t N_pad = TRITON_FULL_N_TILE;
 
                     // ---------------------------------------------------------
-                    // Pack A as Triton-native row-major:
-                    //   A_full = [M_pad x K]
+                    // Pack A as Triton-native row-major [M_pad x K].
+                    // Optimization:
+                    // - If rows are contiguous, use memcpy per row.
+                    // - Only memset A when padding rows are needed.
                     // ---------------------------------------------------------
-                    memset(g_triton_A_full, 0,
-                           (size_t) M_pad * (size_t) K * sizeof(float));
+                    if (m_valid < M_pad) {
+                        memset(g_triton_A_full, 0,
+                               (size_t) M_pad * (size_t) K * sizeof(float));
+                    }
 
-                    for (int64_t r = 0; r < m_valid; ++r) {
-                        const int64_t m_idx = m0 + r;
-                        float *dst_row = g_triton_A_full + r * K;
+                    if (a_nb0 == (int64_t) sizeof(float)) {
+                        for (int64_t r = 0; r < m_valid; ++r) {
+                            const int64_t m_idx = m0 + r;
 
-                        const char *src_row =
-                            A_base_d23 + m_idx * a_nb1;
+                            const char *src_row =
+                                A_base_d23 + m_idx * a_nb1;
 
-                        for (int64_t kk = 0; kk < K; ++kk) {
-                            dst_row[kk] =
-                                *(const float *)(src_row + kk * a_nb0);
+                            float *dst_row =
+                                g_triton_A_full + r * K;
+
+                            memcpy(dst_row, src_row, (size_t) K * sizeof(float));
+                        }
+                    } else {
+                        if (m_valid == M_pad) {
+                            // No padding rows, but non-contiguous K stride.
+                            // Every valid element is written below, so no memset required.
+                        }
+
+                        for (int64_t r = 0; r < m_valid; ++r) {
+                            const int64_t m_idx = m0 + r;
+
+                            const char *src_row =
+                                A_base_d23 + m_idx * a_nb1;
+
+                            float *dst_row =
+                                g_triton_A_full + r * K;
+
+                            for (int64_t kk = 0; kk < K; ++kk) {
+                                dst_row[kk] =
+                                    *(const float *)(src_row + kk * a_nb0);
+                            }
                         }
                     }
 
                     // ---------------------------------------------------------
-                    // Pack B as Triton-native row-major:
-                    //   B_full = [K x N_pad]
-                    // GGML/src1 is logically [K, N].
+                    // Pack B as Triton-native row-major [K x N_pad].
+                    // Optimization:
+                    // - If full N tile, every B element is written, so skip memset.
+                    // - If tail N tile, memset is required to zero padded columns.
                     // ---------------------------------------------------------
-                    memset(g_triton_B_full, 0,
-                           (size_t) K * (size_t) N_pad * sizeof(float));
+                    if (n_valid < N_pad) {
+                        memset(g_triton_B_full, 0,
+                               (size_t) K * (size_t) N_pad * sizeof(float));
+                    }
 
                     for (int64_t c = 0; c < n_valid; ++c) {
                         const int64_t n_idx = n0 + c;
@@ -2914,11 +2945,9 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                     }
 
                     // ---------------------------------------------------------
-                    // C starts from zero for the full K matmul.
-                    // Triton kernel does:
+                    // C must be zero because Triton does:
                     //   acc = load(C)
-                    //   acc += dot(A, B)
-                    //   store(C)
+                    //   acc += dot(A,B)
                     // ---------------------------------------------------------
                     memset(g_triton_C_full, 0,
                            (size_t) M_pad * (size_t) N_pad * sizeof(float));
@@ -2950,6 +2979,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                                 B_base_d23 + n_idx * b_nb1;
 
                             float acc = 0.0f;
+
                             for (int64_t kk = 0; kk < K; ++kk) {
                                 const float av =
                                     *(const float *)(a_row + kk * a_nb0);
@@ -2966,6 +2996,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                         for (int64_t cc = 0; cc < n_valid; ++cc) {
                             const float tmu_v =
                                 g_triton_C_full[rr * N_pad + cc];
+
                             const float ref_v =
                                 C_ref_tile[rr * N_pad + cc];
 
@@ -2997,6 +3028,8 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
                     // ---------------------------------------------------------
                     // Copy valid result back to GGML output.
+                    // Keep element-wise copy because GGML output layout/stride
+                    // is not row-major [M x N] in the same physical order.
                     // ---------------------------------------------------------
                     {
                         char *dst_base = (char *) node->data;

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -921,9 +921,16 @@ cat > "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh" <<'EOL'
 #!/bin/bash
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)
 
-tsi_kernels=("add" "sub" "mult" "div" "abs" "inv" "neg" "sin" "sqrt" "sqr" "sigmoid" "silu" "rms_norm" "swiglu" \
-"add_16" "sub_16" "mult_16" "div_16" "abs_16" "inv_16" "neg_16" "sin_16" "sqrt_16" "sqr_16" "sigmoid_16" "silu_16" "rms_norm_16" "swiglu_16" \
-"mul_mat_tile_f32_k32" "mul_mat_tile_f32_k64" "mul_mat_tile_f32_k128")
+tsi_kernels=(
+  "add" "sub" "mult" "div" "abs" "inv" "neg" "sin" "sqrt" "sqr" "sigmoid" "silu" "rms_norm" "swiglu"
+  "add_16" "sub_16" "mult_16" "div_16" "abs_16" "inv_16" "neg_16" "sin_16" "sqrt" "sqr" "sigmoid_16" "silu_16" "rms_norm_16" "swiglu_16"
+  "mul_mat_tile_f32_k32" "mul_mat_tile_f32_k64" "mul_mat_tile_f32_k128"
+)
+
+triton_kernels=(
+  "triton_add"
+  "triton_mat_mul"
+)
 
 for kernel in "${tsi_kernels[@]}"; do
   dst="__TSI_BLOB_INSTALL_DIR__/txe_${kernel}/blobs"
@@ -935,14 +942,15 @@ for kernel in "${tsi_kernels[@]}"; do
   fi
 done
 
-# Triton ADD
-dst="__TSI_BLOB_INSTALL_DIR__/txe_triton_add/blobs"
-rm -rf "${dst}"
-mkdir -p "${dst}"
+for kernel in "${triton_kernels[@]}"; do
+  dst="__TSI_BLOB_INSTALL_DIR__/txe_${kernel}/blobs"
+  rm -rf "${dst}"
+  mkdir -p "${dst}"
 
-if [ -f "blobs/txe_triton_add/txe_blob_0.blob" ]; then
-  cp "blobs/txe_triton_add/txe_blob_0.blob" "${dst}/txe_blob_0.blob"
-fi
+  if [ -f "blobs/txe_${kernel}/txe_blob_0.blob" ]; then
+    cp "blobs/txe_${kernel}/txe_blob_0.blob" "${dst}/txe_blob_0.blob"
+  fi
+done
 EOL
 
   sed -i "s|__TSI_BLOB_INSTALL_DIR__|${TSI_BLOB_INSTALL_DIR}|g" "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh"

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -210,6 +210,23 @@
 #     SDK_VERSION=0.4.1 source tsi-pkg-build.sh build-all-blobs
 #     SDK_VERSION=0.4.1 source tsi-pkg-build.sh build-fpga-blobs
 #     SDK_VERSION=0.4.1 source tsi-pkg-build.sh build-posix-blobs
+# 10a) Triton MAT_MUL default build:
+#     If no triton option is provided, TRITON_MAT_MUL is enabled by default.
+#     This builds only the Triton MAT_MUL kernel and passes -DTRITON_MAT_MUL=1
+#     to ggml-tsavorite.cpp.
+#     SDK_VERSION=0.4.9 source tsi-pkg-build.sh build-posix
+#
+# 10b) Triton MAT_MUL explicit build:
+#     Same as default, but explicitly selects Triton MAT_MUL.
+#     SDK_VERSION=0.4.9 source tsi-pkg-build.sh triton mat_mul build-posix
+#
+# 10c) Triton ADD explicit build:
+#     Selects Triton ADD and disables Triton MAT_MUL for this build.
+#     SDK_VERSION=0.4.9 source tsi-pkg-build.sh triton add build-posix
+#
+# 10d) Triton ADD + MAT_MUL explicit build:
+#     Selects both Triton ADD and Triton MAT_MUL when compiler support is available.
+#     SDK_VERSION=0.4.9 source tsi-pkg-build.sh triton all build-posix
 #
 # 11) Incremental builds (do not delete build dirs):
 #     SDK_VERSION=0.4.1 source tsi-pkg-build.sh incremental build-posix build-fpga
@@ -402,6 +419,15 @@ parse_args() {
 
   # packaging selection
   PACKAGE_FPGA_BUILD_DIR=""
+  # Triton kernel selection
+  # Default: MAT_MUL enabled if user does not pass any triton option.
+  # User can override with:
+  #   triton add
+  #   triton mat_mul
+  #   triton all
+  ENABLE_TRITON_ADD=0
+  ENABLE_TRITON_MAT_MUL=1
+  __EXPECT_TRITON_ARG=0
 
   local a
   for a in "$@"; do
@@ -421,6 +447,49 @@ parse_args() {
       git-submodule-pull)
         GIT_SUBMODULE_PULL=1
         log_info "git-submodule-pull detected"
+        ;;
+      triton)
+        __EXPECT_TRITON_ARG=1
+        log_info "triton option detected; expecting one of: add | mat_mul | all"
+        ;;
+
+      add)
+        if [ "${__EXPECT_TRITON_ARG}" -eq 1 ]; then
+          ENABLE_TRITON_ADD=1
+          ENABLE_TRITON_MAT_MUL=0
+          __EXPECT_TRITON_ARG=0
+          log_info "TRITON_ADD selected"
+        elif [ -z "${MLIR_COMPILER_DIR_IN}" ]; then
+          MLIR_COMPILER_DIR_IN="$a"
+        elif [ -z "${TOOLBOX_DIR_IN}" ]; then
+          TOOLBOX_DIR_IN="$a"
+        fi
+        ;;
+
+      mat_mul|mat-mul|matmul)
+        if [ "${__EXPECT_TRITON_ARG}" -eq 1 ]; then
+          ENABLE_TRITON_ADD=0
+          ENABLE_TRITON_MAT_MUL=1
+          __EXPECT_TRITON_ARG=0
+          log_info "TRITON_MAT_MUL selected"
+        elif [ -z "${MLIR_COMPILER_DIR_IN}" ]; then
+          MLIR_COMPILER_DIR_IN="$a"
+        elif [ -z "${TOOLBOX_DIR_IN}" ]; then
+          TOOLBOX_DIR_IN="$a"
+        fi
+        ;;
+
+      all)
+        if [ "${__EXPECT_TRITON_ARG}" -eq 1 ]; then
+          ENABLE_TRITON_ADD=1
+          ENABLE_TRITON_MAT_MUL=1
+          __EXPECT_TRITON_ARG=0
+          log_info "TRITON_ADD + TRITON_MAT_MUL selected"
+        elif [ -z "${MLIR_COMPILER_DIR_IN}" ]; then
+          MLIR_COMPILER_DIR_IN="$a"
+        elif [ -z "${TOOLBOX_DIR_IN}" ]; then
+          TOOLBOX_DIR_IN="$a"
+        fi
         ;;
       build-fpga-blobs)
         DO_BLOB_FPGA=1
@@ -553,7 +622,14 @@ parse_args() {
     BUILD_TYPE="debug"
   fi
 
+  # If user wrote only "triton" without argument → error
+  if [ "${__EXPECT_TRITON_ARG}" -eq 1 ]; then
+    die "Missing Triton kernel argument. Use: triton add OR triton mat_mul OR triton all"
+  fi
 
+  # Export so other functions/scripts can use it
+  export ENABLE_TRITON_ADD
+  export ENABLE_TRITON_MAT_MUL
   return 0
 }
 
@@ -796,11 +872,14 @@ build_posix_impl() {
   compute_perf_and_debug_defs "posix"
 
   local common="-DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=posix -DGGML_NATIVE=ON -DGGML_AMX_TILE=OFF -DGGML_AMX_INT8=OFF -DGGML_AMX_BF16=OFF -DGGML_AVX512_BF16=OFF -DGGML_AVX_VNNI=OFF"
+
   local supported=""
   [ "${want_tmu}" -eq 1 ] && supported="${supported} -DTMU_SUPPORTED"
   [ "${want_tvu}" -eq 1 ] && supported="${supported} -DTVU_SUPPORTED"
 
-  local cflags_base="-DGGML_TARGET_POSIX -DGGML_TSAVORITE ${supported} -mno-amx-tile -mno-amx-int8 -mno-amx-bf16 -mno-avx512bf16 -mno-avxvnni"
+  local triton_defs="-DTRITON_ADD=${ENABLE_TRITON_ADD} -DTRITON_MAT_MUL=${ENABLE_TRITON_MAT_MUL}"
+
+  local cflags_base="-DGGML_TARGET_POSIX -DGGML_TSAVORITE ${supported} ${triton_defs} -mno-amx-tile -mno-amx-int8 -mno-amx-bf16 -mno-avx512bf16 -mno-avxvnni"
 
   run cmake -B "${build_dir}" ${common} \
     -DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}" \
@@ -861,15 +940,18 @@ build_fpga_impl() {
   compute_perf_and_debug_defs "fpga"
 
   local ARM_TOOLCHAIN_FILE="${TOOLBOX_DIR}/lib/cmake/toolchains/arm.cmake"
+
   local supported=""
   [ "${want_tmu}" -eq 1 ] && supported="${supported} -DTMU_SUPPORTED"
   [ "${want_tvu}" -eq 1 ] && supported="${supported} -DTVU_SUPPORTED"
 
+  local triton_defs="-DTRITON_ADD=${ENABLE_TRITON_ADD} -DTRITON_MAT_MUL=${ENABLE_TRITON_MAT_MUL}"
+
   run cmake -B "${build_dir}" \
     -DCMAKE_TOOLCHAIN_FILE="${ARM_TOOLCHAIN_FILE}" \
     -DGGML_TSAVORITE=ON -DGGML_TSAVORITE_TARGET=fpga -DLLAMA_CURL=OFF \
-    -DCMAKE_C_FLAGS="${PERF_DEF} ${DBG_DEFS} -DGGML_TSAVORITE ${supported}" \
-    -DCMAKE_CXX_FLAGS="${PERF_DEF} ${DBG_DEFS} -DGGML_TSAVORITE ${supported}" \
+    -DCMAKE_C_FLAGS="${PERF_DEF} ${DBG_DEFS} -DGGML_TSAVORITE ${supported} ${triton_defs}" \
+    -DCMAKE_CXX_FLAGS="${PERF_DEF} ${DBG_DEFS} -DGGML_TSAVORITE ${supported} ${triton_defs}" \
     ${ENABLE_COVERAGE_FLAG} || return 1
 
   run cmake --build "${build_dir}" --config Release || return 1
@@ -1099,8 +1181,14 @@ main() {
     (
       cd "${SUBMODULE_DIR}" || exit 1
       setup_python || exit 1
-      [ "${DO_BLOB_FPGA}" -eq 1 ] && build_fpga_blobs || exit 1
-      [ "${DO_BLOB_POSIX}" -eq 1 ] && build_posix_blobs || exit 1
+
+      if [ "${DO_BLOB_FPGA}" -eq 1 ]; then
+        build_fpga_blobs || exit 1
+      fi
+
+      if [ "${DO_BLOB_POSIX}" -eq 1 ]; then
+        build_posix_blobs || exit 1
+      fi
     )
     local rc=$?
     cd "${ORIG_PWD}" >/dev/null 2>&1 || true


### PR DESCRIPTION
#######
POSIX Validation
[akapoor@wspd0 llama.cpp]$ export USER_DRAM_SIZE=8192
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli-original   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/smolVLM-256M.gguf   --device tsavorite   -c 12288   --temp 0.0   --n-predict 10   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
Failed to generate tool call example: Value is not callable: null at row 1, column 72:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                                                       ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 13:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
            ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 1:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

My cat's name is not mentioned in the text. The cat is

llama_perf_sampler_print:    sampling time =      92.97 ms /    15 runs   (    6.20 ms per token,   161.35 tokens per second)
llama_perf_context_print:        load time =   81250.43 ms
llama_perf_context_print: prompt eval time =   79928.41 ms /     5 tokens (15985.68 ms per token,     0.06 tokens per second)
llama_perf_context_print:        eval time =    3941.16 ms /     9 runs   (  437.91 ms per token,     2.28 tokens per second)
llama_perf_context_print:       total time =   85287.93 ms /    14 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU         2760            2992           4918466           1782.05
  MUL              OPU         2806            3042           2401021            855.67
  RMS_NORM         OPU         2806            2806           2516400            896.79
  MUL_MAT          CPU        48933               0          10033391            205.04
  MUL_MAT          OPU          117             117          79104333         676105.41
  CONT             OPU         2760               0            585080            211.99
  RESHAPE          CPU        14662               0              3569              0.24
  VIEW             CPU        13748               0              1676              0.12
  VIEW             OPU         2760               0               797              0.29
  PERMUTE          CPU         9566               0              1643              0.17
  PERMUTE          OPU         2760               0               343              0.12
  TRANSPOSE        CPU         4286               0               609              0.14
  GET_ROWS         OPU          138               0              4926             35.70
  SET_ROWS         CPU         9611               0              7275              0.76
  SOFT_MAX         OPU         1380               0            250481            181.51
  ROPE             CPU        10849               0             35465              3.27
  GLU              OPU         1380            1496           3176479           2301.80
 not


OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli-original   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf   --device tsavorite   -c 12288   --temp 0.0   --n-predict 10   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
 My cat's name is Luna. She's a black and white



llama_perf_sampler_print:    sampling time =      25.46 ms /    17 runs   (    1.50 ms per token,   667.85 tokens per second)
llama_perf_context_print:        load time =   99915.48 ms
llama_perf_context_print: prompt eval time =   83021.52 ms /     7 tokens (11860.22 ms per token,     0.08 tokens per second)
llama_perf_context_print:        eval time =    7099.78 ms /     9 runs   (  788.86 ms per token,     1.27 tokens per second)
llama_perf_context_print:       total time =  107042.97 ms /    16 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU         2024            2276           3154377           1558.49
  MUL              OPU         2070            2328           2804176           1354.67
  RMS_NORM         OPU         2070            2070           2729705           1318.70
  MUL_MAT          CPU        36325               0          58341509           1606.10
  MUL_MAT          OPU           22              22          79602177        3618280.77
  CONT             OPU         2024               0            371854            183.72
  RESHAPE          CPU        11279               0              4634              0.41
  VIEW             CPU        10539               0              1360              0.13
  VIEW             OPU         2024               0               518              0.26
  PERMUTE          CPU         6846               0              1645              0.24
  PERMUTE          OPU         2024               0               213              0.11
  TRANSPOSE        CPU         3334               0               638              0.19
  GET_ROWS         OPU          138               0              4664             33.80
  SET_ROWS         CPU         7267               0              6624              0.91
  SOFT_MAX         OPU         1012               0            314117            310.39
  ROPE             CPU         7742               0             39198              5.06
  GLU              OPU         1012            1138           4795908           4739.04

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 




#########
TSISIM Validation
#######Model= tinyllama-vo-5m-para.gguf
root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
 was Tim. He loved



llama_perf_sampler_print:    sampling time =      99.88 ms /    11 runs   (    9.08 ms per token,   110.13 tokens per second)
llama_perf_context_print:        load time =    9499.92 ms
llama_perf_context_print: prompt eval time =    2860.41 ms /     6 tokens (  476.74 ms per token,     2.10 tokens per second)
llama_perf_context_print:        eval time =    2188.85 ms /     4 runs   (  547.21 ms per token,     1.83 tokens per second)
llama_perf_context_print:       total time =   11814.97 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          176             246           1572959           8937.27
  MUL              OPU          187             262           2047108          10947.10
  RMS_NORM         OPU          187             187           2302713          12313.97
  MUL_MAT          CPU         3201               0           1327899            414.84
  CONT             OPU          176               0            113111            642.68
  RESHAPE          CPU         1047               0              1950              1.86
  VIEW             CPU         1049               0              1647              1.57
  VIEW             OPU          176               0               259              1.47
  PERMUTE          CPU          697               0              1390              1.99
  PERMUTE          OPU          176               0               196              1.11
  TRANSPOSE        CPU          352               0               609              1.73
  GET_ROWS         OPU           33               0               948             28.73
  SET_ROWS         CPU          704               0              5840              8.30
  SOFT_MAX         OPU           88               0            131764           1497.32
  ROPE             CPU          700               0             10041             14.34
  GLU              OPU           88             123           1750805          19895.51

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 

####Model = smolVLM-256M.gguf
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
Failed to generate tool call example: Value is not callable: null at row 1, column 72:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                                                       ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 13:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
            ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 1:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

 is not mentioned in the



llama_perf_sampler_print:    sampling time =     146.20 ms /     9 runs   (   16.24 ms per token,    61.56 tokens per second)
llama_perf_context_print:        load time = 9691343.11 ms
llama_perf_context_print: prompt eval time = 9673025.33 ms /     4 tokens (2418256.33 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time =   17961.01 ms /     4 runs   ( 4490.25 ms per token,     0.22 tokens per second)
llama_perf_context_print:       total time = 9709493.69 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          660             834           8736029          13236.41
  MUL              OPU          671             848           7693219          11465.30
  RMS_NORM         OPU          671             671          13410529          19985.89
  MUL_MAT          CPU        11400               0          15312789           1343.23
  MUL_MAT          OPU          117             117        9657301557       82541038.95
  CONT             OPU          660               0           1238174           1876.02
  RESHAPE          CPU         3881               0             14536              3.75
  VIEW             CPU         3856               0              6317              1.64
  VIEW             OPU          660               0              1104              1.67
  PERMUTE          CPU         2510               0              5447              2.17
  PERMUTE          OPU          660               0               831              1.26
  TRANSPOSE        CPU         1231               0              3501              2.84
  GET_ROWS         OPU           33               0              2549             77.24
  SET_ROWS         CPU         2605               0             62637             24.04
  SOFT_MAX         OPU          330               0            237587            719.96
  ROPE             CPU         2553               0             87891             34.43
  GLU              OPU          330             417          22287789          67538.75

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 

#####Model = Tiny-Llama-v0.3-FP32-1.1B-F32.gguf

root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
 
 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
 is Luna.




llama_perf_sampler_print:    sampling time =     301.41 ms /    11 runs   (   27.40 ms per token,    36.49 tokens per second)
llama_perf_context_print:        load time = 15160569.45 ms
llama_perf_context_print: prompt eval time = 15054462.48 ms /     6 tokens (2509077.08 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time =  170554.09 ms /     4 runs   (42638.52 ms per token,     0.02 tokens per second)
llama_perf_context_print:       total time = 15332419.70 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          484             694          13668232          28240.15
  MUL              OPU          495             710          13307027          26882.88
  RMS_NORM         OPU          495             495          26348917          53230.14
  MUL_MAT          CPU         8539               0        1499582398         175615.69
  MUL_MAT          OPU           22              22       14926180536      678462751.64
  CONT             OPU          484               0           1933710           3995.27
  RESHAPE          CPU         2768               0             13484              4.87
  VIEW             CPU         2710               0             11489              4.24
  VIEW             OPU          484               0             65669            135.68
  PERMUTE          CPU         1725               0              6686              3.88
  PERMUTE          OPU          484               0              1027              2.12
  TRANSPOSE        CPU          909               0              2675              2.94
  GET_ROWS         OPU           33               0             14552            440.97
  SET_ROWS         CPU         1897               0            313991            165.52
  SOFT_MAX         OPU          242               0            791109           3269.05
  ROPE             CPU         1786               0            106586             59.68
  GLU              OPU          242             347          70065823         289528.19

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# vi run_
run_llama_cli.sh      run_platform_test.sh  
root@tsisim:/usr/bin/tsi/bin# vi run_
run_llama_cli.sh      run_platform_test.sh  
root@tsisim:/usr/bin/tsi/bin# vi run_
run_llama_cli.sh      run_platform_test.sh  
root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
######Model = Gemma3
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
 [end of text]




llama_perf_sampler_print:    sampling time =     106.86 ms /     6 runs   (   17.81 ms per token,    56.15 tokens per second)
llama_perf_context_print:        load time =   88545.36 ms
llama_perf_context_print: prompt eval time =   26760.76 ms /     5 tokens ( 5352.15 ms per token,     0.19 tokens per second)
llama_perf_context_print:        eval time =       0.00 ms /     1 runs   (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:       total time =   88713.87 ms /     6 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              CPU          288               0             48334            167.83
  ADD              OPU           48             232           2695386          56153.88
  MUL              OPU           49             237           2731964          55754.37
  RMS_NORM         OPU           49              49           4211488          85948.73
  MUL_MAT          CPU          861               0          12002004          13939.61
  CONT             OPU           48               0            480216          10004.50
  RESHAPE          CPU          280               0               997              3.56
  VIEW             CPU          283               0               642              2.27
  VIEW             OPU           48               0               102              2.12
  PERMUTE          CPU          185               0               516              2.79
  PERMUTE          OPU           48               0                74              1.54
  TRANSPOSE        CPU           92               0               188              2.04
  GET_ROWS         OPU            3               0               650            216.67
  SET_ROWS         CPU          192               0             19359            100.83
  SOFT_MAX         OPU           24               0            114191           4757.96
  ROPE             CPU          185               0             20424            110.40
  GLU              OPU           24             116          10630958         442956.58

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
Model = Quen
root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
 is Mittens.



llama_perf_sampler_print:    sampling time =     783.93 ms /    11 runs   (   71.27 ms per token,    14.03 tokens per second)


llama_perf_context_print:        load time =   86464.13 ms
llama_perf_context_print: prompt eval time =   43691.89 ms /     6 tokens ( 7281.98 ms per token,     0.14 tokens per second)
llama_perf_context_print:        eval time =   17592.62 ms /     4 runs   ( 4398.16 ms per token,     0.23 tokens per second)
llama_perf_context_print:       total time =  104931.18 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          396             566           5267836          13302.62
  MUL              OPU         1199            2588          45680381          38098.73
  RMS_NORM         OPU         1199            1199          28785449          24007.88
  MUL_MAT          CPU         7157               0          22334117           3120.60
  SCALE            CPU          788               0             12600             15.99
  CONT             OPU          396               0            971150           2452.40
  RESHAPE          CPU         2350               0              7352              3.13
  VIEW             CPU         2339               0              4370              1.87
  VIEW             OPU          396               0               770              1.94
  PERMUTE          CPU         1557               0              3547              2.28
  PERMUTE          OPU          396               0               562              1.42
  TRANSPOSE        CPU          765               0              1341              1.75
  GET_ROWS         OPU           33               0               943             28.58
  SET_ROWS         CPU         1572               0             19634             12.49
  SOFT_MAX         OPU          198               0             76434            386.03
  ROPE             CPU          792               0             35044             44.25
  ROPE             OPU          198               0             15944             80.53
  GLU              CPU          792               0            231118            291.82

OPU Profiling Results:
Profiler disabled
