### PR TITLE
@FIR-2004: Update the ROPE and ROPE_BACK ops to have a cache buffer

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2105,12 +2105,10 @@ static bool ggml_tsavorite_internal_supports_op(const struct ggml_tensor *op) {
           return true;
   case GGML_OP_GET_ROWS_BACK:
           return true;
-#ifndef OLLAMA
   case GGML_OP_ROPE:
           return true;
   case GGML_OP_ROPE_BACK:
           return true;
-#endif
   case GGML_OP_RESHAPE:
           return true;
   case GGML_OP_VIEW:
@@ -2899,7 +2897,7 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
     if(node->type == GGML_TYPE_F16 && src0->type == GGML_TYPE_F16 && (!src1 || src1->type == GGML_TYPE_F16))
 	    kernel_sub_type = DATA_TYPE_F16_INDEX;
 
-    if (node->op == GGML_OP_RMS_NORM ||  node->op == GGML_OP_SOFT_MAX) {
+    if (node->op == GGML_OP_RMS_NORM ||  node->op == GGML_OP_SOFT_MAX || node->op == GGML_OP_ROPE || node->op == GGML_OP_ROPE_BACK) {
         if (!glob_buf) {
             GGML_TSAVORITE_LOG_ERROR("tsi_alloc failied for creating memory for buf \n");
             return GGML_STATUS_ABORTED;


### PR DESCRIPTION
The change uses the global buffer for cache like used for SoftMax and RMS norm for wdata

The Ollama Server 

 journalctl -r -u ollama
Jun 24 21:36:17 tsisim ollama[1442]: time=2026-06-24T21:36:17.610Z level=WARN source=server.go:1757 msg="llama server stopped" pid=1472
Jun 24 21:31:17 tsisim ollama[1442]: [GIN] 2026/06/24 - 21:31:17 | 200 |          1m4s |       127.0.0.1 | POST     "/api/generate"
Jun 24 21:31:17 tsisim ollama[1472]: Profiler disabled
Jun 24 21:31:17 tsisim ollama[1472]: OPU Profiling Results:
Jun 24 21:31:17 tsisim ollama[1472]:  finalize 4
Jun 24 21:31:17 tsisim ollama[1472]:  TSI deploy yaml=/opt/taos/app/ollama-arm64-release/bin/tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
Jun 24 21:30:28 tsisim ollama[1442]: time=2026-06-24T21:30:28.504Z level=INFO source=server.go:1312 msg="llama runner started in 13.40 seconds"
Jun 24 21:30:28 tsisim ollama[1442]: llama_context: graph splits = 261
Jun 24 21:30:28 tsisim ollama[1442]: llama_context: graph nodes  = 729
Jun 24 21:30:28 tsisim ollama[1442]: llama_context:        CPU compute buffer size =   513.25 MiB
Jun 24 21:30:28 tsisim ollama[1442]: llama_context:  tsavorite compute buffer size =   171.25 MiB
Jun 24 21:30:26 tsisim ollama[1442]: llama_kv_cache: size =   60.00 MiB (  4096 cells,  15 layers,  1/1 seqs), K (f16):   30.00 MiB, V (f16):   30.00 MiB
Jun 24 21:30:26 tsisim ollama[1442]: llama_kv_cache:        CPU KV buffer size =    60.00 MiB
Jun 24 21:30:26 tsisim ollama[1442]: llama_kv_cache_iswa: creating     SWA KV cache, size = 4096 cells
Jun 24 21:30:26 tsisim ollama[1442]: llama_kv_cache: size =   12.00 MiB (  4096 cells,   3 layers,  1/1 seqs), K (f16):    6.00 MiB, V (f16):    6.00 MiB
Jun 24 21:30:26 tsisim ollama[1442]: llama_kv_cache:        CPU KV buffer size =    12.00 MiB

Ollama Client
root@tsisim:/opt/taos/app# ollama run Gemma3:270M "Where is Amazon River?" 
pulling manifest 
21:30:12,326: pulling 735af2139dc6: 100% ▕██████████████████▏ 291 MB                         
21:30:12,326: pulling 4b19ac7dd2fb: 100% ▕██████████████████▏  476 B                         
21:30:12,327: pulling 3e2c24001f9e: 100% ▕██████████████████▏ 8.4 KB                         
21:30:12,327: pulling 339e884a40f6: 100% ▕██████████████████▏   61 B                         
21:30:12,328: pulling 74156d92caf6: 100% ▕██████████████████▏  490 B                         
21:30:12,329: verifying sha256 digest 
21:30:12,329: writing manifest 
21:30:12,329: success 
⠏ [skylp write register interface] Socket Packet - sequence_num: 16, command: 2, write address: 0x2c500100, src: 0
[skylp sockets] Sending data: 012010000001502c...
[skylp sockets] Transport Payload: payload size 8 received
[skylp sockets] Received data: 7f001000acc21aac
[skylp write register interface] MMIO WRITE (socket) addr=0x2c500100, val=0xf5f05080
[skylp write register interface] Socket Packet - sequence_num: 17, command: 2, write address: 0x2c500104, src: 0
[skylp sockets] Sending data: 012011000401502c...
[skylp sockets] Transport Payload: payload size 8 received
[skylp sockets] Received data: 7f001100acc21aac
[skylp write register interface] MMIO WRITE (socket) addr=0x2c500104, val=0x4
[skylp write register interface] Socket Packet - sequence_num: 18, command: 2, write address: 0x2c500108, src: 0
[skylp sockets] Sending data: 012012000801502c...
[skylp sockets] Transport Payload: payload size 8 received
[skylp sockets] Received data: 7f001200acc21aac
[skylp write register interface] MMIO WRITE (socket) addr=0x2c500108, val=0xf5f05080
[skylp write register interface] Socket Packet - sequence_num: 19, command: 2, write address: 0x2c50010c, src: 0
[skylp sockets] Sending data: 012013000c01502c...
[skylp sockets] Transport Payload: payload size 8 received
[skylp sockets] Received data: 7f001300acc21aac
[skylp write register interface] MMIO WRITE (socket) addr=0x2c50010c, val=0x4
[skylp write register interface] Socket Packet - sequence_num: 20, command: 2, write address: 0x2c500110, src: 0
[skylp sockets] Sending data: 012014001001502c...
[skylp sockets] Transport Payload: payload size 8 received
[skylp sockets] Received data: 7f001400acc21aac
[skylp write register interface] MMIO WRITE (socket) addr=0x2c500110, val=0xf5f05080
[skylp write register interface] Socket Packet - sequence_num: 21, command: 2, write address: 0x2c500114, src: 0
[skylp sockets] Sending data: 012015001401502c...
[skylp sockets] Transport Payload: payload size 8 received
[skylp sockets] Received data: 7f001500acc21aac
[skylp write register interface] MMIO WRITE (socket) addr=0x2c500114, val=0x4
[skylp write register interface] Socket Packet - sequence_num: 22, command: 2, write address: 0x2c500118, src: 0
[skylp sockets] Sending data: 012016001801502c...
[skylp sockets] Transport Payload: payload size 8 received
[skylp sockets] Received data: 7f001600acc21aac
[skylp write register interface] MMIO WRITE (socket) addr=0x2c500118, val=0xf5f05080
[skylp write register interface] Socket Packet - sequence_num: 23, command: 2, write address: 0x2c50011c, src: 0
[skylp sockets] Sending data: 012017001c01502c...
[skylp sockets] Transport Payload: payload size 8 received
[skylp sockets] Received data: 7f001700acc21aac
[skylp write register interface] MMIO WRITE (socket) addr=0x2c50011c, val=0x4
Amazon River is located in **South America**.
21:31:17,201: 
21:31:17,601: 
21:31:17,601: root@tsisim:/opt/taos/app# 
