### PR TITLE
@FIR-2057 llama.cpp: Regression: MAT_MUL Fails Due to Pack-Args Order…

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -2814,12 +2814,12 @@ static void *_mlir_ciface_matmul_kernel_memory_wrapper_triton_manual_internal(
     int idx = 0;
 
     // M,N,K,A,B,C,grid1,grid2,grid3
-    tsi_pack_triton_matmul_arg(p, idx, M_desc,     "M");
-    tsi_pack_triton_matmul_arg(p, idx, N_desc,     "N");
-    tsi_pack_triton_matmul_arg(p, idx, K_desc,     "K");
     tsi_pack_triton_matmul_arg(p, idx, A_desc,     "A");
     tsi_pack_triton_matmul_arg(p, idx, B_desc,     "B");
     tsi_pack_triton_matmul_arg(p, idx, C_desc,     "C");
+    tsi_pack_triton_matmul_arg(p, idx, M_desc,     "M");
+    tsi_pack_triton_matmul_arg(p, idx, N_desc,     "N");
+    tsi_pack_triton_matmul_arg(p, idx, K_desc,     "K");
     tsi_pack_triton_matmul_arg(p, idx, grid1_desc, "grid1");
     tsi_pack_triton_matmul_arg(p, idx, grid2_desc, "grid2");
     tsi_pack_triton_matmul_arg(p, idx, grid3_desc, "grid3");


### PR DESCRIPTION
This can't be tested on posix

Tested on internal8
hence attaching Tsisim result with 20 txe


root@tsisim:/tsi/tsi-sw# ./check_tsictl.sh 
Index 0:     execute_blob_count   : 1740
Index 1:     execute_blob_count   : 293
Index 2:     execute_blob_count   : 293
Index 3:     execute_blob_count   : 292
Index 4:     execute_blob_count   : 204
Index 5:     execute_blob_count   : 204
Index 6:     execute_blob_count   : 98
Index 7:     execute_blob_count   : 97
Index 8:     execute_blob_count   : 98
Index 9:     execute_blob_count   : 97
Index 10:     execute_blob_count   : 97
Index 11:     execute_blob_count   : 97
Index 12:     execute_blob_count   : 97
Index 13:     execute_blob_count   : 97
Index 14:     execute_blob_count   : 97
Index 15:     execute_blob_count   : 97
Index 16:     execute_blob_count   : 97
Index 17:     execute_blob_count   : 97
Index 18:     execute_blob_count   : 96
Index 19:     execute_blob_count   : 95
root@tsisim:/tsi/tsi-sw# 



Gemma Model successful run

is "cat" and



llama_perf_sampler_print:    sampling time =     107.50 ms /    11 runs   (    9.77 ms per token,   102.32 tokens per second)
llama_perf_context_print:        load time =  279479.28 ms
llama_perf_context_print: prompt eval time =  276491.79 ms /     6 tokens (46081.97 ms per token,     0.02 tokens per second)
llama_perf_context_print:        eval time =   32094.01 ms /     4 runs   ( 8023.50 ms per token,     0.12 tokens per second)
llama_perf_context_print:       total time =  311693.90 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          396             566          12459876          31464.33
  MUL              OPU         1199            2588            572976            477.88
  RMS_NORM         OPU         1199            1199            156701            130.69
  MUL_MAT          CPU         6803               0          11953900           1757.15
  MUL_MAT          OPU           69            1380         249968512        3622732.06
  SCALE            CPU          209               0              1475              7.06
  CONT             OPU          396               0             95530            241.24
  RESHAPE          CPU         1824               0              1872              1.03
  VIEW             CPU         1512               0               270              0.18
  VIEW             OPU          396               0               174              0.44
  PERMUTE          CPU          937               0               253              0.27
  PERMUTE          OPU          396               0               145              0.37
  TRANSPOSE        CPU          398               0                68              0.17
  GET_ROWS         OPU           33               0              1127             34.15
  SET_ROWS         CPU         1229               0              7612              6.19
  SOFT_MAX         OPU          198               0             17716             89.47
  ROPE             CPU          740               0              7281              9.84
  ROPE             OPU          198               0              5901             29.80
  GLU              CPU          711               0             69103             97.19
HAL TRACE: hal_lib_deinit: complete

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# cd tsi-ggml
root@tsisim:/usr/bin/tsi/bin/tsi-ggml# ./simple-backend-tsi mat-mul

MAT_MUL test: A=[256,8,1,1] B=[256,64,1,1] C=[8,64,1,1]

 TSI deploy yaml=/usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1
HAL INFO:  hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x3c000000
HAL DEBUG: hal_lib_init: chiplet 0 va=0xe5bf58c80000
HAL DEBUG: hal_lib_init: chiplet 1 va=0xe5bf94c80000
HAL DEBUG: hal_lib_init: chiplet 2 va=0xe5bfd0c80000
HAL DEBUG: hal_lib_init: chiplet 3 va=0xe5c00cc80000
HAL DEBUG: hal_lib_init: chiplet 4 va=0xe5c048c80000
HAL DEBUG: hal_lib_init: chiplet 5 va=0xe5c084c80000
HAL DEBUG: hal_lib_init: chiplet 6 va=0xe5c0c0c80000
HAL DEBUG: hal_lib_init: chiplet 7 va=0xe5c0fcc80000
HAL DEBUG: hal_lib_init: chiplet 8 va=0xe5c138c80000
HAL DEBUG: hal_lib_init: chiplet 9 va=0xe5c174c80000
HAL INFO:  hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
MAT_MUL compute buffer size: 2.3750 KB
TRITON_MATMUL_OFFLOADED_SHAPE: A=[256,8,1,1] B=[256,64,1,1] node=[8,64,1,1]
TRITON_MATMUL_PACK_ARG: A data=0xe5bf58875080 handle=21474791552 shape0=2048 offset=0 stride0=1
TRITON_MATMUL_PACK_ARG: B data=0xe5bf58805080 handle=21474332800 shape0=16384 offset=0 stride0=1
TRITON_MATMUL_PACK_ARG: C data=0xe5bf58879080 handle=21474807936 shape0=512 offset=0 stride0=1
TRITON_MATMUL_PACK_ARG: M data=0xe5bf5887a680 handle=21474813568 shape0=8 offset=0 stride0=1
TRITON_MATMUL_PACK_ARG: N data=0xe5bf5887a880 handle=21474814080 shape0=64 offset=0 stride0=1
TRITON_MATMUL_PACK_ARG: K data=0xe5bf5887aa80 handle=21474814592 shape0=256 offset=0 stride0=1
TRITON_MATMUL_PACK_ARG: grid1 data=0xe5bf5887ac80 handle=21474815104 shape0=1 offset=0 stride0=1
TRITON_MATMUL_PACK_ARG: grid2 data=0xe5bf5887ae80 handle=21474815616 shape0=1 offset=0 stride0=1
TRITON_MATMUL_PACK_ARG: grid3 data=0xe5bf5887b080 handle=21474816128 shape0=1 offset=0 stride0=1

MAT_MUL TEST PASSED

HAL TRACE: hal_lib_deinit: complete

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin/tsi-ggml# 



Tiny-Llama-v0.3-FP32-1.1B-F32.gguf model run
###########
is Luna.




llama_perf_sampler_print:    sampling time =      22.19 ms /    11 runs   (    2.02 ms per token,   495.81 tokens per second)
llama_perf_context_print:        load time =  350386.62 ms
llama_perf_context_print: prompt eval time =  345817.78 ms /     6 tokens (57636.30 ms per token,     0.02 tokens per second)
llama_perf_context_print:        eval time =   52532.82 ms /     4 runs   (13133.20 ms per token,     0.08 tokens per second)
llama_perf_context_print:       total time =  403001.19 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          484             694          28785936          59475.07
  MUL              OPU          495             710            122364            247.20
  RMS_NORM         OPU          495             495             93447            188.78
  MUL_MAT          CPU         8471               0          96210044          11357.58
  MUL_MAT          OPU           22             440         290826301       13219377.32
  CONT             OPU          484               0            128134            264.74
  RESHAPE          CPU         2009               0              3150              1.57
  VIEW             CPU         1767               0               500              0.28
  VIEW             OPU          484               0              9208             19.02
  PERMUTE          CPU         1135               0               624              0.55
  PERMUTE          OPU          484               0               164              0.34
  TRANSPOSE        CPU          479               0               195              0.41
  GET_ROWS         OPU           33               0              3835            116.21
  SET_ROWS         CPU         1449               0             73121             50.46
  SOFT_MAX         OPU          242               0            167073            690.38
  ROPE             CPU         1716               0             19472             11.35
  GLU              OPU          242             347          40029269         165410.20
HAL TRACE: hal_lib_deinit: complete

OPU Profiling Results:
Profiler disabled







