### PR TITLE
@FIR2024 - Enable Triton MAT_MUL Execution Across Multi-TXE

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3221,6 +3221,197 @@ static inline void call_triton_matmul_full_packed(
         M_desc, N_desc, K_desc,
         grid1_desc, grid2_desc, grid3_desc);
 }
+
+
+// ============================================================================
+// Triton MAT_MUL Multi-TXE M-split support
+// ============================================================================
+
+static std::vector<float *> g_triton_A_full_mt;
+static std::vector<float *> g_triton_B_full_mt;
+static std::vector<float *> g_triton_C_full_mt;
+
+static std::vector<int64_t> g_triton_M_cap_mt;
+static std::vector<int64_t> g_triton_N_cap_mt;
+static std::vector<int64_t> g_triton_K_cap_mt;
+
+static std::mutex g_triton_mt_alloc_mutex;
+
+static inline void ensure_triton_full_buffers_for_device(
+    int deviceId,
+    int64_t M_pad,
+    int64_t N_pad,
+    int64_t K) {
+    TSAVORITE_GGML_ASSERT(deviceId >= 0);
+    TSAVORITE_GGML_ASSERT((uint32_t)deviceId < num_of_txes);
+    TSAVORITE_GGML_ASSERT(M_pad > 0);
+    TSAVORITE_GGML_ASSERT(N_pad > 0);
+    TSAVORITE_GGML_ASSERT(K > 0);
+    TSAVORITE_GGML_ASSERT((M_pad % 8) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % 64) == 0);
+    TSAVORITE_GGML_ASSERT((K % 32) == 0);
+
+    std::lock_guard<std::mutex> lk(g_triton_mt_alloc_mutex);
+
+    if (g_triton_A_full_mt.size() != num_of_txes) {
+        g_triton_A_full_mt.assign(num_of_txes, nullptr);
+        g_triton_B_full_mt.assign(num_of_txes, nullptr);
+        g_triton_C_full_mt.assign(num_of_txes, nullptr);
+
+        g_triton_M_cap_mt.assign(num_of_txes, 0);
+        g_triton_N_cap_mt.assign(num_of_txes, 0);
+        g_triton_K_cap_mt.assign(num_of_txes, 0);
+    }
+
+    const int64_t need_M = M_pad;
+    const int64_t need_N = N_pad;
+    const int64_t need_K = tsi_round_up_i64(K, 32);
+
+    if (!g_triton_A_full_mt[deviceId] ||
+        !g_triton_B_full_mt[deviceId] ||
+        !g_triton_C_full_mt[deviceId] ||
+        need_M > g_triton_M_cap_mt[deviceId] ||
+        need_N > g_triton_N_cap_mt[deviceId] ||
+        need_K > g_triton_K_cap_mt[deviceId]) {
+
+        g_triton_M_cap_mt[deviceId] = need_M;
+        g_triton_N_cap_mt[deviceId] = need_N;
+        g_triton_K_cap_mt[deviceId] = need_K;
+
+        g_triton_A_full_mt[deviceId] = (float *) tsi_alloc(
+            (size_t)need_M * (size_t)need_K * sizeof(float));
+
+        g_triton_B_full_mt[deviceId] = (float *) tsi_alloc(
+            (size_t)need_K * (size_t)need_N * sizeof(float));
+
+        g_triton_C_full_mt[deviceId] = (float *) tsi_alloc(
+            (size_t)need_M * (size_t)need_N * sizeof(float));
+
+        TSAVORITE_GGML_ASSERT(g_triton_A_full_mt[deviceId]);
+        TSAVORITE_GGML_ASSERT(g_triton_B_full_mt[deviceId]);
+        TSAVORITE_GGML_ASSERT(g_triton_C_full_mt[deviceId]);
+
+        TSAVORITE_GGML_ASSERT((((uintptr_t)g_triton_A_full_mt[deviceId]) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t)g_triton_B_full_mt[deviceId]) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t)g_triton_C_full_mt[deviceId]) & 127) == 0);
+    }
+}
+
+struct triton_matmul_desc_set_t {
+    MemRefDescriptor<Rank> *A_desc = nullptr;
+    MemRefDescriptor<Rank> *B_desc = nullptr;
+    MemRefDescriptor<Rank> *C_desc = nullptr;
+    MemRefDescriptor<Rank> *M_desc = nullptr;
+    MemRefDescriptor<Rank> *N_desc = nullptr;
+    MemRefDescriptor<Rank> *K_desc = nullptr;
+    MemRefDescriptor<Rank> *grid1_desc = nullptr;
+    MemRefDescriptor<Rank> *grid2_desc = nullptr;
+    MemRefDescriptor<Rank> *grid3_desc = nullptr;
+
+    int32_t *M_payload = nullptr;
+    int32_t *N_payload = nullptr;
+    int32_t *K_payload = nullptr;
+    int32_t *grid1_payload = nullptr;
+    int32_t *grid2_payload = nullptr;
+    int32_t *grid3_payload = nullptr;
+};
+
+static std::vector<triton_matmul_desc_set_t> g_triton_desc_mt;
+static std::mutex g_triton_desc_mt_mutex;
+
+static inline triton_matmul_desc_set_t *ensure_triton_desc_for_device(int deviceId) {
+    TSAVORITE_GGML_ASSERT(deviceId >= 0);
+    TSAVORITE_GGML_ASSERT((uint32_t)deviceId < num_of_txes);
+
+    std::lock_guard<std::mutex> lk(g_triton_desc_mt_mutex);
+
+    if (g_triton_desc_mt.size() != num_of_txes) {
+        g_triton_desc_mt.resize(num_of_txes);
+    }
+
+    triton_matmul_desc_set_t &s = g_triton_desc_mt[deviceId];
+
+    if (!s.A_desc) {
+        s.A_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        s.B_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        s.C_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+
+        s.M_desc     = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        s.N_desc     = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        s.K_desc     = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        s.grid1_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        s.grid2_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+        s.grid3_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
+
+        s.M_payload     = (int32_t *) tsi_alloc(128);
+        s.N_payload     = (int32_t *) tsi_alloc(128);
+        s.K_payload     = (int32_t *) tsi_alloc(128);
+        s.grid1_payload = (int32_t *) tsi_alloc(128);
+        s.grid2_payload = (int32_t *) tsi_alloc(128);
+        s.grid3_payload = (int32_t *) tsi_alloc(128);
+
+        TSAVORITE_GGML_ASSERT(s.A_desc && s.B_desc && s.C_desc);
+        TSAVORITE_GGML_ASSERT(s.M_desc && s.N_desc && s.K_desc);
+        TSAVORITE_GGML_ASSERT(s.grid1_desc && s.grid2_desc && s.grid3_desc);
+        TSAVORITE_GGML_ASSERT(s.M_payload && s.N_payload && s.K_payload);
+        TSAVORITE_GGML_ASSERT(s.grid1_payload && s.grid2_payload && s.grid3_payload);
+    }
+
+    return &s;
+}
+
+static inline void call_triton_matmul_full_packed_on_device(
+    int deviceId,
+    float *A_full,
+    float *B_full,
+    float *C_full,
+    int32_t M_pad,
+    int32_t N_pad,
+    int32_t K) {
+    TSAVORITE_GGML_ASSERT(deviceId >= 0);
+    TSAVORITE_GGML_ASSERT((uint32_t)deviceId < num_of_txes);
+    TSAVORITE_GGML_ASSERT((M_pad % 8) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % 64) == 0);
+    TSAVORITE_GGML_ASSERT((K % 32) == 0);
+
+    triton_matmul_desc_set_t *s = ensure_triton_desc_for_device(deviceId);
+
+    init_rank1_memref_flat(s->A_desc, (void *)A_full, (int64_t)M_pad * (int64_t)K);
+    init_rank1_memref_flat(s->B_desc, (void *)B_full, (int64_t)K * (int64_t)N_pad);
+    init_rank1_memref_flat(s->C_desc, (void *)C_full, (int64_t)M_pad * (int64_t)N_pad);
+
+    init_scalar_i32_memref_aligned(s->M_desc,     s->M_payload,     M_pad);
+    init_scalar_i32_memref_aligned(s->N_desc,     s->N_payload,     N_pad);
+    init_scalar_i32_memref_aligned(s->K_desc,     s->K_payload,     K);
+    init_scalar_i32_memref_aligned(s->grid1_desc, s->grid1_payload, 1);
+    init_scalar_i32_memref_aligned(s->grid2_desc, s->grid2_payload, 1);
+    init_scalar_i32_memref_aligned(s->grid3_desc, s->grid3_payload, 1);
+
+    void *commandList =
+        _mlir_ciface_matmul_kernel_memory_wrapper_triton_manual_internal(
+            s->A_desc,
+            s->B_desc,
+            s->C_desc,
+            s->M_desc,
+            s->N_desc,
+            s->K_desc,
+            s->grid1_desc,
+            s->grid2_desc,
+            s->grid3_desc,
+            (TSI_DeviceIdType)deviceId);
+
+    if (!commandList) {
+        fprintf(stderr,
+                "Command List Empty for Triton MAT_MUL on device %d\n",
+                deviceId);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    tsi_blob_execution_internal(commandList);
+}
+
 #endif /* TRITON_MAT_MUL */
 
 extern "C" void tmu_mul_mat_k32 (const void *A, const void *B, void *C) {
@@ -3387,23 +3578,88 @@ static inline void ensure_tmu_pack_buffers() {
 //  - increments node->tsi_kernel_runs and device stats for MUL_MAT
 // -----------------------------------------------------------------------------
 
+static inline void triton_matmul_log_offloaded_shape_once(
+    const struct ggml_tensor *A,
+    const struct ggml_tensor *B,
+    const struct ggml_tensor *C,
+    int64_t K,
+    int64_t M,
+    int64_t N,
+    int64_t M_pad,
+    int64_t N_pad) {
+#if TRITON_DEBUG
+    static std::mutex s_log_mutex;
+    static std::vector<std::string> s_seen;
+
+    char key[512];
+    snprintf(key, sizeof(key),
+             "K=%ld M=%ld N=%ld D2=%ld D3=%ld "
+             "A=[%ld,%ld,%ld,%ld] B=[%ld,%ld,%ld,%ld] C=[%ld,%ld,%ld,%ld]",
+             (long)K, (long)M, (long)N,
+             (long)C->ne[2], (long)C->ne[3],
+             (long)A->ne[0], (long)A->ne[1], (long)A->ne[2], (long)A->ne[3],
+             (long)B->ne[0], (long)B->ne[1], (long)B->ne[2], (long)B->ne[3],
+             (long)C->ne[0], (long)C->ne[1], (long)C->ne[2], (long)C->ne[3]);
+
+    bool already_seen = false;
+    {
+        std::lock_guard<std::mutex> lk(s_log_mutex);
+        for (const std::string &s : s_seen) {
+            if (s == key) {
+                already_seen = true;
+                break;
+            }
+        }
+        if (!already_seen) {
+            s_seen.push_back(std::string(key));
+        }
+    }
+
+    if (!already_seen) {
+        fprintf(stderr,
+                "TRITON_MATMUL_OFFLOAD_SHAPE: "
+                "K=%ld M=%ld N=%ld M_pad=%ld N_pad=%ld D2=%ld D3=%ld "
+                "A_ne=[%ld,%ld,%ld,%ld] B_ne=[%ld,%ld,%ld,%ld] C_ne=[%ld,%ld,%ld,%ld] "
+                "A_nb=[%ld,%ld,%ld,%ld] B_nb=[%ld,%ld,%ld,%ld] C_nb=[%ld,%ld,%ld,%ld]\n",
+                (long)K, (long)M, (long)N,
+                (long)M_pad, (long)N_pad,
+                (long)C->ne[2], (long)C->ne[3],
+                (long)A->ne[0], (long)A->ne[1], (long)A->ne[2], (long)A->ne[3],
+                (long)B->ne[0], (long)B->ne[1], (long)B->ne[2], (long)B->ne[3],
+                (long)C->ne[0], (long)C->ne[1], (long)C->ne[2], (long)C->ne[3],
+                (long)A->nb[0], (long)A->nb[1], (long)A->nb[2], (long)A->nb[3],
+                (long)B->nb[0], (long)B->nb[1], (long)B->nb[2], (long)B->nb[3],
+                (long)C->nb[0], (long)C->nb[1], (long)C->nb[2], (long)C->nb[3]);
+        fflush(stderr);
+    }
+#else
+    (void)A;
+    (void)B;
+    (void)C;
+    (void)K;
+    (void)M;
+    (void)N;
+    (void)M_pad;
+    (void)N_pad;
+#endif
+}
+
 static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     struct ggml_backend_tsavorite_context * ctx,
     txe_device_s device,
     struct ggml_tensor * node,
     enum ggml_tsavorite_kernel_type kernel_type,
     int kernel_sub_type) {
+    GGML_UNUSED(ctx);
+    GGML_UNUSED(kernel_sub_type);
 
-    if (!node || !node->src[0] || !node->src[1]) {
+    if (!node || !node->src[0] || !node->src[1] || !node->data) {
         return GGML_STATUS_FAILED;
     }
 
     const struct ggml_tensor *A = node->src[0];
     const struct ggml_tensor *B = node->src[1];
 
-    // -----------------------------
-    // Base dims
-    // -----------------------------
     const int64_t K = A->ne[0];
     const int64_t M = A->ne[1];
     const int64_t N = B->ne[1];
@@ -3412,20 +3668,10 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     if (B->ne[0] != K) return GGML_STATUS_FAILED;
     if ((K % 32) != 0) return GGML_STATUS_FAILED;
 
-    // -----------------------------
-    // Batch dims (NEW)
-    // -----------------------------
     const int64_t D2 = node->ne[2];
     const int64_t D3 = node->ne[3];
 
-    // -----------------------------
-    // Padding (same for all slices)
-    // -----------------------------
-    const int64_t M_pad = ((M + 7) / 8) * 8;
     const int64_t N_pad = ((N + 63) / 64) * 64;
-
-    // Allocate ONCE (no growth per slice)
-    ensure_triton_full_buffers(M_pad, N_pad, K);
 
     const int64_t a_nb0 = nb_or_default(A, 0);
     const int64_t a_nb1 = nb_or_default(A, 1);
@@ -3442,88 +3688,205 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     const int64_t c_nb2 = nb_or_default(node, 2);
     const int64_t c_nb3 = nb_or_default(node, 3);
 
-    char *A_base = (char *) A->data;
-    char *B_base = (char *) B->data;
-    char *C_base = (char *) node->data;
+    char *A_base = (char *)A->data;
+    char *B_base = (char *)B->data;
+    char *C_base = (char *)node->data;
 
-    // =========================================================
-    //  MAIN FIX: loop over batch dims (instead of expanding)
-    // =========================================================
+    // ============================================================
+    // Single-TXE / generated-host-wrapper path.
+    // Keep old behavior when multi_thread_enable=false or txe_count<=1.
+    // ============================================================
+    if (!multi_thread_enable || num_of_txes <= 1) {
+        const int64_t M_pad = ((M + 7) / 8) * 8;
+
+        ensure_triton_full_buffers(M_pad, N_pad, K);
+
+        for (int64_t d3 = 0; d3 < D3; ++d3) {
+            for (int64_t d2 = 0; d2 < D2; ++d2) {
+                char *A_ptr = A_base + d2 * a_nb2 + d3 * a_nb3;
+                char *B_ptr = B_base + d2 * b_nb2 + d3 * b_nb3;
+                char *C_ptr = C_base + d2 * c_nb2 + d3 * c_nb3;
+
+                memset(g_triton_A_full, 0, (size_t)M_pad * (size_t)K * sizeof(float));
+
+                for (int64_t r = 0; r < M; ++r) {
+                    const char *row = A_ptr + r * a_nb1;
+                    float *dst = g_triton_A_full + r * K;
+
+                    if (a_nb0 == sizeof(float)) {
+                        memcpy(dst, row, (size_t)K * sizeof(float));
+                    } else {
+                        for (int64_t k = 0; k < K; ++k) {
+                            dst[k] = *(float *)(row + k * a_nb0);
+                        }
+                    }
+                }
+
+                memset(g_triton_B_full, 0, (size_t)K * (size_t)N_pad * sizeof(float));
+
+                for (int64_t c = 0; c < N; ++c) {
+                    const char *col = B_ptr + c * b_nb1;
+                    for (int64_t k = 0; k < K; ++k) {
+                        g_triton_B_full[k * N_pad + c] =
+                            *(float *)(col + k * b_nb0);
+                    }
+                }
+
+                memset(g_triton_C_full, 0, (size_t)M_pad * (size_t)N_pad * sizeof(float));
+
+                call_triton_matmul_full_packed(
+                    g_triton_A_full,
+                    g_triton_B_full,
+                    g_triton_C_full,
+                    (int32_t)M_pad,
+                    (int32_t)N_pad,
+                    (int32_t)K);
+
+                if (multi_thread_enable) {
+                    join_all_workers();
+                }
+
+                for (int64_t r = 0; r < M; ++r) {
+                    for (int64_t c = 0; c < N; ++c) {
+                        *(float *)(C_ptr + r * c_nb0 + c * c_nb1) =
+                            g_triton_C_full[r * N_pad + c];
+                    }
+                }
+
+                if (device) {
+                    ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
+                }
+                ++node->tsi_kernel_runs;
+            }
+        }
+
+        return GGML_STATUS_SUCCESS;
+    }
+
+    // ============================================================
+    // Multi-TXE path: split M dimension across available TXEs.
+    // ============================================================
+    const int64_t active_txes = (int64_t)num_of_txes;
+    const int64_t rows_per_txe_unaligned = (M + active_txes - 1) / active_txes;
+    const int64_t rows_per_txe = ((rows_per_txe_unaligned + 7) / 8) * 8;
+
+    uint64_t launched_kernel_calls = 0;
+
     for (int64_t d3 = 0; d3 < D3; ++d3) {
         for (int64_t d2 = 0; d2 < D2; ++d2) {
-
             char *A_ptr = A_base + d2 * a_nb2 + d3 * a_nb3;
             char *B_ptr = B_base + d2 * b_nb2 + d3 * b_nb3;
             char *C_ptr = C_base + d2 * c_nb2 + d3 * c_nb3;
 
-            // -----------------------
-            // Pack A
-            // -----------------------
-            memset(g_triton_A_full, 0, M_pad * K * sizeof(float));
+            for (int64_t m0 = 0; m0 < M; m0 += rows_per_txe * active_txes) {
+                uint64_t batch_launched = 0;
 
-            for (int64_t r = 0; r < M; ++r) {
-                const char *row = A_ptr + r * a_nb1;
-                float *dst = g_triton_A_full + r * K;
-
-                if (a_nb0 == sizeof(float)) {
-                    memcpy(dst, row, K * sizeof(float));
-                } else {
-                    for (int64_t k = 0; k < K; ++k) {
-                        dst[k] = *(float *)(row + k * a_nb0);
+                for (int64_t t = 0; t < active_txes; ++t) {
+                    const int64_t tile_m0 = m0 + t * rows_per_txe;
+                    if (tile_m0 >= M) {
+                        break;
                     }
+
+                    const int64_t M_valid =
+                        (M - tile_m0 > rows_per_txe) ? rows_per_txe : (M - tile_m0);
+
+                    const int64_t M_tile_pad =
+                        ((M_valid + 7) / 8) * 8;
+
+                    const int deviceId = acquire_device_blocking();
+
+                    if (deviceId < 0 || (uint32_t)deviceId >= num_of_txes) {
+                        fprintf(stderr,
+                                "ERROR: Triton MAT_MUL failed to acquire valid deviceId=%d num_of_txes=%u\n",
+                                deviceId,
+                                (unsigned)num_of_txes);
+                        fflush(stderr);
+                        tsi_cleanup();
+                        abort();
+                    }
+
+                    ensure_triton_full_buffers_for_device(
+                        deviceId,
+                        M_tile_pad,
+                        N_pad,
+                        K);
+
+                    float *A_tile = g_triton_A_full_mt[deviceId];
+                    float *B_tile = g_triton_B_full_mt[deviceId];
+                    float *C_tile = g_triton_C_full_mt[deviceId];
+
+                    {
+                        std::lock_guard<std::mutex> lk(workers_mutex);
+                        workers.emplace_back([=] () {
+                            // Pack A tile: [M_tile_pad x K]
+                            memset(A_tile, 0, (size_t)M_tile_pad * (size_t)K * sizeof(float));
+
+                            for (int64_t r = 0; r < M_valid; ++r) {
+                                const int64_t src_r = tile_m0 + r;
+                                const char *row = A_ptr + src_r * a_nb1;
+                                float *dst = A_tile + r * K;
+
+                                if (a_nb0 == sizeof(float)) {
+                                    memcpy(dst, row, (size_t)K * sizeof(float));
+                                } else {
+                                    for (int64_t k = 0; k < K; ++k) {
+                                        dst[k] = *(const float *)(row + k * a_nb0);
+                                    }
+                                }
+                            }
+
+                            // Pack B full: [K x N_pad]
+                            memset(B_tile, 0, (size_t)K * (size_t)N_pad * sizeof(float));
+
+                            for (int64_t c = 0; c < N; ++c) {
+                                const char *col = B_ptr + c * b_nb1;
+                                for (int64_t k = 0; k < K; ++k) {
+                                    B_tile[k * N_pad + c] =
+                                        *(const float *)(col + k * b_nb0);
+                                }
+                            }
+
+                            // Clear C tile
+                            memset(C_tile, 0, (size_t)M_tile_pad * (size_t)N_pad * sizeof(float));
+
+                            // Run Triton MAT_MUL on this device
+                            call_triton_matmul_full_packed_on_device(
+                                deviceId,
+                                A_tile,
+                                B_tile,
+                                C_tile,
+                                (int32_t)M_tile_pad,
+                                (int32_t)N_pad,
+                                (int32_t)K);
+
+                            // Copy valid rows back
+                            for (int64_t r = 0; r < M_valid; ++r) {
+                                const int64_t dst_r = tile_m0 + r;
+                                for (int64_t c = 0; c < N; ++c) {
+                                    *(float *)(C_ptr + dst_r * c_nb0 + c * c_nb1) =
+                                        C_tile[r * N_pad + c];
+                                }
+                            }
+
+                            release_device(deviceId);
+                        });
+                    }
+
+                    ++batch_launched;
+                    ++launched_kernel_calls;
                 }
-            }
 
-            // -----------------------
-            // Pack B
-            // -----------------------
-            memset(g_triton_B_full, 0, K * N_pad * sizeof(float));
-
-            for (int64_t c = 0; c < N; ++c) {
-                const char *col = B_ptr + c * b_nb1;
-                for (int64_t k = 0; k < K; ++k) {
-                    g_triton_B_full[k * N_pad + c] =
-                        *(float *)(col + k * b_nb0);
-                }
-            }
-
-            // -----------------------
-            // Clear C
-            // -----------------------
-            memset(g_triton_C_full, 0, M_pad * N_pad * sizeof(float));
-
-            // -----------------------
-            // Kernel call
-            // -----------------------
-            call_triton_matmul_full_packed(
-                g_triton_A_full,
-                g_triton_B_full,
-                g_triton_C_full,
-                (int32_t)M_pad,
-                (int32_t)N_pad,
-                (int32_t)K);
-
-            if (multi_thread_enable) {
-                join_all_workers();
-            }
-
-            // -----------------------
-            // Copy back
-            // -----------------------
-            for (int64_t r = 0; r < M; ++r) {
-                for (int64_t c = 0; c < N; ++c) {
-                    *(float *)(C_ptr + r*c_nb0 + c*c_nb1) =
-                        g_triton_C_full[r * N_pad + c];
+                if (batch_launched > 0) {
+                    join_all_workers();
                 }
             }
         }
     }
 
     if (device) {
-        ++device->stats.op_run_count[kernel_type].num_of_kernel_call;
+        device->stats.op_run_count[kernel_type].num_of_kernel_call += launched_kernel_calls;
     }
-
-    ++node->tsi_kernel_runs;
+    node->tsi_kernel_runs += launched_kernel_calls;
 
     return GGML_STATUS_SUCCESS;
 }

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3503,6 +3503,10 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                 (int32_t)N_pad,
                 (int32_t)K);
 
+            if (multi_thread_enable) {
+                join_all_workers();
+            }
+
             // -----------------------
             // Copy back
             // -----------------------

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2634,20 +2634,45 @@ void _mlir_ciface_txe_mul_mat_tile_f32_k2048_host  (void *A_tile, void *B_tile, 
 }
 
 // -----------------------------------------------------------------------------
-// Triton MATMUL minimal wrapper for static K=32
-// Keeps existing ggml_tsavorite_run_tmu_mul_mat() packing/copyback unchanged.
-// A pack : [1,1,TMU_M_TILE_MAX,32]
-// B pack : [1,1,TMU_N_BLOCK,32]   // row-major packed as N x K (same as current TMU path)
-// C tile : [1,1,TMU_M_TILE_MAX,TMU_N_BLOCK]
-// Scalars: M, N, K, grid1, grid2, grid3 (all memref-of-1xi32 style)
-// -----------------------------------------------------------------------------
+// Triton MAT_MUL implementation for dynamic matrix shapes.
 //
+// Current implementation targets the Triton 1x8 TXE shape. Supported matrix
+// shapes are handled by padding M and N to the Triton kernel alignment
+// requirements, then packing the full matrices into Triton-compatible buffers.
+//
+// K is dynamic and is passed at runtime. The only current K constraint is that
+// it must satisfy the Triton MAT_MUL alignment requirement.
+//
+// Packed buffers:
+//   A full : [M_pad x K]
+//   B full : [K x N_pad]
+//   C full : [M_pad x N_pad]
+//
+// Scalars:
+//   M_pad, N_pad, K, grid1, grid2, grid3 are passed through packed_args.
+//
+// Note:
+//   This implementation currently uses the Triton 1x8 TXE shape. Future TXE
+//   configurations such as 8x1, 4x2, and 2x4 can be added through
+//   shape-specific alignment, packing, and dispatch logic.
+// -----------------------------------------------------------------------------
+
+
+// TXE Shape specific
+#define TRITON_MATMUL_1X8_M_DIM      8
+#define TRITON_MATMUL_1X8_N_DIM     64
+
+
+// Data type specific
+#define TRITON_MATMUL_F32_K_DIM      32
+
+#define TRITON_MATMUL_ALIGNMENT_BYTES      128
+#define TRITON_MATMUL_ALIGNMENT_MASK      (TRITON_MATMUL_ALIGNMENT_BYTES - 1)
 
 static int32_t g_triton_cur_M_tile = TMU_M_TILE_MAX;
 static int32_t g_triton_cur_N_tile = TMU_N_BLOCK;
 
 
-// I will enable at next PR when multi threadig tested with 2 TXE
 extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper(
     void *A, void *B, void *C,
     void *M_scalar, void *N_scalar, void *K_scalar,
@@ -2691,9 +2716,6 @@ static inline void tsi_pack_triton_matmul_arg(
     }
 
     p[idx++] = tsi_shmem_handle_from_ptr(d->data);
-
-    //p[idx++] = (int64_t)(d->offset);
-
     p[idx++] = (int64_t)d->shape[0];
 
 #if TRITON_DEBUG
@@ -2843,7 +2865,7 @@ static void *_mlir_ciface_matmul_kernel_memory_wrapper_triton_manual_internal(
     return commandList;
 }
 
-extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_triton_dispatch (
+static void _mlir_ciface_matmul_kernel_memory_wrapper_triton_dispatch (
     void *A_desc_v,
     void *B_desc_v,
     void *C_desc_v,
@@ -2949,9 +2971,6 @@ static inline int64_t tsi_round_up_i64(int64_t v, int64_t a) {
     return ((v + a - 1) / a) * a;
 }
 
-//static constexpr int32_t TRITON_FULL_M_TILE = 64;
-//static constexpr int32_t TRITON_FULL_N_TILE = 64;
-
 static float *g_triton_A_full = nullptr; // [M_cap x K_cap]
 static float *g_triton_B_full = nullptr; // [K_cap x N_cap]
 static float *g_triton_C_full = nullptr; // [M_cap x N_cap]
@@ -2965,13 +2984,13 @@ static inline void ensure_triton_full_buffers(int64_t M_pad, int64_t N_pad, int6
     TSAVORITE_GGML_ASSERT(N_pad > 0);
     TSAVORITE_GGML_ASSERT(K > 0);
 
-    TSAVORITE_GGML_ASSERT((M_pad % 8) == 0);
-    TSAVORITE_GGML_ASSERT((N_pad % 64) == 0);
-    TSAVORITE_GGML_ASSERT((K % 32) == 0);
+    TSAVORITE_GGML_ASSERT((M_pad % TRITON_MATMUL_1X8_M_DIM) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % TRITON_MATMUL_1X8_N_DIM) == 0);
+    TSAVORITE_GGML_ASSERT((K % TRITON_MATMUL_F32_K_DIM) == 0);
 
     const int64_t need_M = M_pad;
     const int64_t need_N = N_pad;
-    const int64_t need_K = tsi_round_up_i64(K, 32);
+    const int64_t need_K = tsi_round_up_i64(K, TRITON_MATMUL_F32_K_DIM);
 
     if (!g_triton_A_full || !g_triton_B_full || !g_triton_C_full ||
         need_M > g_triton_M_cap ||
@@ -3001,9 +3020,9 @@ static inline void ensure_triton_full_buffers(int64_t M_pad, int64_t N_pad, int6
         TSAVORITE_GGML_ASSERT(g_triton_B_full);
         TSAVORITE_GGML_ASSERT(g_triton_C_full);
 
-        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_A_full) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_B_full) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_C_full) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_A_full) & TRITON_MATMUL_ALIGNMENT_MASK) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_B_full) & TRITON_MATMUL_ALIGNMENT_MASK) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t) g_triton_C_full) & TRITON_MATMUL_ALIGNMENT_MASK) == 0);
     }
 }
 
