### PR TITLE
@FIR-2020 - llama.cpp sdk-4.11 changes

### DIFF
--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -382,8 +382,18 @@ ensure_submodules() {
 parse_args() {
   SHOW_HELP=0
   BUILD_TYPE=""
-  MLIR_COMPILER_DIR_IN="${MLIR_COMPILER_DIR:-}"
-  TOOLBOX_DIR_IN="${TOOLBOX_DIR:-}"
+  # Always reset SDK-derived env on every script invocation.
+  # SDK_VERSION is the only required input. Old exported paths must not leak
+  # across runs when switching SDK versions.
+  unset MLIR_COMPILER_DIR
+  unset TOOLBOX_DIR
+  unset TSICommon_DIR
+  unset MLIR_SDK_VERSION
+  unset COMPILER_INSTALL_DIR
+  unset FAU_LOOKUP_TABLE_PATH
+
+  MLIR_COMPILER_DIR_IN=""
+  TOOLBOX_DIR_IN=""
   ENABLE_COVERAGE_FLAG=""
 
   # submodules

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -430,12 +430,14 @@ parse_args() {
   # packaging selection
   PACKAGE_FPGA_BUILD_DIR=""
   # Triton kernel selection
-  # Default: MAT_MUL enabled if user does not pass any triton option.
+  # Default behavior is equivalent to: triton all
+  # TODO: keep "triton all" option for now for backward compatibility.
+  # Later release can remove explicit "all" option once default behavior is stable.
   # User can override with:
   #   triton add
   #   triton mat_mul
   #   triton all
-  ENABLE_TRITON_ADD=0
+  ENABLE_TRITON_ADD=1
   ENABLE_TRITON_MAT_MUL=1
   __EXPECT_TRITON_ARG=0
 


### PR DESCRIPTION
tsi-pkg-build.sh Updates

Added environment cleanup/reset logic to remove stale environment variable entries before applying a new SDK configuration. Default Build Behavior Change
Triton is now enabled by default, and all Triton kernels are compiled automatically as part of the llama.cpp build process.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*

Below are log 

akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli-original   -p "my cat's name is"  -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf  --device tsavorite   -c 12288   --temp 0.0   --n-predict 10   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
 my cat's name is Luna.
I'm a cat person



llama_perf_sampler_print:    sampling time =      23.94 ms /    17 runs   (    1.41 ms per token,   710.05 tokens per second)
llama_perf_context_print:        load time =   83053.25 ms
llama_perf_context_print: prompt eval time =   81226.49 ms /     7 tokens (11603.78 ms per token,     0.09 tokens per second)
llama_perf_context_print:        eval time =    7020.02 ms /     9 runs   (  780.00 ms per token,     1.28 tokens per second)
llama_perf_context_print:       total time =   90099.53 ms /    16 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU         2024            2276           3214507           1588.20
  MUL              OPU         2070            2328           3324604           1606.09
  RMS_NORM         OPU         2070            2070           2855874           1379.65
  MUL_MAT          CPU        36406               0          59127887           1624.12
  MUL_MAT          OPU           22              22          77912830        3541492.27
  CONT             OPU         2024               0            348146            172.01
  RESHAPE          CPU        10870               0              4218              0.39
  VIEW             CPU         9933               0              1006              0.10
  VIEW             OPU         2024               0               601              0.30
  PERMUTE          CPU         7080               0              1371              0.19
  PERMUTE          OPU         2024               0               202              0.10
  TRANSPOSE        CPU         2767               0               449              0.16
  GET_ROWS         OPU          138               0              3517             25.49
  SET_ROWS         CPU         7409               0              7070              0.95
  SOFT_MAX         OPU         1012               0            313670            309.95
  ROPE             CPU         7868               0             39635              5.04
  GLU              OPU         1012            1138           4246871           4196.51

OPU Profiling Results:
Profiler disabled


