### PR TITLE
@FIR-2061 - llama.cpp:Read TXE count from /etc/taos/taos.json and aut…

### DIFF
--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1004,13 +1004,12 @@ bundle_fpga() {
   local build_dir="$1"
   log_info "creating tar bundle for fpga (${build_dir})"
 
-  # REQUIRED CHANGE: local version now comes from SDK_VERSION (default 0.4.0)
   local TSI_GGML_VERSION="${SDK_VERSION}"
-
   local TSI_GGML_BUNDLE_INSTALL_DIR=tsi-ggml
   local GGML_TSI_INSTALL_DIR=ggml-tsi-kernel
   local TSI_GGML_RELEASE_DIR=/proj/rel/sw/ggml
   local TSI_BLOB_INSTALL_DIR
+
   TSI_BLOB_INSTALL_DIR="$(pwd)/${GGML_TSI_INSTALL_DIR}/fpga-kernel/build-fpga"
 
   [ -f "${build_dir}/bin/llama-cli" ] || die "package requested but ${build_dir}/bin/llama-cli not found. Run an FPGA build first."
@@ -1020,7 +1019,88 @@ bundle_fpga() {
 
 cat > "./${TSI_GGML_BUNDLE_INSTALL_DIR}/ggml.sh" <<'EOL'
 #!/bin/bash
+
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)
+
+TAOS_CONFIG_PATH="/etc/taos/taos.json"
+
+update_one_tsavorite_deployment_yaml() {
+  local deployment_yaml_path="$1"
+  local txe_count="$2"
+
+  mkdir -p "$(dirname "${deployment_yaml_path}")" || return 1
+
+  cat > "${deployment_yaml_path}" <<EOF
+# Tsavorite deployment config
+txe_count:${txe_count}
+multi_thread_enable: true
+EOF
+
+  echo "INFO: updated ${deployment_yaml_path} with txe_count:${txe_count}, multi_thread_enable:true"
+  return 0
+}
+
+read_txe_count_from_taos_json() {
+  if [ ! -f "${TAOS_CONFIG_PATH}" ]; then
+    echo "WARNING: ${TAOS_CONFIG_PATH} not found; using conservative default txe_count=1" >&2
+    echo "1"
+    return 0
+  fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: ${TAOS_CONFIG_PATH} exists but python3 was not found; cannot parse JSON." >&2
+    return 1
+  fi
+
+  python3 - <<'PY'
+import json
+import sys
+
+path = "/etc/taos/taos.json"
+
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+except Exception as e:
+    print(f"ERROR: failed to parse {path}: {e}", file=sys.stderr)
+    sys.exit(2)
+
+if not isinstance(data, dict):
+    print(f"ERROR: {path} must contain a JSON object like {{\"txe_count\": 20}}", file=sys.stderr)
+    sys.exit(2)
+
+if set(data.keys()) != {"txe_count"}:
+    print(f"ERROR: {path} must contain exactly one field: txe_count", file=sys.stderr)
+    sys.exit(2)
+
+txe_count = data.get("txe_count")
+
+if isinstance(txe_count, bool) or not isinstance(txe_count, int) or txe_count < 1:
+    print(f"ERROR: {path} field txe_count must be an integer >= 1", file=sys.stderr)
+    sys.exit(2)
+
+print(txe_count)
+PY
+}
+
+update_tsavorite_deployment_yaml_from_taos() {
+  local txe_count=""
+  local script_dir=""
+
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+  txe_count="$(read_txe_count_from_taos_json)" || return 1
+
+  update_one_tsavorite_deployment_yaml "${script_dir}/tsavorite-model-deployment.yaml" "${txe_count}" || return 1
+
+  if [ -d "${script_dir}/../bin" ] || [ -f "${script_dir}/../bin/tsavorite-model-deployment.yaml" ]; then
+    update_one_tsavorite_deployment_yaml "${script_dir}/../bin/tsavorite-model-deployment.yaml" "${txe_count}" || return 1
+  fi
+
+  return 0
+}
+
+update_tsavorite_deployment_yaml_from_taos || exit 1
 
 tsi_kernels=(
   "add" "sub" "mult" "div" "abs" "inv" "neg" "sin" "sqrt" "sqr" "sigmoid" "silu" "rms_norm" "swiglu"
@@ -1063,32 +1143,26 @@ EOL
   cp "${build_dir}/bin/libllama"*.so "${TSI_GGML_BUNDLE_INSTALL_DIR}/" || return 1
   cp "${build_dir}/bin/simple-backend-tsi" "${TSI_GGML_BUNDLE_INSTALL_DIR}/" || return 1
 
-  # REQUIRED ADDITION: include tsavorite-model-deployment.yaml in same dir as .so
-  local yaml_src=""
-  if [ -n "${TSAVORITE_DEPLOYMENT_YAML_SRC:-}" ]; then
-    yaml_src="${TSAVORITE_DEPLOYMENT_YAML_SRC}"
-  elif [ -f "./tsavorite-model-deployment.yaml" ]; then
-    yaml_src="./tsavorite-model-deployment.yaml"
-  elif [ -n "${__TSI_SCRIPT_DIR}" ] && [ -f "${__TSI_SCRIPT_DIR}/tsavorite-model-deployment.yaml" ]; then
-    yaml_src="${__TSI_SCRIPT_DIR}/tsavorite-model-deployment.yaml"
-  fi
+  cat > "${TSI_GGML_BUNDLE_INSTALL_DIR}/tsavorite-model-deployment.yaml" <<'EOF'
+# Tsavorite deployment config
+txe_count:1
+multi_thread_enable: true
+EOF
 
-  if [ -n "${yaml_src}" ]; then
-    cp "${yaml_src}" "${TSI_GGML_BUNDLE_INSTALL_DIR}/tsavorite-model-deployment.yaml" || return 1
-    log_info "included tsavorite-model-deployment.yaml from: ${yaml_src}"
-  else
-    log_info "WARNING: tsavorite-model-deployment.yaml not found; bundle will not include it (set TSAVORITE_DEPLOYMENT_YAML_SRC to override)."
-  fi
+  log_info "included default tsavorite-model-deployment.yaml with txe_count:1 and multi_thread_enable:true; ggml.sh updates same-dir yaml and ../bin yaml when present."
 
   tar -cvzf "${TSI_GGML_BUNDLE_INSTALL_DIR}-${TSI_GGML_VERSION}.tz" "${TSI_GGML_BUNDLE_INSTALL_DIR}"/* || return 1
 
   if [ "$(tolower "$BUILD_TYPE")" = "release" ]; then
     cp "${TSI_GGML_BUNDLE_INSTALL_DIR}-${TSI_GGML_VERSION}.tz" "${TSI_GGML_RELEASE_DIR}/" || return 1
+
     local LATEST_TZ="${TSI_GGML_BUNDLE_INSTALL_DIR}-${TSI_GGML_VERSION}.tz"
     local LATEST_FULL_PATH="${TSI_GGML_RELEASE_DIR}/$(basename "$LATEST_TZ")"
+
     rm -f "${TSI_GGML_RELEASE_DIR}/tsi-ggml-aws-latest.tz" "${TSI_GGML_RELEASE_DIR}/tsi-ggml-latest.tz"
     ln -s "/aws${LATEST_FULL_PATH}" "${TSI_GGML_RELEASE_DIR}/tsi-ggml-aws-latest.tz"
     ln -s "${LATEST_FULL_PATH}" "${TSI_GGML_RELEASE_DIR}/tsi-ggml-latest.tz"
+
     log_info "Symlinks updated to point to $(basename "$LATEST_FULL_PATH")"
   fi
 


### PR DESCRIPTION
following cases tested
1 /etc/taos/taos.json ---txe_count(20 & 18)
2 remove this file and tested we are switching to default config for llama.cpp which is 1 txe.
PLease see all test cases logs

deployment file update
root@tsisim:/usr/bin/tsi/bin/tsi-ggml# 
root@tsisim:/usr/bin/tsi/bin/tsi-ggml# vi tsavorite-model-deployment.yaml 
[>4;mroot@tsisim:/usr/bin/tsi/bin/tsi-ggml# ./ggml.sh
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true
root@tsisim:/usr/bin/tsi/bin/tsi-ggml# vi tsavorite-model-deployment.yaml 
[>4;mroot@tsisim:/usr/bin/tsi/bin/tsi-ggml# 
root@tsisim:/usr/bin/tsi/bin/tsi-ggml# 
root@tsisim:/usr/bin/tsi/bin/tsi-ggml# cd ..
root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1
HAL INFO:  hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x3c000000
HAL DEBUG: hal_lib_init: chiplet 0 va=0xfc634c370000
HAL DEBUG: hal_lib_init: chiplet 1 va=0xfc6388370000
HAL DEBUG: hal_lib_init: chiplet 2 va=0xfc63c4370000
HAL DEBUG: hal_lib_init: chiplet 3 va=0xfc6400370000
HAL DEBUG: hal_lib_init: chiplet 4 va=0xfc643c370000
HAL DEBUG: hal_lib_init: chiplet 5 va=0xfc6478370000
HAL DEBUG: hal_lib_init: chiplet 6 va=0xfc64b4370000
HAL DEBUG: hal_lib_init: chiplet 7 va=0xfc64f0370000
HAL DEBUG: hal_lib_init: chiplet 8 va=0xfc652c370000
HAL DEBUG: hal_lib_init: chiplet 9 va=0xfc6568370000
HAL INFO:  hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
 is "cat" and

llama_perf_sampler_print:    sampling time =     106.95 ms /    11 runs   (    9.72 ms per token,   102.85 tokens per second)
llama_perf_context_print:        load time =  274338.32 ms
llama_perf_context_print: prompt eval time =  267419.82 ms /     6 tokens (44569.97 ms per token,     0.02 tokens per second)
llama_perf_context_print:        eval time =   31017.22 ms /     4 runs   ( 7754.30 ms per token,     0.13 tokens per second)
llama_perf_context_print:       total time =  305475.83 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          396             566          12083534          30513.97
  MUL              OPU         1199            2588            532261            443.92
  RMS_NORM         OPU         1199            1199            159835            133.31
  MUL_MAT          CPU         6800               0          11413703           1678.49
  MUL_MAT          OPU           69            1380         241468833        3499548.30
  SCALE            CPU          209               0              1491              7.13
  CONT             OPU          396               0             95720            241.72
  RESHAPE          CPU         1771               0              1905              1.08
  VIEW             CPU         1426               0               193              0.14
  VIEW             OPU          396               0               215              0.54
  PERMUTE          CPU          959               0               277              0.29
  PERMUTE          OPU          396               0               136              0.34
  TRANSPOSE        CPU          407               0                76              0.19
  GET_ROWS         OPU           33               0               446             13.52
  SET_ROWS         CPU         1229               0              7377              6.00
  SOFT_MAX         OPU          198               0             16614             83.91
  ROPE             CPU          716               0              7224             10.09
  ROPE             OPU          198               0              6174             31.18
  GLU              CPU          702               0             66191             94.29


HAL TRACE: hal_lib_deinit: complete

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:18, multi_thread_enable:true

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=18 multi_thread_enable=1
HAL INFO:  hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x3c000000
HAL DEBUG: hal_lib_init: chiplet 0 va=0xf85e01e50000
HAL DEBUG: hal_lib_init: chiplet 1 va=0xf85e3de50000
HAL DEBUG: hal_lib_init: chiplet 2 va=0xf85e79e50000
HAL DEBUG: hal_lib_init: chiplet 3 va=0xf85eb5e50000
HAL DEBUG: hal_lib_init: chiplet 4 va=0xf85ef1e50000
HAL DEBUG: hal_lib_init: chiplet 5 va=0xf85f2de50000
HAL DEBUG: hal_lib_init: chiplet 6 va=0xf85f69e50000
HAL DEBUG: hal_lib_init: chiplet 7 va=0xf85fa5e50000
HAL DEBUG: hal_lib_init: chiplet 8 va=0xf85fe1e50000
HAL DEBUG: hal_lib_init: chiplet 9 va=0xf8601de50000
HAL INFO:  hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
 is "cat" and



llama_perf_sampler_print:    sampling time =     106.18 ms /    11 runs   (    9.65 ms per token,   103.60 tokens per second)
llama_perf_context_print:        load time =    9947.21 ms
llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =   31234.71 ms /     4 runs   ( 7808.68 ms per token,     0.13 tokens per second)
llama_perf_context_print:       total time =   33450.04 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          360             360           7706627          21407.30
  MUL              OPU         1090            1630            177369            162.72
  RMS_NORM         OPU         1090            1090            149004            136.70
  MUL_MAT          CPU         6485               0          10654925           1643.01
  SCALE            CPU          190               0              1226              6.45
  CONT             OPU          360               0             87823            243.95
  RESHAPE          CPU         1667               0              1612              0.97
  VIEW             CPU         1322               0               218              0.16
  VIEW             OPU          360               0               181              0.50
  PERMUTE          CPU          835               0               174              0.21
  PERMUTE          OPU          360               0               116              0.32
  TRANSPOSE        CPU          376               0                56              0.15
  GET_ROWS         OPU           30               0               307             10.23
  SET_ROWS         CPU         1108               0              4973              4.49
  SOFT_MAX         OPU          180               0             10579             58.77
  ROPE             CPU          620               0              5093              8.21
  ROPE             OPU          180               0              4586             25.48
  GLU              CPU          660               0             36241             54.91
HAL TRACE: hal_lib_deinit: complete

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# tail -f ./tsi-ggml/tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count:18
multi_thread_enable: true

###########
First tested with 20

now change the file to 18 and also tested

root@tsisim:/tsi/tsi-sw# 
root@tsisim:/tsi/tsi-sw# 
root@tsisim:/tsi/tsi-sw# cat /etc/taos/taos.json 
{
  "txe_count": 18
}
root@tsisim:/tsi/tsi-sw# 
root@tsisim:/tsi/tsi-sw# 

###############
REMOVED the file and tested


oot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# cat ./tsi-ggml/tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count:1
multi_thread_enable: true
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ls -lrt /etc/taos/
total 4
-rwxrwxrwx 1 root root 22 Jul 11 03:56 taos.json_1
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
WARNING: /etc/taos/taos.json not found; using conservative default txe_count=1
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:1, multi_thread_enable:true

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1
HAL INFO:  hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x3c000000
HAL DEBUG: hal_lib_init: chiplet 0 va=0xfa046f510000
HAL DEBUG: hal_lib_init: chiplet 1 va=0xfa04ab510000
HAL DEBUG: hal_lib_init: chiplet 2 va=0xfa04e7510000
HAL DEBUG: hal_lib_init: chiplet 3 va=0xfa0523510000
HAL DEBUG: hal_lib_init: chiplet 4 va=0xfa055f510000
HAL DEBUG: hal_lib_init: chiplet 5 va=0xfa059b510000
HAL DEBUG: hal_lib_init: chiplet 6 va=0xfa05d7510000
HAL DEBUG: hal_lib_init: chiplet 7 va=0xfa0613510000
HAL DEBUG: hal_lib_init: chiplet 8 va=0xfa064f510000
HAL DEBUG: hal_lib_init: chiplet 9 va=0xfa068b510000
HAL INFO:  hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
 was Tim. He loved



llama_perf_sampler_print:    sampling time =      13.88 ms /    11 runs   (    1.26 ms per token,   792.22 tokens per second)
llama_perf_context_print:        load time =    4137.13 ms
llama_perf_context_print: prompt eval time =    3714.32 ms /     6 tokens (  619.05 ms per token,     1.62 tokens per second)
llama_perf_context_print:        eval time =    3543.95 ms /     4 runs   (  885.99 ms per token,     1.13 tokens per second)
llama_perf_context_print:       total time =    7697.90 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          176             246           3421146          19438.33
  MUL              OPU          187             262            954878           5106.30
  RMS_NORM         OPU          187             187             15261             81.61
  MUL_MAT          CPU         2798               0            308771            110.35
  CONT             OPU          176               0             10070             57.22
  RESHAPE          CPU          601               0               163              0.27
  VIEW             CPU          629               0                76              0.12
  VIEW             OPU          176               0               106              0.60
  PERMUTE          CPU          392               0                81              0.21
  PERMUTE          OPU          176               0                36              0.20
  TRANSPOSE        CPU          194               0                37              0.19
  GET_ROWS         OPU           33               0                85              2.58
  SET_ROWS         CPU          580               0              1448              2.50
  SOFT_MAX         OPU           88               0             30440            345.91
  ROPE             CPU          489               0              1292              2.64
  GLU              OPU           88             123           2013224          22877.55
HAL TRACE: hal_lib_deinit: complete

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# vi ./tsi-ggml/tsavorite-model-deployment.yaml 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# cat ./tsi-ggml/tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count:2
multi_thread_enable: true
root@tsisim:/usr/bin/tsi/bin# ls -lrt /etc/taos/
total 4
-rwxrwxrwx 1 root root 22 Jul 11 03:56 taos.json_1
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
WARNING: /etc/taos/taos.json not found; using conservative default txe_count=1
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:1, multi_thread_enable:true

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1
HAL INFO:  hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x3c000000
HAL DEBUG: hal_lib_init: chiplet 0 va=0xfdabe3b30000
HAL DEBUG: hal_lib_init: chiplet 1 va=0xfdac1fb30000
HAL DEBUG: hal_lib_init: chiplet 2 va=0xfdac5bb30000
HAL DEBUG: hal_lib_init: chiplet 3 va=0xfdac97b30000
HAL DEBUG: hal_lib_init: chiplet 4 va=0xfdacd3b30000
HAL DEBUG: hal_lib_init: chiplet 5 va=0xfdad0fb30000
HAL DEBUG: hal_lib_init: chiplet 6 va=0xfdad4bb30000
HAL DEBUG: hal_lib_init: chiplet 7 va=0xfdad87b30000
HAL DEBUG: hal_lib_init: chiplet 8 va=0xfdadc3b30000
HAL DEBUG: hal_lib_init: chiplet 9 va=0xfdadffb30000
HAL INFO:  hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
 was Tim. He loved



llama_perf_sampler_print:    sampling time =      14.12 ms /    11 runs   (    1.28 ms per token,   778.82 tokens per second)
llama_perf_context_print:        load time =    1259.92 ms
llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =    3617.94 ms /     4 runs   (  904.48 ms per token,     1.11 tokens per second)
llama_perf_context_print:       total time =    3985.52 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          160             160           2271612          14197.58
  MUL              OPU          170             170             17269            101.58
  RMS_NORM         OPU          170             170             19701            115.89
  MUL_MAT          CPU         2598               0            225470             86.79
  CONT             OPU          160               0              9507             59.42
  RESHAPE          CPU          526               0               141              0.27
  VIEW             CPU          547               0                67              0.12
  VIEW             OPU          160               0                77              0.48
  PERMUTE          CPU          355               0                78              0.22
  PERMUTE          OPU          160               0                61              0.38
  TRANSPOSE        CPU          171               0                26              0.15
  GET_ROWS         OPU           30               0               158              5.27
  SET_ROWS         CPU          489               0              1173              2.40
  SOFT_MAX         OPU           80               0             17664            220.80
  ROPE             CPU          439               0              2104              4.79
  GLU              OPU           80              80           1335758          16696.97
HAL TRACE: hal_lib_deinit: complete

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# cat ./tsi-ggml/tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count:1
multi_thread_enable: true
root@tsisim:/usr/bin/tsi/bin# 