@@ -3047,12 +3066,12 @@ static inline void call_triton_matmul_full_packed(
         grid2_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
         grid3_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
 
-        M_payload     = (int32_t *) tsi_alloc(128);
-        N_payload     = (int32_t *) tsi_alloc(128);
-        K_payload     = (int32_t *) tsi_alloc(128);
-        grid1_payload = (int32_t *) tsi_alloc(128);
-        grid2_payload = (int32_t *) tsi_alloc(128);
-        grid3_payload = (int32_t *) tsi_alloc(128);
+        M_payload     = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        N_payload     = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        K_payload     = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        grid1_payload = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        grid2_payload = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        grid3_payload = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
 
         TSAVORITE_GGML_ASSERT(A_desc && B_desc && C_desc);
         TSAVORITE_GGML_ASSERT(M_desc && N_desc && K_desc);
@@ -3063,9 +3082,9 @@ static inline void call_triton_matmul_full_packed(
         inited = true;
     }
 
-    TSAVORITE_GGML_ASSERT((M_pad % 8) == 0);
-    TSAVORITE_GGML_ASSERT((N_pad % 64) == 0);
-    TSAVORITE_GGML_ASSERT((K % 32) == 0);
+    TSAVORITE_GGML_ASSERT((M_pad % TRITON_MATMUL_1X8_M_DIM) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % TRITON_MATMUL_1X8_N_DIM) == 0);
+    TSAVORITE_GGML_ASSERT((K % TRITON_MATMUL_F32_K_DIM) == 0);
 
     init_rank1_memref_flat(
         A_desc,
@@ -3121,9 +3140,9 @@ static inline void ensure_triton_full_buffers_for_device(
     TSAVORITE_GGML_ASSERT(M_pad > 0);
     TSAVORITE_GGML_ASSERT(N_pad > 0);
     TSAVORITE_GGML_ASSERT(K > 0);
-    TSAVORITE_GGML_ASSERT((M_pad % 8) == 0);
-    TSAVORITE_GGML_ASSERT((N_pad % 64) == 0);
-    TSAVORITE_GGML_ASSERT((K % 32) == 0);
+    TSAVORITE_GGML_ASSERT((M_pad % TRITON_MATMUL_1X8_M_DIM) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % TRITON_MATMUL_1X8_N_DIM) == 0);
+    TSAVORITE_GGML_ASSERT((K % TRITON_MATMUL_F32_K_DIM) == 0);
 
     std::lock_guard<std::mutex> lk(g_triton_mt_alloc_mutex);
 
@@ -3139,7 +3158,7 @@ static inline void ensure_triton_full_buffers_for_device(
 
     const int64_t need_M = M_pad;
     const int64_t need_N = N_pad;
-    const int64_t need_K = tsi_round_up_i64(K, 32);
+    const int64_t need_K = tsi_round_up_i64(K, TRITON_MATMUL_F32_K_DIM);
 
     if (!g_triton_A_full_mt[deviceId] ||
         !g_triton_B_full_mt[deviceId] ||
@@ -3165,9 +3184,9 @@ static inline void ensure_triton_full_buffers_for_device(
         TSAVORITE_GGML_ASSERT(g_triton_B_full_mt[deviceId]);
         TSAVORITE_GGML_ASSERT(g_triton_C_full_mt[deviceId]);
 
-        TSAVORITE_GGML_ASSERT((((uintptr_t)g_triton_A_full_mt[deviceId]) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t)g_triton_B_full_mt[deviceId]) & 127) == 0);
-        TSAVORITE_GGML_ASSERT((((uintptr_t)g_triton_C_full_mt[deviceId]) & 127) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t)g_triton_A_full_mt[deviceId]) & TRITON_MATMUL_ALIGNMENT_MASK) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t)g_triton_B_full_mt[deviceId]) & TRITON_MATMUL_ALIGNMENT_MASK) == 0);
+        TSAVORITE_GGML_ASSERT((((uintptr_t)g_triton_C_full_mt[deviceId]) & TRITON_MATMUL_ALIGNMENT_MASK) == 0);
     }
 }
 
