### PR TITLE
@FIR-2023 - llama.cpp: Implement Triton MAT_MUL host_wrapper Integration and Pack-Args Handling

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -90,10 +90,17 @@ struct TsavoriteRuntimeState {
     BlobDescriptor **blobDescriptor_add = nullptr;
     BlobDescriptor **blobDescriptor_mult = nullptr;
     BlobDescriptor **blobDescriptor_rms_norm = nullptr;
+#if TRITON_MAT_MUL
+    BlobDescriptor **blobDescriptor_matmul = nullptr;
+#endif
+
 
     void **loadResult_add = nullptr;
     void **loadResult_mult = nullptr;
     void **loadResult_rms_norm = nullptr;
+#if TRITON_MAT_MUL
+    void **loadResult_matmul;
+#endif
 
     // blob lifetime state machine
     enum BlobState : uint8_t {
@@ -132,10 +139,17 @@ auto &device_cv = g_rt.device_cv;
 auto &blobDescriptor_add      = g_rt.blobDescriptor_add;
 auto &blobDescriptor_mult     = g_rt.blobDescriptor_mult;
 auto &blobDescriptor_rms_norm = g_rt.blobDescriptor_rms_norm;
+#if TRITON_MAT_MUL
+auto &blobDescriptor_matmul   = g_rt.blobDescriptor_matmul;
+#endif
+
 
 auto &loadResult_add          = g_rt.loadResult_add;
 auto &loadResult_mult         = g_rt.loadResult_mult;
 auto &loadResult_rms_norm     = g_rt.loadResult_rms_norm;
+#if TRITON_MAT_MUL
+auto &loadResult_matmul       = g_rt.loadResult_matmul;
+#endif
 } // anonymous namespace
 
 constexpr int kMaxBacktraceFrames = 64;
@@ -473,6 +487,18 @@ static inline void tsi_blob_free_tables() {
         blobDescriptor_rms_norm = nullptr;
     }
 
+#if TRITON_MAT_MUL
+    if (loadResult_matmul) {
+        free(loadResult_matmul);
+        loadResult_matmul = nullptr;
+    }
+
+    if (blobDescriptor_matmul) {
+        free(blobDescriptor_matmul);
+        blobDescriptor_matmul = nullptr;
+    }
+#endif
+
     g_rt.blob_tables_txes = 0;
     g_rt.blob_state = TsavoriteRuntimeState::BLOB_UNINITIALIZED;
 }
@@ -503,11 +529,26 @@ static inline void tsi_blob_unload_only() {
             }
         }
     }