@@ -3217,12 +3236,12 @@ static inline triton_matmul_desc_set_t *ensure_triton_desc_for_device(int device
         s.grid2_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
         s.grid3_desc = (MemRefDescriptor<Rank> *) tsi_alloc(sizeof(MemRefDescriptor<Rank>));
 
-        s.M_payload     = (int32_t *) tsi_alloc(128);
-        s.N_payload     = (int32_t *) tsi_alloc(128);
-        s.K_payload     = (int32_t *) tsi_alloc(128);
-        s.grid1_payload = (int32_t *) tsi_alloc(128);
-        s.grid2_payload = (int32_t *) tsi_alloc(128);
-        s.grid3_payload = (int32_t *) tsi_alloc(128);
+        s.M_payload     = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        s.N_payload     = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        s.K_payload     = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        s.grid1_payload = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        s.grid2_payload = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        s.grid3_payload = (int32_t *) tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
 
         TSAVORITE_GGML_ASSERT(s.A_desc && s.B_desc && s.C_desc);
         TSAVORITE_GGML_ASSERT(s.M_desc && s.N_desc && s.K_desc);
@@ -3244,9 +3263,9 @@ static inline void call_triton_matmul_full_packed_on_device(
     int32_t K) {
     TSAVORITE_GGML_ASSERT(deviceId >= 0);
     TSAVORITE_GGML_ASSERT((uint32_t)deviceId < num_of_txes);
-    TSAVORITE_GGML_ASSERT((M_pad % 8) == 0);
-    TSAVORITE_GGML_ASSERT((N_pad % 64) == 0);
-    TSAVORITE_GGML_ASSERT((K % 32) == 0);
+    TSAVORITE_GGML_ASSERT((M_pad % TRITON_MATMUL_1X8_M_DIM) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % TRITON_MATMUL_1X8_N_DIM) == 0);
+    TSAVORITE_GGML_ASSERT((K % TRITON_MATMUL_F32_K_DIM) == 0);
 
     triton_matmul_desc_set_t *s = ensure_triton_desc_for_device(deviceId);
 

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2725,6 +2725,7 @@ static inline void tsi_pack_triton_matmul_arg(
 //   Current implementation supports F32 only. BF16/F16 and mixed-precision
 //   are not supported in ggml-tsavorite.cpp.
 
+#if 0
 extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_triton_manual(
     void *A_desc_v,
     void *B_desc_v,
@@ -2847,6 +2848,186 @@ extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_triton_manual(
     tsi_add_command_to_list(commandList, blobExecuteCmd);
     tsi_finalize_command_list(commandList);
     tsi_wait(commandList);
+}
+#endif /* 0 */
+
+static void *_mlir_ciface_matmul_kernel_memory_wrapper_triton_manual_internal(
+    void *A_desc_v,
+    void *B_desc_v,
+    void *C_desc_v,
+    void *M_desc_v,
+    void *N_desc_v,
+    void *K_desc_v,
+    void *grid1_desc_v,
+    void *grid2_desc_v,
+    void *grid3_desc_v,
+    TSI_DeviceIdType deviceId) {
+
+    constexpr int64_t kPackedArgsI64   = 18;
+    constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * (int64_t)sizeof(int64_t);
+
+    std::lock_guard<std::mutex> lock(tsi_pack_mutex);
+
+    if ((uint32_t)deviceId >= num_of_txes) {
+        fprintf(stderr,
+                "ERROR: Triton MAT_MUL deviceId=%d out of range num_of_txes=%u\n",
+                (int)deviceId, (unsigned)num_of_txes);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
+        fprintf(stderr,
+                "ERROR: Triton MAT_MUL packed_args not initialized deviceId=%d size=%zu num_of_txes=%u\n",
+                (int)deviceId,
+                packed_args.size(),
+                (unsigned)num_of_txes);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    auto *grid1_desc = (MemRefDescriptor<Rank> *)grid1_desc_v;
+    auto *grid2_desc = (MemRefDescriptor<Rank> *)grid2_desc_v;
+    auto *grid3_desc = (MemRefDescriptor<Rank> *)grid3_desc_v;
+
+    auto *A_desc = (MemRefDescriptor<Rank> *)A_desc_v;
+    auto *B_desc = (MemRefDescriptor<Rank> *)B_desc_v;
+    auto *C_desc = (MemRefDescriptor<Rank> *)C_desc_v;
+
+    auto *M_desc = (MemRefDescriptor<Rank> *)M_desc_v;
+    auto *N_desc = (MemRefDescriptor<Rank> *)N_desc_v;
+    auto *K_desc = (MemRefDescriptor<Rank> *)K_desc_v;
+
+    int64_t *p = static_cast<int64_t *>(packed_args[deviceId]);
+    memset(p, 0, (size_t)kPackedArgsBytes);
+
+    M_desc->offset = 0;
+    N_desc->offset = 0;
+    K_desc->offset = 0;
+    A_desc->offset = 0;
+    B_desc->offset = 0;
+    C_desc->offset = 0;
+    grid1_desc->offset = 0;
+    grid2_desc->offset = 0;
+    grid3_desc->offset = 0;
+
+    int idx = 0;
+
+    // M,N,K,A,B,C,grid1,grid2,grid3
+    tsi_pack_triton_matmul_arg(p, idx, M_desc,     "M");
+    tsi_pack_triton_matmul_arg(p, idx, N_desc,     "N");
+    tsi_pack_triton_matmul_arg(p, idx, K_desc,     "K");
+    tsi_pack_triton_matmul_arg(p, idx, A_desc,     "A");
+    tsi_pack_triton_matmul_arg(p, idx, B_desc,     "B");
+    tsi_pack_triton_matmul_arg(p, idx, C_desc,     "C");
+    tsi_pack_triton_matmul_arg(p, idx, grid1_desc, "grid1");
+    tsi_pack_triton_matmul_arg(p, idx, grid2_desc, "grid2");
+    tsi_pack_triton_matmul_arg(p, idx, grid3_desc, "grid3");
+
+    if (idx != kPackedArgsI64) {
+        fprintf(stderr,
+                "ERROR: Triton MAT_MUL packed idx=%d expected=%ld\n",
+                idx, (long)kPackedArgsI64);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    void *commandList = tsi_create_command_list(deviceId);
+    if (!commandList) {
+        fprintf(stderr,
+                "ERROR: tsi_create_command_list failed for Triton MAT_MUL device=%d\n",
+                (int)deviceId);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    const int64_t packedHandle =
+        tsi_shmem_handle_from_ptr(packed_args[deviceId]);
+
+    void *blobExecuteCmd = tsi_launch_blob(
+        blobDescriptor_matmul[0],
+        packedHandle,
+        kPackedArgsBytes);
+
+    if (!blobExecuteCmd) {
+        fprintf(stderr,
+                "ERROR: tsi_launch_blob failed for Triton MAT_MUL device=%d blob_desc=%p packedHandle=%ld bytes=%ld\n",
+                (int)deviceId,
+                (void *)blobDescriptor_matmul[0],
+                (long)packedHandle,
+                (long)kPackedArgsBytes);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    tsi_add_command_to_list(commandList, blobExecuteCmd);
+    return commandList;
+}
+
+extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_triton_dispatch (
+    void *A_desc_v,
+    void *B_desc_v,
+    void *C_desc_v,
+    void *M_desc_v,
+    void *N_desc_v,
+    void *K_desc_v,
+    void *grid1_desc_v,
+    void *grid2_desc_v,
+    void *grid3_desc_v) {
+
+    tsi_init_per_txe_state_once();
+
+    if (!multi_thread_enable) {
+        _mlir_ciface_matmul_kernel_memory_wrapper(
+            A_desc_v,
+            B_desc_v,
+            C_desc_v,
+            M_desc_v,
+            N_desc_v,
+            K_desc_v,
+            grid1_desc_v,
+            grid2_desc_v,
+            grid3_desc_v);
+        return;
+    }
+
+    int deviceId = acquire_device_blocking();
+
+    void *commandList =
+        _mlir_ciface_matmul_kernel_memory_wrapper_triton_manual_internal(
+            A_desc_v,
+            B_desc_v,
+            C_desc_v,
+            M_desc_v,
+            N_desc_v,
+            K_desc_v,
+            grid1_desc_v,
+            grid2_desc_v,
+            grid3_desc_v,
+            deviceId);
+
+    if (!commandList) {
+        fprintf(stderr,
+                "Command List Empty for Triton MAT_MUL on device %d\n",
+                deviceId);
+        fflush(stderr);
+        release_device(deviceId);
+        tsi_cleanup();
+        abort();
+    }
+
+    {
+        std::lock_guard<std::mutex> lk(workers_mutex);
+        workers.emplace_back([=]() {
+       tsi_blob_execution_internal(commandList);
+            release_device(deviceId);
+        });
+    }
 }
 
 
@@ -3035,18 +3216,10 @@ static inline void call_triton_matmul_full_packed(
     init_scalar_i32_memref_aligned(grid3_desc, grid3_payload, 1);
 
 
-    if (multi_thread_enable) {
-        _mlir_ciface_matmul_kernel_memory_wrapper_triton_manual(
-            A_desc, B_desc, C_desc,
-            M_desc, N_desc, K_desc,
-            grid1_desc, grid2_desc, grid3_desc);
-    } else {
-         // below api is generated by triton compiler
-        _mlir_ciface_matmul_kernel_memory_wrapper(
-            A_desc, B_desc, C_desc,
-            M_desc, N_desc, K_desc,
-            grid1_desc, grid2_desc, grid3_desc);
-    }
+    _mlir_ciface_matmul_kernel_memory_wrapper_triton_dispatch(
+        A_desc, B_desc, C_desc,
+        M_desc, N_desc, K_desc,
+        grid1_desc, grid2_desc, grid3_desc);
 }
 #endif /* TRITON_MAT_MUL */
 

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2725,132 +2725,6 @@ static inline void tsi_pack_triton_matmul_arg(
 //   Current implementation supports F32 only. BF16/F16 and mixed-precision
 //   are not supported in ggml-tsavorite.cpp.
 
-#if 0
-extern "C" void _mlir_ciface_matmul_kernel_memory_wrapper_triton_manual(
-    void *A_desc_v,
-    void *B_desc_v,
-    void *C_desc_v,
-    void *M_desc_v,
-    void *N_desc_v,
-    void *K_desc_v,
-    void *grid1_desc_v,
-    void *grid2_desc_v,
-    void *grid3_desc_v) {
-    constexpr TSI_DeviceIdType kDeviceId = 0;
-    constexpr int64_t kPackedArgsI64     = 18;
-    constexpr int64_t kPackedArgsBytes   = kPackedArgsI64 * (int64_t)sizeof(int64_t);
-
-    tsi_init_per_txe_state_once();
-
-    if ((uint32_t)kDeviceId >= num_of_txes) {
-        fprintf(stderr,
-                "ERROR: Triton MAT_MUL deviceId=%d out of range num_of_txes=%u\n",
-                (int)kDeviceId, (unsigned)num_of_txes);
-        tsi_cleanup();
-        abort();
-    }
-
-    if (packed_args.size() != num_of_txes || !packed_args[kDeviceId]) {
-        fprintf(stderr,
-                "ERROR: Triton MAT_MUL packed_args not initialized deviceId=%d size=%zu num_of_txes=%u\n",
-                (int)kDeviceId,
-                packed_args.size(),
-                (unsigned)num_of_txes);
-        tsi_cleanup();
-        abort();
-    }
-
-    auto *grid1_desc = (MemRefDescriptor<Rank> *)grid1_desc_v;
-    auto *grid2_desc = (MemRefDescriptor<Rank> *)grid2_desc_v;
-    auto *grid3_desc = (MemRefDescriptor<Rank> *)grid3_desc_v;
-    auto *A_desc     = (MemRefDescriptor<Rank> *)A_desc_v;
-    auto *B_desc     = (MemRefDescriptor<Rank> *)B_desc_v;
-    auto *C_desc     = (MemRefDescriptor<Rank> *)C_desc_v;
-    auto *M_desc     = (MemRefDescriptor<Rank> *)M_desc_v;
-    auto *N_desc     = (MemRefDescriptor<Rank> *)N_desc_v;
-    auto *K_desc     = (MemRefDescriptor<Rank> *)K_desc_v;
-
-    std::lock_guard<std::mutex> lock(tsi_pack_mutex);
-
-    int64_t *p = static_cast<int64_t *>(packed_args[kDeviceId]);
-    memset(p, 0, (size_t)kPackedArgsBytes);
-
-    int idx = 0;
-
-    M_desc->offset = 0;
-    N_desc->offset = 0;
-    K_desc->offset = 0;
-    A_desc->offset = 0;
-    B_desc->offset = 0;
-    C_desc->offset = 0;
-    grid1_desc->offset = 0;
-    grid2_desc->offset = 0;
-    grid3_desc->offset = 0;
-
-// m,n,k,a,b,c,g1,g2,g3
-    tsi_pack_triton_matmul_arg(p, idx, M_desc,     "M");
-    tsi_pack_triton_matmul_arg(p, idx, N_desc,     "N");
-    tsi_pack_triton_matmul_arg(p, idx, K_desc,     "K");
-    tsi_pack_triton_matmul_arg(p, idx, A_desc,     "A");
-    tsi_pack_triton_matmul_arg(p, idx, B_desc,     "B");
-    tsi_pack_triton_matmul_arg(p, idx, C_desc,     "C");
-    tsi_pack_triton_matmul_arg(p, idx, grid1_desc, "grid1");
-    tsi_pack_triton_matmul_arg(p, idx, grid2_desc, "grid2");
-    tsi_pack_triton_matmul_arg(p, idx, grid3_desc, "grid3");
-
-
-    if (idx != kPackedArgsI64) {
-        fprintf(stderr,
-                "ERROR: Triton MAT_MUL packed idx=%d expected=%ld\n",
-                idx, (long)kPackedArgsI64);
-        tsi_cleanup();
-        abort();
-    }
-
-    const int64_t packedHandle =
-        tsi_shmem_handle_from_ptr(packed_args[kDeviceId]);
-
-#if TRITON_DEBUG
-    fprintf(stderr,
-            "TRITON_MATMUL_LAUNCH: device=%d blob_desc=%p packed_args=%p packed_handle=%ld bytes=%ld\n",
-            (int)kDeviceId,
-            (void *)blobDescriptor_matmul[0],
-            packed_args[kDeviceId],
-            (long)packedHandle,
-            (long)kPackedArgsBytes);
-#endif
-
-    void *commandList = tsi_create_command_list(kDeviceId);
-    if (!commandList) {
-        fprintf(stderr,
-                "ERROR: tsi_create_command_list failed for Triton MAT_MUL device=%d\n",
-                (int)kDeviceId);
-        tsi_cleanup();
-        abort();
-    }
-
-    void *blobExecuteCmd = tsi_launch_blob(
-        blobDescriptor_matmul[0],
-        packedHandle,
-        kPackedArgsBytes);
-
-    if (!blobExecuteCmd) {
-        fprintf(stderr,
-                "ERROR: tsi_launch_blob failed for Triton MAT_MUL device=%d blob_desc=%p packedHandle=%ld bytes=%ld\n",
-                (int)kDeviceId,
-                (void *)blobDescriptor_matmul[0],
-                (long)packedHandle,
-                (long)kPackedArgsBytes);
-        tsi_cleanup();
-        abort();
-    }
-
-    tsi_add_command_to_list(commandList, blobExecuteCmd);
-    tsi_finalize_command_list(commandList);
-    tsi_wait(commandList);
-}
-#endif /* 0 */
-
 static void *_mlir_ciface_matmul_kernel_memory_wrapper_triton_manual_internal(
     void *A_desc_v,
     void *B_desc_v,
@@ -3581,25 +3455,21 @@ static inline void ensure_tmu_pack_buffers() {
 static inline void triton_matmul_log_offloaded_shape_once(
     const struct ggml_tensor *A,
     const struct ggml_tensor *B,
-    const struct ggml_tensor *C,
-    int64_t K,
-    int64_t M,
-    int64_t N,
-    int64_t M_pad,
-    int64_t N_pad) {
+    const struct ggml_tensor *node) {
 #if TRITON_DEBUG
+    if (!A || !B || !node) {
+        return;
+    }
+
     static std::mutex s_log_mutex;
     static std::vector<std::string> s_seen;
 
     char key[512];
     snprintf(key, sizeof(key),
-             "K=%ld M=%ld N=%ld D2=%ld D3=%ld "
-             "A=[%ld,%ld,%ld,%ld] B=[%ld,%ld,%ld,%ld] C=[%ld,%ld,%ld,%ld]",
-             (long)K, (long)M, (long)N,
-             (long)C->ne[2], (long)C->ne[3],
-             (long)A->ne[0], (long)A->ne[1], (long)A->ne[2], (long)A->ne[3],
-             (long)B->ne[0], (long)B->ne[1], (long)B->ne[2], (long)B->ne[3],
-             (long)C->ne[0], (long)C->ne[1], (long)C->ne[2], (long)C->ne[3]);
+             "A=[%ld,%ld,%ld,%ld] B=[%ld,%ld,%ld,%ld] node=[%ld,%ld,%ld,%ld]",
+             (long)A->ne[0],    (long)A->ne[1],    (long)A->ne[2],    (long)A->ne[3],
+             (long)B->ne[0],    (long)B->ne[1],    (long)B->ne[2],    (long)B->ne[3],
+             (long)node->ne[0], (long)node->ne[1], (long)node->ne[2], (long)node->ne[3]);
 
     bool already_seen = false;
     {
@@ -3617,30 +3487,19 @@ static inline void triton_matmul_log_offloaded_shape_once(
 
     if (!already_seen) {
         fprintf(stderr,
-                "TRITON_MATMUL_OFFLOAD_SHAPE: "
-                "K=%ld M=%ld N=%ld M_pad=%ld N_pad=%ld D2=%ld D3=%ld "
-                "A_ne=[%ld,%ld,%ld,%ld] B_ne=[%ld,%ld,%ld,%ld] C_ne=[%ld,%ld,%ld,%ld] "
-                "A_nb=[%ld,%ld,%ld,%ld] B_nb=[%ld,%ld,%ld,%ld] C_nb=[%ld,%ld,%ld,%ld]\n",
-                (long)K, (long)M, (long)N,
-                (long)M_pad, (long)N_pad,
-                (long)C->ne[2], (long)C->ne[3],
-                (long)A->ne[0], (long)A->ne[1], (long)A->ne[2], (long)A->ne[3],
-                (long)B->ne[0], (long)B->ne[1], (long)B->ne[2], (long)B->ne[3],
-                (long)C->ne[0], (long)C->ne[1], (long)C->ne[2], (long)C->ne[3],
-                (long)A->nb[0], (long)A->nb[1], (long)A->nb[2], (long)A->nb[3],
-                (long)B->nb[0], (long)B->nb[1], (long)B->nb[2], (long)B->nb[3],
-                (long)C->nb[0], (long)C->nb[1], (long)C->nb[2], (long)C->nb[3]);
+                "TRITON_MATMUL_OFFLOADED_SHAPE: "
+                "A=[%ld,%ld,%ld,%ld] "
+                "B=[%ld,%ld,%ld,%ld] "
+                "node=[%ld,%ld,%ld,%ld]\n",
+                (long)A->ne[0],    (long)A->ne[1],    (long)A->ne[2],    (long)A->ne[3],
+                (long)B->ne[0],    (long)B->ne[1],    (long)B->ne[2],    (long)B->ne[3],
+                (long)node->ne[0], (long)node->ne[1], (long)node->ne[2], (long)node->ne[3]);
         fflush(stderr);
     }
 #else
     (void)A;
     (void)B;
-    (void)C;
-    (void)K;
-    (void)M;
-    (void)N;
-    (void)M_pad;
-    (void)N_pad;
+    (void)node;
 #endif
 }
 
@@ -3673,6 +3532,9 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
     const int64_t N_pad = ((N + 63) / 64) * 64;
 
+#if TRITON_DEBUG
+    triton_matmul_log_offloaded_shape_once(A, B, node);
+#endif
     const int64_t a_nb0 = nb_or_default(A, 0);
     const int64_t a_nb1 = nb_or_default(A, 1);
     const int64_t a_nb2 = nb_or_default(A, 2);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2658,6 +2658,8 @@ void _mlir_ciface_txe_mul_mat_tile_f32_k2048_host  (void *A_tile, void *B_tile, 
 // -----------------------------------------------------------------------------
 
 
+#if TRITON_MAT_MUL
+
 // TXE Shape specific
 #define TRITON_MATMUL_1X8_M_DIM      8
 #define TRITON_MATMUL_1X8_N_DIM     64
@@ -2935,7 +2937,6 @@ static void _mlir_ciface_matmul_kernel_memory_wrapper_triton_dispatch (
 // - Descriptor and scalar payload must both be device-visible and 128B aligned
 // -----------------------------------------------------------------------------
 
-#if TRITON_MAT_MUL
 template<int N>
 static inline void init_rank1_memref_flat(
     MemRefDescriptor<N> *d,
@@ -3305,163 +3306,6 @@ static inline void call_triton_matmul_full_packed_on_device(
     tsi_blob_execution_internal(commandList);
 }
 
-#endif /* TRITON_MAT_MUL */
-
-extern "C" void tmu_mul_mat_k32 (const void *A, const void *B, void *C) {
-    call_tmu_blob<32>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k32_host);
-}
-extern "C" void tmu_mul_mat_k64 (const void *A, const void *B, void *C) {
-    call_tmu_blob<64>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k64_host);
-}
-extern "C" void tmu_mul_mat_k128(const void *A, const void *B, void *C) {
-    call_tmu_blob<128>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k128_host);
-}
-extern "C" void tmu_mul_mat_k256(const void *A, const void *B, void *C) {
-    call_tmu_blob<256>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k256_host);
-}
-extern "C" void tmu_mul_mat_k512(const void *A, const void *B, void *C) {
-    call_tmu_blob<512>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k512_host);
-}
-extern "C" void tmu_mul_mat_k1024(const void *A, const void *B, void *C) {
-    call_tmu_blob<1024>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k1024_host);
-}
-extern "C" void tmu_mul_mat_k2048(const void *A, const void *B, void *C) {
-    call_tmu_blob<2048>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k2048_host);
-}
-
-// ============================================================================
-// DISPATCH (ONE PER K BUCKET) — points to ABI-safe wrappers above
-// ============================================================================
-
-typedef void (*tmu_mul_mat_tile_fn)(const void *A_tile, const void *B_tile, void *C_tile);
-
-struct tmu_bucket_dispatch {
-    int k;
-    tmu_mul_mat_tile_fn fn;
-};
-
-static const tmu_bucket_dispatch g_tmu_dispatch[] = {
-    // Larger K buckets are temporarily disabled (blob size > 64 KB).
-#if 0
-    { 2048, tmu_mul_mat_k2048 },
-    { 1024, tmu_mul_mat_k1024 },
-    {  512, tmu_mul_mat_k512  },
-    {  256, tmu_mul_mat_k256  },
-    {  128, tmu_mul_mat_k128  },
-    {   64, tmu_mul_mat_k64   },
-#endif
-    {   32, tmu_mul_mat_k32   },
-    {    0, nullptr           }
-};
-
-static inline const tmu_bucket_dispatch *tmu_find_bucket(int k) {
-    for (int i = 0; g_tmu_dispatch[i].k != 0; ++i) {
-        if (g_tmu_dispatch[i].k == k) return &g_tmu_dispatch[i];
-    }
-    return nullptr;
-}
-
-static inline int tmu_decompose_k(int64_t k, int *out, int max_parts) {
-    if (!out || max_parts <= 0) return -1;
-    if (k < 0) return -1;  // defensive: never allow negative K
-
-    int n = 0;
-
-    for (int i = 0; g_tmu_dispatch[i].k != 0 && n < max_parts; ++i) {
-        const int bucket = g_tmu_dispatch[i].k;
-
-        // Defensive: bucket must be positive
-        if (bucket <= 0) return -1;
-
-        while (k >= (int64_t) bucket && n < max_parts) {
-            out[n++] = bucket;
-            k -= (int64_t) bucket;
-            // Defensive: k should never go negative due to the loop condition
-            if (k < 0) return -1;
-        }
-    }
-
-    // Must decompose exactly; otherwise unsupported remainder
-    return (k == 0) ? n : -1;
-}
-
-// ============================================================================
-// PACKING HELPERS (FP32)
-// ============================================================================
-
-static inline void pack_A_tile_f32(
-    float *A_pack,             // [TMU_M_TILE_MAX * K_chunk]
-    const char *A_base_d23,     // src0->data already offset for d2/d3
-    int64_t m0,
-    int64_t m_tile,
-    int64_t k0,
-    int64_t K_chunk,
-    int64_t a_nb0,
-    int64_t a_nb1
-) {
-    memset(A_pack, 0, (size_t)(TMU_M_TILE_MAX * K_chunk) * sizeof(float));
-
-    for (int64_t r = 0; r < m_tile; ++r) {
-        const int64_t m = m0 + r;
-        float *dst = A_pack + r * K_chunk;
-
-        const char *src_row = A_base_d23 + m * a_nb1 + k0 * a_nb0;
-        for (int64_t kk = 0; kk < K_chunk; ++kk) {
-            dst[kk] = *(const float *)(src_row + kk * a_nb0);
-        }
-    }
-}
-
-static inline void pack_B_tile_f32(
-    float *B_pack,             // [TMU_N_BLOCK * K_chunk]
-    const char *B_base_d23,     // src1->data already offset for d2/d3
-    int64_t n0,
-    int64_t n_valid,
-    int64_t k0,
-    int64_t K_chunk,
-    int64_t b_nb0,
-    int64_t b_nb1
-) {
-    memset(B_pack, 0, (size_t)(TMU_N_BLOCK * K_chunk) * sizeof(float));
-
-    for (int64_t c = 0; c < n_valid; ++c) {
-        const int64_t n = n0 + c;
-        float *dst = B_pack + c * K_chunk;
-
-        const char *src_col = B_base_d23 + n * b_nb1 + k0 * b_nb0;
-        for (int64_t kk = 0; kk < K_chunk; ++kk) {
-            dst[kk] = *(const float *)(src_col + kk * b_nb0);
-        }
-    }
-}
-
-// ============================================================================
-// REUSABLE BUFFERS — allocated once per process
-// ============================================================================
-
-static float *g_A_pack = nullptr;   // 64 * 2048
-static float *g_B_pack = nullptr;   // 32 * 2048
-static float *g_C_tile = nullptr;   // 64 * 32
-static int    g_pack_maxK = 0;
-
-static std::once_flag g_tmu_buf_once;
-
-static inline void ensure_tmu_pack_buffers() {
-    std::call_once(g_tmu_buf_once, []() {
-        const int maxK = 2048; // fixed maximum bucket
-
-        g_pack_maxK = maxK;
-
-        g_A_pack = (float *) tsi_alloc((size_t)TMU_M_TILE_MAX * (size_t)maxK * sizeof(float));
-        g_B_pack = (float *) tsi_alloc((size_t)TMU_N_BLOCK     * (size_t)maxK * sizeof(float));
-        g_C_tile = (float *) tsi_alloc((size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
-
-        TSAVORITE_GGML_ASSERT(g_A_pack && g_B_pack && g_C_tile);
-    });
-}
-
-
-#if TRITON_MAT_MUL
 
 // -----------------------------------------------------------------------------
 // TMU MUL_MAT runner (called from ggml_tsavorite_graph_compute)
@@ -3772,8 +3616,161 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     return GGML_STATUS_SUCCESS;
 }
 
-
 #else
+
+extern "C" void tmu_mul_mat_k32 (const void *A, const void *B, void *C) {
+    call_tmu_blob<32>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k32_host);
+}
+extern "C" void tmu_mul_mat_k64 (const void *A, const void *B, void *C) {
+    call_tmu_blob<64>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k64_host);
+}
+extern "C" void tmu_mul_mat_k128(const void *A, const void *B, void *C) {
+    call_tmu_blob<128>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k128_host);
+}
+extern "C" void tmu_mul_mat_k256(const void *A, const void *B, void *C) {
+    call_tmu_blob<256>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k256_host);
+}
+extern "C" void tmu_mul_mat_k512(const void *A, const void *B, void *C) {
+    call_tmu_blob<512>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k512_host);
+}
+extern "C" void tmu_mul_mat_k1024(const void *A, const void *B, void *C) {
+    call_tmu_blob<1024>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k1024_host);
+}
+extern "C" void tmu_mul_mat_k2048(const void *A, const void *B, void *C) {
+    call_tmu_blob<2048>(A, B, C, _mlir_ciface_txe_mul_mat_tile_f32_k2048_host);
+}
+
+// ============================================================================
+// DISPATCH (ONE PER K BUCKET) — points to ABI-safe wrappers above
+// ============================================================================
+
+typedef void (*tmu_mul_mat_tile_fn)(const void *A_tile, const void *B_tile, void *C_tile);
+
+struct tmu_bucket_dispatch {
+    int k;
+    tmu_mul_mat_tile_fn fn;
+};
+
+static const tmu_bucket_dispatch g_tmu_dispatch[] = {
+    // Larger K buckets are temporarily disabled (blob size > 64 KB).
+#if 0
+    { 2048, tmu_mul_mat_k2048 },
+    { 1024, tmu_mul_mat_k1024 },
+    {  512, tmu_mul_mat_k512  },
+    {  256, tmu_mul_mat_k256  },
+    {  128, tmu_mul_mat_k128  },
+    {   64, tmu_mul_mat_k64   },
+#endif
+    {   32, tmu_mul_mat_k32   },
+    {    0, nullptr           }
+};
+
+static inline const tmu_bucket_dispatch *tmu_find_bucket(int k) {
+    for (int i = 0; g_tmu_dispatch[i].k != 0; ++i) {
+        if (g_tmu_dispatch[i].k == k) return &g_tmu_dispatch[i];
+    }
+    return nullptr;
+}
+
+static inline int tmu_decompose_k(int64_t k, int *out, int max_parts) {
+    if (!out || max_parts <= 0) return -1;
+    if (k < 0) return -1;  // defensive: never allow negative K
+
+    int n = 0;
+
+    for (int i = 0; g_tmu_dispatch[i].k != 0 && n < max_parts; ++i) {
+        const int bucket = g_tmu_dispatch[i].k;
+
+        // Defensive: bucket must be positive
+        if (bucket <= 0) return -1;
+
+        while (k >= (int64_t) bucket && n < max_parts) {
+            out[n++] = bucket;
+            k -= (int64_t) bucket;
+            // Defensive: k should never go negative due to the loop condition
+            if (k < 0) return -1;
+        }
+    }
+
+    // Must decompose exactly; otherwise unsupported remainder
+    return (k == 0) ? n : -1;
+}
+
+// ============================================================================
+// PACKING HELPERS (FP32)
+// ============================================================================
+
+static inline void pack_A_tile_f32(
+    float *A_pack,             // [TMU_M_TILE_MAX * K_chunk]
+    const char *A_base_d23,     // src0->data already offset for d2/d3
+    int64_t m0,
+    int64_t m_tile,
+    int64_t k0,
+    int64_t K_chunk,
+    int64_t a_nb0,
+    int64_t a_nb1
+) {
+    memset(A_pack, 0, (size_t)(TMU_M_TILE_MAX * K_chunk) * sizeof(float));
+
+    for (int64_t r = 0; r < m_tile; ++r) {
+        const int64_t m = m0 + r;
+        float *dst = A_pack + r * K_chunk;
+
+        const char *src_row = A_base_d23 + m * a_nb1 + k0 * a_nb0;
+        for (int64_t kk = 0; kk < K_chunk; ++kk) {
+            dst[kk] = *(const float *)(src_row + kk * a_nb0);
+        }
+    }
+}
+
+static inline void pack_B_tile_f32(
+    float *B_pack,             // [TMU_N_BLOCK * K_chunk]
+    const char *B_base_d23,     // src1->data already offset for d2/d3
+    int64_t n0,
+    int64_t n_valid,
+    int64_t k0,
+    int64_t K_chunk,
+    int64_t b_nb0,
+    int64_t b_nb1
+) {
+    memset(B_pack, 0, (size_t)(TMU_N_BLOCK * K_chunk) * sizeof(float));
+
+    for (int64_t c = 0; c < n_valid; ++c) {
+        const int64_t n = n0 + c;
+        float *dst = B_pack + c * K_chunk;
+
+        const char *src_col = B_base_d23 + n * b_nb1 + k0 * b_nb0;
+        for (int64_t kk = 0; kk < K_chunk; ++kk) {
+            dst[kk] = *(const float *)(src_col + kk * b_nb0);
+        }
+    }
+}
+
+// ============================================================================
+// REUSABLE BUFFERS — allocated once per process
+// ============================================================================
+
+static float *g_A_pack = nullptr;   // 64 * 2048
+static float *g_B_pack = nullptr;   // 32 * 2048
+static float *g_C_tile = nullptr;   // 64 * 32
+static int    g_pack_maxK = 0;
+
+static std::once_flag g_tmu_buf_once;
+
+static inline void ensure_tmu_pack_buffers() {
+    std::call_once(g_tmu_buf_once, []() {
+        const int maxK = 2048; // fixed maximum bucket
+
+        g_pack_maxK = maxK;
+
+        g_A_pack = (float *) tsi_alloc((size_t)TMU_M_TILE_MAX * (size_t)maxK * sizeof(float));
+        g_B_pack = (float *) tsi_alloc((size_t)TMU_N_BLOCK     * (size_t)maxK * sizeof(float));
+        g_C_tile = (float *) tsi_alloc((size_t)TMU_M_TILE_MAX * (size_t)TMU_N_BLOCK * sizeof(float));
+
+        TSAVORITE_GGML_ASSERT(g_A_pack && g_B_pack && g_C_tile);
+    });
+}
+
 static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     struct ggml_backend_tsavorite_context * /*ctx*/,
     txe_device_s device,

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -440,6 +440,7 @@ parse_args() {
   ENABLE_TRITON_ADD=1
   ENABLE_TRITON_MAT_MUL=1
   __EXPECT_TRITON_ARG=0
+  ENABLE_TRITON_DEBUG=0
 
   local a
   for a in "$@"; do
@@ -464,6 +465,11 @@ parse_args() {
         __EXPECT_TRITON_ARG=1
         log_info "triton option detected; expecting one of: add | mat_mul | all"
         ;;
+
+      triton-debug)
+         ENABLE_TRITON_DEBUG=1
+         log_info "TRITON_DEBUG enabled"
+         ;;
 
       add)
         if [ "${__EXPECT_TRITON_ARG}" -eq 1 ]; then
@@ -642,6 +648,7 @@ parse_args() {
   # Export so other functions/scripts can use it
   export ENABLE_TRITON_ADD
   export ENABLE_TRITON_MAT_MUL
+  export ENABLE_TRITON_DEBUG
   return 0
 }
 
@@ -889,7 +896,7 @@ build_posix_impl() {
   [ "${want_tmu}" -eq 1 ] && supported="${supported} -DTMU_SUPPORTED"
   [ "${want_tvu}" -eq 1 ] && supported="${supported} -DTVU_SUPPORTED"
 
-  local triton_defs="-DTRITON_ADD=${ENABLE_TRITON_ADD} -DTRITON_MAT_MUL=${ENABLE_TRITON_MAT_MUL}"
+  local triton_defs="-DTRITON_ADD=${ENABLE_TRITON_ADD} -DTRITON_MAT_MUL=${ENABLE_TRITON_MAT_MUL} -DTRITON_DEBUG=${ENABLE_TRITON_DEBUG}"
 
   local cflags_base="-DGGML_TARGET_POSIX -DGGML_TSAVORITE ${supported} ${triton_defs} -mno-amx-tile -mno-amx-int8 -mno-amx-bf16 -mno-avx512bf16 -mno-avxvnni"
 
@@ -957,7 +964,7 @@ build_fpga_impl() {
   [ "${want_tmu}" -eq 1 ] && supported="${supported} -DTMU_SUPPORTED"
   [ "${want_tvu}" -eq 1 ] && supported="${supported} -DTVU_SUPPORTED"
 
-  local triton_defs="-DTRITON_ADD=${ENABLE_TRITON_ADD} -DTRITON_MAT_MUL=${ENABLE_TRITON_MAT_MUL}"
+  local triton_defs="-DTRITON_ADD=${ENABLE_TRITON_ADD} -DTRITON_MAT_MUL=${ENABLE_TRITON_MAT_MUL} -DTRITON_DEBUG=${ENABLE_TRITON_DEBUG}"
 
   run cmake -B "${build_dir}" \
     -DCMAKE_TOOLCHAIN_FILE="${ARM_TOOLCHAIN_FILE}" \


### PR DESCRIPTION

July 1st tested, Multi-threading disable result on tsisim
[>4;mroot@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0
Failed to generate tool call example: Value is not callable: null at row 1, column 72:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                                                       ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 13:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
            ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 1:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

 is not mentioned in the

llama_perf_sampler_print:    sampling time =     153.38 ms /     9 runs   (   17.04 ms per token,    58.68 tokens per second)
llama_perf_context_print:        load time = 9616483.06 ms
llama_perf_context_print: prompt eval time = 9600088.83 ms /     4 tokens (2400022.21 ms per token,     0.00 tokens per second)


llama_perf_context_print:        eval time =   18140.95 ms /     4 runs   ( 4535.24 ms per token,     0.22 tokens per second)
llama_perf_context_print:       total time = 9634814.48 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          660             834           8302095          12578.93
  MUL              OPU          671             848           7905864          11782.21
  RMS_NORM         OPU          671             671          14866372          22155.55
  MUL_MAT          CPU        11419               0          15580150           1364.41
  MUL_MAT          OPU          117             117        9584204037       81916273.82
  CONT             OPU          660               0           1237395           1874.84
  RESHAPE          CPU         3913               0              8776              2.24
  VIEW             CPU         3874               0              9109              2.35
  VIEW             OPU          660               0               999              1.51
  PERMUTE          CPU         2542               0              8075              3.18
  PERMUTE          OPU          660               0              1742              2.64
  TRANSPOSE        CPU         1233               0              2906              2.36
  GET_ROWS         OPU           33               0               688             20.85
  SET_ROWS         CPU         2611               0             42221             16.17
  SOFT_MAX         OPU          330               0            248878            754.18
  ROPE             CPU         2593               0             61688             23.79
  GLU              OPU          330             417          22152182          67127.82

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 




##########
Multi-TXE enabled 
TSISIM result
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=2 multi_thread_enable=1


is Luna.




llama_perf_sampler_print:    sampling time =     245.18 ms /    11 runs   (   22.29 ms per token,    44.87 tokens per second)
llama_perf_context_print:        load time = 7568701.44 ms
llama_perf_context_print: prompt eval time = 7462570.51 ms /     6 tokens (1243761.75 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time =  136468.73 ms /     4 runs   (34117.18 ms per token,     0.03 tokens per second)
llama_perf_context_print:       total time = 7706038.95 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          484             694          13507227          27907.49
  MUL              OPU          495             710           2489475           5029.24
  RMS_NORM         OPU          495             495           6579956          13292.84
  MUL_MAT          CPU         8550               0        1003404365         117357.24
  MUL_MAT          OPU           22              44        7364142102      334733731.91
  CONT             OPU          484               0           1915535           3957.72
  RESHAPE          CPU         2771               0             15493              5.59
  VIEW             CPU         2697               0              8554              3.17
  VIEW             OPU          484               0             67016            138.46
  PERMUTE          CPU         1798               0              6661              3.70
  PERMUTE          OPU          484               0               995              2.06
  TRANSPOSE        CPU          820               0              2613              3.19
  GET_ROWS         OPU           33               0              6709            203.30
  SET_ROWS         CPU         1905               0            281271            147.65
  SOFT_MAX         OPU          242               0            720200           2976.03
  ROPE             CPU         1851               0             93721             50.63
  GLU              OPU          242             347          64303759         265718.01

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 



root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=2 multi_thread_enable=1
MUL_MAT_REJECT_SS1345: K=576 M=49280 N=512 M_pad=49280 N_pad=512 total_bytes=215646208 limit=46137344 a=[576,49280,1,1] b=[576,512,1,1] op=[49280,512,1,1]
MUL_MAT_REJECT_SS1345: K=576 M=49280 N=1 M_pad=49280 N_pad=64 total_bytes=126304256 limit=46137344 a=[576,49280,1,1] b=[576,1,1,1] op=[49280,1,1,1]
Failed to generate tool call example: Value is not callable: null at row 1, column 72:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                                                       ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 42:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
                                         ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 13:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
            ^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}
 at row 1, column 1:
<|im_start|>{% for message in messages %}{{message['role'] | capitalize}}{% if message['content'][0]['type'] == 'image' %}{{':'}}{% else %}{{': '}}{% endif %}{% for line in message['content'] %}{% if line['type'] == 'text' %}{{line['text']}}{% elif line['type'] == 'image' %}{{ '<image>' }}{% endif %}{% endfor %}<end_of_utterance>
^
{% endfor %}{% if add_generation_prompt %}{{ 'Assistant:' }}{% endif %}

is not mentioned in the



llama_perf_sampler_print:    sampling time =     153.44 ms /     9 runs   (   17.05 ms per token,    58.66 tokens per second)
llama_perf_context_print:        load time = 4889416.88 ms
llama_perf_context_print: prompt eval time = 4863297.03 ms /     4 tokens (1215824.26 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time =   17794.12 ms /     4 runs   ( 4448.53 ms per token,     0.22 tokens per second)
llama_perf_context_print:       total time = 4907399.11 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          660             834           9373583          14202.40
  MUL              OPU          671             848           1054673           1571.79
  RMS_NORM         OPU          671             671            491162            731.99
  MUL_MAT          CPU        11425               0          14050687           1229.82
  MUL_MAT          OPU          117             234        4849568568       41449304.00
  CONT             OPU          660               0           1398337           2118.69
  RESHAPE          CPU         3862               0             12552              3.25
  VIEW             CPU         3830               0              6523              1.70
  VIEW             OPU          660               0              1391              2.11
  PERMUTE          CPU         2490               0              5821              2.34
  PERMUTE          OPU          660               0               913              1.38
  TRANSPOSE        CPU         1231               0              3402              2.76
  GET_ROWS         OPU           33               0              2327             70.52
  SET_ROWS         CPU         2612               0             53960             20.66
  SOFT_MAX         OPU          330               0            239166            724.75
  ROPE             CPU         2564               0             96291             37.55
  GLU              OPU          330             417          22219512          67331.85

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 


#####
Performance result
https://tsavoritesi.atlassian.net/wiki/x/B4CxZg