+#if TRITON_MAT_MUL
+    if (blobDescriptor_matmul) {
+        for (uint32_t i = 0; i < TSI_RUN_TIME_INSTANCE; ++i) {
+            if (blobDescriptor_matmul[i]) {
+                tsi_unload_blob(blobDescriptor_matmul[i]);
+                blobDescriptor_matmul[i] = nullptr;
+            }
+        }
+    }
+#endif
 
     // best-effort: clear loadResult_* entries too
     if (loadResult_add)      memset(loadResult_add,      0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
     if (loadResult_mult)     memset(loadResult_mult,     0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
     if (loadResult_rms_norm) memset(loadResult_rms_norm, 0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
+#if TRITON_MAT_MUL
+    if (loadResult_matmul) {
+        memset(loadResult_matmul, 0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
+    }
+#endif
 
     g_rt.blob_state = TsavoriteRuntimeState::BLOB_TABLES_ALLOCATED;
 }
@@ -526,13 +567,26 @@ static inline void tsi_blob_ensure_tables_allocated() {
     loadResult_add      = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
     loadResult_mult     = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
     loadResult_rms_norm = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
+#if TRITON_MAT_MUL
+    loadResult_matmul   = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
+#endif
 
     blobDescriptor_add      = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
     blobDescriptor_mult     = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
     blobDescriptor_rms_norm = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
+#if TRITON_MAT_MUL
+    blobDescriptor_matmul   = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
+#endif
 
     if (!loadResult_add || !loadResult_mult || !loadResult_rms_norm ||
-        !blobDescriptor_add || !blobDescriptor_mult || !blobDescriptor_rms_norm) {
+#if TRITON_MAT_MUL
+        !loadResult_matmul ||
+#endif
+        !blobDescriptor_add || !blobDescriptor_mult || !blobDescriptor_rms_norm
+#if TRITON_MAT_MUL
+        || !blobDescriptor_matmul
+#endif
+        ) {
         // free any partial allocations before abort
         tsi_blob_free_tables();
         fprintf(stderr, "Failed to allocate blob tables (num_of_txes=%u)\n", (unsigned)num_of_txes);
@@ -562,11 +616,17 @@ static void tsi_load_all_blobs() {
         char name_add[64];
         char name_mult[64];
         char name_rms[64];
+#if TRITON_MAT_MUL
+        char name_matmul[64];
+#endif
+
 
         snprintf(name_add,  sizeof(name_add),  "txe_add_dev%u",  i);
         snprintf(name_mult, sizeof(name_mult), "txe_mult_dev%u", i);
         snprintf(name_rms,  sizeof(name_rms),  "txe_rms_norm_dev%u", i);
-
+#if TRITON_MAT_MUL
+        snprintf(name_matmul, sizeof(name_matmul), "txe_triton_mat_mul_dev%u", i);
+#endif
         failed_txe = i;
 
         // ADD
@@ -613,6 +673,26 @@ static void tsi_load_all_blobs() {
         }
         blobDescriptor_rms_norm[i] =
             static_cast<BlobDescriptor *>(loadResult_rms_norm[i]);
+
+
+    #if TRITON_MAT_MUL
+        // Triton MAT_MUL
+        loadResult_matmul[i] = tsi_load_blob(
+            i,
+            name_matmul,
+            blob_prefix(
+                "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_triton_mat_mul/blobs/txe_blob_0"
+            ).c_str()
+        );
+
+        if (!loadResult_matmul[i]) {
+            strcpy(blob_name, name_matmul);
+            goto error;
+        }
+
+        blobDescriptor_matmul[i] =
+            static_cast<BlobDescriptor *>(loadResult_matmul[i]);
+    #endif
     }
 
     // success
@@ -2566,12 +2646,10 @@ static int32_t g_triton_cur_N_tile = TMU_N_BLOCK;
 
 
 // I will enable at next PR when multi threadig tested with 2 TXE
-#if MAT_MUL_HOST_GENERATED
 extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper(
     void *A, void *B, void *C,
     void *M_scalar, void *N_scalar, void *K_scalar,
     void *grid1_scalar, void *grid2_scalar, void *grid3_scalar);
-#endif /* MAT_MUL_HOST_GENERATED */
 
 // -----------------------------------------------------------------------------
 // Triton MAT_MUL manual memory wrapper
@@ -2596,70 +2674,6 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper(
 // First step: fixed device 0.
 // -----------------------------------------------------------------------------
 
-static void *g_triton_matmul_load_result = nullptr;
-static BlobDescriptor *g_triton_matmul_blob_desc = nullptr;
-
-static inline const char *tsavorite_getenv_or_default(const char *name, const char *defval) {
-    const char *v = std::getenv(name);
-    return (v && v[0]) ? v : defval;
-}
-
-static inline void tsi_load_triton_matmul_blob_once() {
-    if (g_triton_matmul_blob_desc) {
-        return;
-    }
-
-    const char *blob_name = tsavorite_getenv_or_default(
-        "TSAVORITE_TRITON_MATMUL_BLOB_NAME",
-        "txe_triton_mat_mul_dev0");
-
-    const char *blob_prefix_env = std::getenv("TSAVORITE_TRITON_MATMUL_BLOB_PREFIX");
-
-    std::string prefix;
-    if (blob_prefix_env && blob_prefix_env[0]) {
-        prefix = blob_prefix_env;
-    } else {
-#ifdef GGML_TARGET_POSIX
-        prefix = blob_prefix(
-            "/ggml-tsi-kernel/posix-kernel/build-posix/txe_triton_mat_mul/blobs/txe_blob_0"
-        );
-#else
-        prefix = blob_prefix(
-            "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_triton_mat_mul/blobs/txe_blob_0"
-        );
-#endif
-    }
-
-#if TRITON_DEBUG
-    fprintf(stderr,
-            "TRITON_MATMUL_LOAD_BLOB: device=0 name=%s prefix=%s\n",
-            blob_name, prefix.c_str());
-#endif
-
-    g_triton_matmul_load_result = tsi_load_blob(
-        0,
-        blob_name,
-        prefix.c_str());
-
-    if (!g_triton_matmul_load_result) {
-        fprintf(stderr,
-                "ERROR: failed to load Triton MAT_MUL blob: device=0 name=%s prefix=%s\n",
-                blob_name, prefix.c_str());
-        tsi_cleanup();
-        abort();
-    }
-
-    g_triton_matmul_blob_desc =
-        static_cast<BlobDescriptor *>(g_triton_matmul_load_result);
-
-    if (!g_triton_matmul_blob_desc) {
-        fprintf(stderr,
-                "ERROR: Triton MAT_MUL blob descriptor is NULL after load: name=%s prefix=%s\n",
-                blob_name, prefix.c_str());
-        tsi_cleanup();
-        abort();
-    }
-}
 
 static inline void tsi_pack_triton_matmul_arg(
     int64_t *p,
@@ -2692,8 +2706,24 @@ static inline void tsi_pack_triton_matmul_arg(
 #endif
 }
 
+// Triton MAT_MUL wrapper (F32-only)
+//
+// Inputs:
+//   A_desc_v     : MemRefDescriptor<F32> for matrix A
+//   B_desc_v     : MemRefDescriptor<F32> for matrix B
+//   C_desc_v     : MemRefDescriptor<F32> for output matrix C
+//   M_desc_v     : MemRefDescriptor<F32> scalar M
+//   N_desc_v     : MemRefDescriptor<F32> scalar N
+//   K_desc_v     : MemRefDescriptor<F32> scalar K
+//   grid1_desc_v : MemRefDescriptor<F32> scalar grid1
+//   grid2_desc_v : MemRefDescriptor<F32> scalar grid2
+//   grid3_desc_v : MemRefDescriptor<F32> scalar grid3
+//
+// Note:
+//   Current implementation supports F32 only. BF16/F16 and mixed-precision
+//   are not supported in ggml-tsavorite.cpp.
 
-extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
+extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_triton_manual(
     void *A_desc_v,
     void *B_desc_v,
     void *C_desc_v,
@@ -2708,7 +2738,6 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
     constexpr int64_t kPackedArgsBytes   = kPackedArgsI64 * (int64_t)sizeof(int64_t);
 
     tsi_init_per_txe_state_once();
-    tsi_load_triton_matmul_blob_once();
 
     if ((uint32_t)kDeviceId >= num_of_txes) {
         fprintf(stderr,
@@ -2782,7 +2811,7 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
     fprintf(stderr,
             "TRITON_MATMUL_LAUNCH: device=%d blob_desc=%p packed_args=%p packed_handle=%ld bytes=%ld\n",
             (int)kDeviceId,
-            (void *)g_triton_matmul_blob_desc,
+            (void *)blobDescriptor_matmul[0],
             packed_args[kDeviceId],
             (long)packedHandle,
             (long)kPackedArgsBytes);
@@ -2798,7 +2827,7 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
     }
 
     void *blobExecuteCmd = tsi_launch_blob(
-        g_triton_matmul_blob_desc,
+        blobDescriptor_matmul[0],
         packedHandle,
         kPackedArgsBytes);
 
@@ -2806,7 +2835,7 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
         fprintf(stderr,
                 "ERROR: tsi_launch_blob failed for Triton MAT_MUL device=%d blob_desc=%p packedHandle=%ld bytes=%ld\n",
                 (int)kDeviceId,
-                (void *)g_triton_matmul_blob_desc,
+                (void *)blobDescriptor_matmul[0],
                 (long)packedHandle,
                 (long)kPackedArgsBytes);
         tsi_cleanup();
@@ -3004,10 +3033,18 @@ static inline void call_triton_matmul_full_packed(
     init_scalar_i32_memref_aligned(grid3_desc, grid3_payload, 1);
 
 
-    _mlir_ciface_matmul_kernel_memory_wrapper_new(
-        A_desc, B_desc, C_desc,
-        M_desc, N_desc, K_desc,
-        grid1_desc, grid2_desc, grid3_desc);
+    if (multi_thread_enable) {
+        _mlir_ciface_matmul_kernel_memory_wrapper_triton_manual(
+            A_desc, B_desc, C_desc,
+            M_desc, N_desc, K_desc,
+            grid1_desc, grid2_desc, grid3_desc);
+    } else {
+         // below api is generated by triton compiler
+        _mlir_ciface_matmul_kernel_memory_wrapper(
+            A_desc, B_desc, C_desc,
+            M_desc, N_desc, K_desc,
+            grid1_desc, grid2_desc, grid3_desc);
+    }
 }
 #endif /* TRITON_MAT_MUL */
 

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2565,12 +2565,13 @@ static int32_t g_triton_cur_M_tile = TMU_M_TILE_MAX;
 static int32_t g_triton_cur_N_tile = TMU_N_BLOCK;
 
 
-#if 0
+// I will enable at next PR when multi threadig tested with 2 TXE
+#if MAT_MUL_HOST_GENERATED
 extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper(
     void *A, void *B, void *C,
     void *M_scalar, void *N_scalar, void *K_scalar,
     void *grid1_scalar, void *grid2_scalar, void *grid3_scalar);
-#endif /* 0 */
+#endif /* MAT_MUL_HOST_GENERATED */
 
 // -----------------------------------------------------------------------------
 // Triton MAT_MUL manual memory wrapper
@@ -2821,7 +2822,6 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
 }
 
 
-// ANOOP
 // -----------------------------------------------------------------------------
 // Triton MAT_MUL ABI helpers
 // IMPORTANT:

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2757,11 +2757,8 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
 
 // m,n,k,a,b,c,g1,g2,g3
     tsi_pack_triton_matmul_arg(p, idx, M_desc,     "M");
-    //M_desc->shape[0] = 1;
     tsi_pack_triton_matmul_arg(p, idx, N_desc,     "N");
-    //N_desc->shape[0] = 1;
     tsi_pack_triton_matmul_arg(p, idx, K_desc,     "K");
-    //K_desc->shape[0] = 1;
     tsi_pack_triton_matmul_arg(p, idx, A_desc,     "A");
     tsi_pack_triton_matmul_arg(p, idx, B_desc,     "B");
     tsi_pack_triton_matmul_arg(p, idx, C_desc,     "C");

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2565,10 +2565,244 @@ static int32_t g_triton_cur_M_tile = TMU_M_TILE_MAX;
 static int32_t g_triton_cur_N_tile = TMU_N_BLOCK;
 
 
+#if 0
 extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper(
     void *A, void *B, void *C,
     void *M_scalar, void *N_scalar, void *K_scalar,
     void *grid1_scalar, void *grid2_scalar, void *grid3_scalar);
+#endif /* 0 */
+
+// -----------------------------------------------------------------------------
+// Triton MAT_MUL manual memory wrapper
+//
+// TSISIM blob path:
+//   fpga-kernel/build-fpga/txe_triton_mat_mul/blobs/txe_blob_0.blob
+//
+// tsi_load_blob() expects prefix WITHOUT ".blob":
+//   .../txe_triton_mat_mul/blobs/txe_blob_0
+//
+// ABI assumption:
+//   9 args:
+//     A, B, C, M, N, K, grid1, grid2, grid3
+//
+// Each arg packed as 16 bytes:
+//   p[idx++] = tsi_shmem_handle_from_ptr(desc->data);
+//   p[idx++] = desc->shape[0];
+//
+// Total:
+//   9 args * 2 int64 = 18 int64 = 144 bytes
+//
+// First step: fixed device 0.
+// -----------------------------------------------------------------------------
+
+static void *g_triton_matmul_load_result = nullptr;
+static BlobDescriptor *g_triton_matmul_blob_desc = nullptr;
+
+static inline const char *tsavorite_getenv_or_default(const char *name, const char *defval) {
+    const char *v = std::getenv(name);
+    return (v && v[0]) ? v : defval;
+}
+
+static inline void tsi_load_triton_matmul_blob_once() {
+    if (g_triton_matmul_blob_desc) {
+        return;
+    }
+
+    const char *blob_name = tsavorite_getenv_or_default(
+        "TSAVORITE_TRITON_MATMUL_BLOB_NAME",
+        "txe_triton_mat_mul_dev0");
+
+    const char *blob_prefix_env = std::getenv("TSAVORITE_TRITON_MATMUL_BLOB_PREFIX");
+
+    std::string prefix;
+    if (blob_prefix_env && blob_prefix_env[0]) {
+        prefix = blob_prefix_env;
+    } else {
+#ifdef GGML_TARGET_POSIX
+        prefix = blob_prefix(
+            "/ggml-tsi-kernel/posix-kernel/build-posix/txe_triton_mat_mul/blobs/txe_blob_0"
+        );
+#else
+        prefix = blob_prefix(
+            "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_triton_mat_mul/blobs/txe_blob_0"
+        );
+#endif
+    }
+
+#if TRITON_DEBUG
+    fprintf(stderr,
+            "TRITON_MATMUL_LOAD_BLOB: device=0 name=%s prefix=%s\n",
+            blob_name, prefix.c_str());
+#endif
+
+    g_triton_matmul_load_result = tsi_load_blob(
+        0,
+        blob_name,
+        prefix.c_str());
+
+    if (!g_triton_matmul_load_result) {
+        fprintf(stderr,
+                "ERROR: failed to load Triton MAT_MUL blob: device=0 name=%s prefix=%s\n",
+                blob_name, prefix.c_str());
+        tsi_cleanup();
+        abort();
+    }
+
+    g_triton_matmul_blob_desc =
+        static_cast<BlobDescriptor *>(g_triton_matmul_load_result);
+
+    if (!g_triton_matmul_blob_desc) {
+        fprintf(stderr,
+                "ERROR: Triton MAT_MUL blob descriptor is NULL after load: name=%s prefix=%s\n",
+                blob_name, prefix.c_str());
+        tsi_cleanup();
+        abort();
+    }
+}
+
+static inline void tsi_pack_triton_matmul_arg(
+    int64_t *p,
+    int &idx,
+    MemRefDescriptor<Rank> *d,
+    const char *name) {
+    if (!d || !d->data) {
+        fprintf(stderr,
+                "ERROR: Triton MAT_MUL arg %s NULL desc/data desc=%p data=%p\n",
+                name, (const void *)d, d ? d->data : nullptr);
+        tsi_cleanup();
+        abort();
+    }
+
+    p[idx++] = tsi_shmem_handle_from_ptr(d->data);
+
+    p[idx++] = (int64_t)(d->offset);
+
+    p[idx++] = (int64_t)d->shape[0];
+
+#if TRITON_DEBUG
+    fprintf(stderr,
+            "TRITON_MATMUL_PACK_ARG: %s data=%p handle=%ld shape0=%ld offset=%ld stride0=%ld\n",
+            name,
+            d->data,
+            (long)p[idx - 2],
+            (long)d->shape[0],
+            (long)d->offset,
+            (long)d->strides[0]);
+#endif
+}
+
+extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
+    void *A_desc_v,
+    void *B_desc_v,
+    void *C_desc_v,
+    void *M_desc_v,
+    void *N_desc_v,
+    void *K_desc_v,
+    void *grid1_desc_v,
+    void *grid2_desc_v,
+    void *grid3_desc_v) {
+    constexpr TSI_DeviceIdType kDeviceId = 0;
+    constexpr int64_t kPackedArgsI64     = 27;
+    constexpr int64_t kPackedArgsBytes   = kPackedArgsI64 * (int64_t)sizeof(int64_t);
+
+    tsi_init_per_txe_state_once();
+    tsi_load_triton_matmul_blob_once();
+
+    if ((uint32_t)kDeviceId >= num_of_txes) {
+        fprintf(stderr,
+                "ERROR: Triton MAT_MUL deviceId=%d out of range num_of_txes=%u\n",
+                (int)kDeviceId, (unsigned)num_of_txes);
+        tsi_cleanup();
+        abort();
+    }
+
+    if (packed_args.size() != num_of_txes || !packed_args[kDeviceId]) {
+        fprintf(stderr,
+                "ERROR: Triton MAT_MUL packed_args not initialized deviceId=%d size=%zu num_of_txes=%u\n",
+                (int)kDeviceId,
+                packed_args.size(),
+                (unsigned)num_of_txes);
+        tsi_cleanup();
+        abort();
+    }
+
+    auto *A_desc     = (MemRefDescriptor<Rank> *)A_desc_v;
+    auto *B_desc     = (MemRefDescriptor<Rank> *)B_desc_v;
+    auto *C_desc     = (MemRefDescriptor<Rank> *)C_desc_v;
+    auto *M_desc     = (MemRefDescriptor<Rank> *)M_desc_v;
+    auto *N_desc     = (MemRefDescriptor<Rank> *)N_desc_v;
+    auto *K_desc     = (MemRefDescriptor<Rank> *)K_desc_v;
+    auto *grid1_desc = (MemRefDescriptor<Rank> *)grid1_desc_v;
+    auto *grid2_desc = (MemRefDescriptor<Rank> *)grid2_desc_v;
+    auto *grid3_desc = (MemRefDescriptor<Rank> *)grid3_desc_v;
+
+    std::lock_guard<std::mutex> lock(tsi_pack_mutex);
+
+    int64_t *p = static_cast<int64_t *>(packed_args[kDeviceId]);
+    memset(p, 0, (size_t)kPackedArgsBytes);
+
+    int idx = 0;
+
+    tsi_pack_triton_matmul_arg(p, idx, A_desc,     "A");
+    tsi_pack_triton_matmul_arg(p, idx, B_desc,     "B");
+    tsi_pack_triton_matmul_arg(p, idx, C_desc,     "C");
+    tsi_pack_triton_matmul_arg(p, idx, M_desc,     "M");
+    tsi_pack_triton_matmul_arg(p, idx, N_desc,     "N");
+    tsi_pack_triton_matmul_arg(p, idx, K_desc,     "K");
+    tsi_pack_triton_matmul_arg(p, idx, grid1_desc, "grid1");
+    tsi_pack_triton_matmul_arg(p, idx, grid2_desc, "grid2");
+    tsi_pack_triton_matmul_arg(p, idx, grid3_desc, "grid3");
+
+    if (idx != kPackedArgsI64) {
+        fprintf(stderr,
+                "ERROR: Triton MAT_MUL packed idx=%d expected=%ld\n",
+                idx, (long)kPackedArgsI64);
+        tsi_cleanup();
+        abort();
+    }
+
+    const int64_t packedHandle =
+        tsi_shmem_handle_from_ptr(packed_args[kDeviceId]);
+
+#if TRITON_DEBUG
+    fprintf(stderr,
+            "TRITON_MATMUL_LAUNCH: device=%d blob_desc=%p packed_args=%p packed_handle=%ld bytes=%ld\n",
+            (int)kDeviceId,
+            (void *)g_triton_matmul_blob_desc,
+            packed_args[kDeviceId],
+            (long)packedHandle,
+            (long)kPackedArgsBytes);
+#endif
+
+    void *commandList = tsi_create_command_list(kDeviceId);
+    if (!commandList) {
+        fprintf(stderr,
+                "ERROR: tsi_create_command_list failed for Triton MAT_MUL device=%d\n",
+                (int)kDeviceId);
+        tsi_cleanup();
+        abort();
+    }
+
+    void *blobExecuteCmd = tsi_launch_blob(
+        g_triton_matmul_blob_desc,
+        packedHandle,
+        kPackedArgsBytes);
+
+    if (!blobExecuteCmd) {
+        fprintf(stderr,
+                "ERROR: tsi_launch_blob failed for Triton MAT_MUL device=%d blob_desc=%p packedHandle=%ld bytes=%ld\n",
+                (int)kDeviceId,
+                (void *)g_triton_matmul_blob_desc,
+                (long)packedHandle,
+                (long)kPackedArgsBytes);
+        tsi_cleanup();
+        abort();
+    }
+
+    tsi_add_command_to_list(commandList, blobExecuteCmd);
+    tsi_finalize_command_list(commandList);
+    tsi_wait(commandList);
+}
 
 
 // ANOOP
@@ -2754,7 +2988,7 @@ static inline void call_triton_matmul_full_packed(
     init_scalar_i32_memref_aligned(grid2_desc, grid2_payload, 1);
     init_scalar_i32_memref_aligned(grid3_desc, grid3_payload, 1);
 
-    _mlir_ciface_matmul_kernel_memory_wrapper(
+    _mlir_ciface_matmul_kernel_memory_wrapper_new(
         A_desc, B_desc, C_desc,
         M_desc, N_desc, K_desc,
         grid1_desc, grid2_desc, grid3_desc);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2839,7 +2839,9 @@ static inline void init_scalar_i32_memref_aligned(
     d->base       = payload_ptr;
     d->data       = payload_ptr;
     d->offset     = 0;
-    d->shape[0]   = 1;
+    //We bypass Triton generated host_wrapper and pack blob args manually.
+    //d->shape[0]   = 1;
+    d->shape[0]   = v;
     d->strides[0] = 1;
     *((int32_t *) payload_ptr) = v;
 }

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2675,7 +2675,7 @@ static inline void tsi_pack_triton_matmul_arg(
 
     p[idx++] = tsi_shmem_handle_from_ptr(d->data);
 
-    p[idx++] = (int64_t)(d->offset);
+    //p[idx++] = (int64_t)(d->offset);
 
     p[idx++] = (int64_t)d->shape[0];
 
@@ -2702,7 +2702,7 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
     void *grid2_desc_v,
     void *grid3_desc_v) {
     constexpr TSI_DeviceIdType kDeviceId = 0;
-    constexpr int64_t kPackedArgsI64     = 27;
+    constexpr int64_t kPackedArgsI64     = 12;
     constexpr int64_t kPackedArgsBytes   = kPackedArgsI64 * (int64_t)sizeof(int64_t);
 
     tsi_init_per_txe_state_once();
@@ -2743,6 +2743,7 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
 
     int idx = 0;
 
+#if 0
     tsi_pack_triton_matmul_arg(p, idx, A_desc,     "A");
     tsi_pack_triton_matmul_arg(p, idx, B_desc,     "B");
     tsi_pack_triton_matmul_arg(p, idx, C_desc,     "C");
@@ -2752,6 +2753,13 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
     tsi_pack_triton_matmul_arg(p, idx, grid1_desc, "grid1");
     tsi_pack_triton_matmul_arg(p, idx, grid2_desc, "grid2");
     tsi_pack_triton_matmul_arg(p, idx, grid3_desc, "grid3");
+#endif
+    tsi_pack_triton_matmul_arg(p, idx, M_desc,     "M");
+    tsi_pack_triton_matmul_arg(p, idx, N_desc,     "N");
+    tsi_pack_triton_matmul_arg(p, idx, K_desc,     "K");
+    tsi_pack_triton_matmul_arg(p, idx, A_desc,     "A");
+    tsi_pack_triton_matmul_arg(p, idx, B_desc,     "B");
+    tsi_pack_triton_matmul_arg(p, idx, C_desc,     "C");
 
     if (idx != kPackedArgsI64) {
         fprintf(stderr,

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2691,6 +2691,7 @@ static inline void tsi_pack_triton_matmul_arg(
 #endif
 }
 
+
 extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
     void *A_desc_v,
     void *B_desc_v,
@@ -2702,7 +2703,7 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
     void *grid2_desc_v,
     void *grid3_desc_v) {
     constexpr TSI_DeviceIdType kDeviceId = 0;
-    constexpr int64_t kPackedArgsI64     = 12;
+    constexpr int64_t kPackedArgsI64     = 18;
     constexpr int64_t kPackedArgsBytes   = kPackedArgsI64 * (int64_t)sizeof(int64_t);
 
     tsi_init_per_txe_state_once();
@@ -2726,15 +2727,15 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
         abort();
     }
 
+    auto *grid1_desc = (MemRefDescriptor<Rank> *)grid1_desc_v;
+    auto *grid2_desc = (MemRefDescriptor<Rank> *)grid2_desc_v;
+    auto *grid3_desc = (MemRefDescriptor<Rank> *)grid3_desc_v;
     auto *A_desc     = (MemRefDescriptor<Rank> *)A_desc_v;
     auto *B_desc     = (MemRefDescriptor<Rank> *)B_desc_v;
     auto *C_desc     = (MemRefDescriptor<Rank> *)C_desc_v;
     auto *M_desc     = (MemRefDescriptor<Rank> *)M_desc_v;
     auto *N_desc     = (MemRefDescriptor<Rank> *)N_desc_v;
     auto *K_desc     = (MemRefDescriptor<Rank> *)K_desc_v;
-    auto *grid1_desc = (MemRefDescriptor<Rank> *)grid1_desc_v;
-    auto *grid2_desc = (MemRefDescriptor<Rank> *)grid2_desc_v;
-    auto *grid3_desc = (MemRefDescriptor<Rank> *)grid3_desc_v;
 
     std::lock_guard<std::mutex> lock(tsi_pack_mutex);
 
@@ -2743,23 +2744,30 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_new(
 
     int idx = 0;
 
-#if 0
+    M_desc->offset = 0;
+    N_desc->offset = 0;
+    K_desc->offset = 0;
+    A_desc->offset = 0;
+    B_desc->offset = 0;
+    C_desc->offset = 0;
+    grid1_desc->offset = 0;
+    grid2_desc->offset = 0;
+    grid3_desc->offset = 0;
+
+// m,n,k,a,b,c,g1,g2,g3
+    tsi_pack_triton_matmul_arg(p, idx, M_desc,     "M");
+    //M_desc->shape[0] = 1;
+    tsi_pack_triton_matmul_arg(p, idx, N_desc,     "N");
+    //N_desc->shape[0] = 1;
+    tsi_pack_triton_matmul_arg(p, idx, K_desc,     "K");
+    //K_desc->shape[0] = 1;
     tsi_pack_triton_matmul_arg(p, idx, A_desc,     "A");
     tsi_pack_triton_matmul_arg(p, idx, B_desc,     "B");
     tsi_pack_triton_matmul_arg(p, idx, C_desc,     "C");
-    tsi_pack_triton_matmul_arg(p, idx, M_desc,     "M");
-    tsi_pack_triton_matmul_arg(p, idx, N_desc,     "N");
-    tsi_pack_triton_matmul_arg(p, idx, K_desc,     "K");
     tsi_pack_triton_matmul_arg(p, idx, grid1_desc, "grid1");
     tsi_pack_triton_matmul_arg(p, idx, grid2_desc, "grid2");
     tsi_pack_triton_matmul_arg(p, idx, grid3_desc, "grid3");
-#endif
-    tsi_pack_triton_matmul_arg(p, idx, M_desc,     "M");
-    tsi_pack_triton_matmul_arg(p, idx, N_desc,     "N");
-    tsi_pack_triton_matmul_arg(p, idx, K_desc,     "K");
-    tsi_pack_triton_matmul_arg(p, idx, A_desc,     "A");
-    tsi_pack_triton_matmul_arg(p, idx, B_desc,     "B");
-    tsi_pack_triton_matmul_arg(p, idx, C_desc,     "C");
+
 
     if (idx != kPackedArgsI64) {
         fprintf(stderr,
@@ -2858,8 +2866,8 @@ static inline int64_t tsi_round_up_i64(int64_t v, int64_t a) {
     return ((v + a - 1) / a) * a;
 }
 
-static constexpr int32_t TRITON_FULL_M_TILE = 64;
-static constexpr int32_t TRITON_FULL_N_TILE = 64;
+//static constexpr int32_t TRITON_FULL_M_TILE = 64;
+//static constexpr int32_t TRITON_FULL_N_TILE = 64;
 
 static float *g_triton_A_full = nullptr; // [M_cap x K_cap]
 static float *g_triton_B_full = nullptr; // [K_cap x N_cap]
@@ -2997,6 +3005,7 @@ static inline void call_triton_matmul_full_packed(
     init_scalar_i32_memref_aligned(grid1_desc, grid1_payload, 1);
     init_scalar_i32_memref_aligned(grid2_desc, grid2_payload, 1);
     init_scalar_i32_memref_aligned(grid3_desc, grid3_payload, 1);
+
 
     _mlir_ciface_matmul_kernel_memory_wrapper_new(
         A_desc, B_desc, C_desc,

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2009,6 +2009,8 @@ static void ggml_tsavorite_free(struct ggml_backend_tsavorite_context *ctx) {
 
 void
 tsi_cleanup() {
+    fflush(stderr);
+    fflush(stdout);
     if (runtime_initialized != true)
         return;
     runtime_initialized = false;


### PR DESCRIPTION
Tested on Tsisim

########
Current test After Address all PR comments. June 30th at 9PM
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1
Failed to generate tool call example: Value is not callable: null at row 1, column 72:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                                                       ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 13:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
            ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 1:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

 is not mentioned in the

llama_perf_sampler_print:    sampling time =     143.00 ms /     9 runs   (   15.89 ms per token,    62.94 tokens per second)
llama_perf_context_print:        load time = 9455376.72 ms
llama_perf_context_print: prompt eval time = 9439155.40 ms /     4 tokens (2359788.85 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time =   17641.27 ms /     4 runs   ( 4410.32 ms per token,     0.23 tokens per second)
llama_perf_context_print:       total time = 9473190.12 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          660             834           7965329          12068.68
  MUL              OPU          671             848           2518222           3752.94
  RMS_NORM         OPU          671             671            461092            687.17
  MUL_MAT          CPU        11411               0          16055072           1406.98
  MUL_MAT          OPU          117             117        9422688683       80535800.71
  CONT             OPU          660               0           1290476           1955.27
  RESHAPE          CPU         3862               0             10300              2.67
  VIEW             CPU         3823               0              7990              2.09
  VIEW             OPU          660               0              1527              2.31
  PERMUTE          CPU         2481               0              5396              2.17
  PERMUTE          OPU          660               0               847              1.28
  TRANSPOSE        CPU         1219               0              2640              2.17
  GET_ROWS         OPU           33               0               785             23.79
  SET_ROWS         CPU         2602               0             34792             13.37
  SOFT_MAX         OPU          330               0            239387            725.42
  ROPE             CPU         2553               0             73396             28.75
  GLU              OPU          330             417          22306947          67596.81



OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 








########
Old test before PR comments
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
Failed to generate tool call example: Value is not callable: null at row 1, column 72:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                                                       ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 13:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
            ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 1:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

 is not mentioned in the

llama_perf_sampler_print:    sampling time =     175.68 ms /     9 runs   (   19.52 ms per token,    51.23 tokens per second)


llama_perf_context_print:        load time = 9454359.98 ms
llama_perf_context_print: prompt eval time = 9430654.03 ms /     4 tokens (2357663.51 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time =   18791.83 ms /     4 runs   ( 4697.96 ms per token,     0.21 tokens per second)
llama_perf_context_print:       total time = 9473369.11 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          660             834          10402774          15761.78
  MUL              OPU          671             848           8190397          12206.25
  RMS_NORM         OPU          671             671          14140643          21073.98
  MUL_MAT          CPU        11402               0          15920313           1396.27
  MUL_MAT          OPU          117             117        9415206286       80471848.60
  CONT             OPU          660               0           1298648           1967.65
  RESHAPE          CPU         3857               0             11883              3.08
  VIEW             CPU         3837               0              7147              1.86
  VIEW             OPU          660               0              1013              1.53
  PERMUTE          CPU         2459               0              5842              2.38
  PERMUTE          OPU          660               0               882              1.34
  TRANSPOSE        CPU         1189               0              7750              6.52
  GET_ROWS         OPU           33               0              1353             41.00
  SET_ROWS         CPU         2581               0             40765             15.79
  SOFT_MAX         OPU          330               0            255207            773.35
  ROPE             CPU         2525               0             85846             34.00
  GLU              OPU          330             417          23130380          70092.06
OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
