### PR TITLE
@FIR-2019-  Optimize Triton MAT_MUL for small-N shapes using transpos…

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3727,7 +3727,19 @@ static inline void init_scalar_i32_memref_aligned(
 }
 
 static inline int64_t tsi_round_up_i64(int64_t v, int64_t a) {
-    return ((v + a - 1) / a) * a;
+    if (v <= 0 || a <= 0) {
+        return 0;
+    }
+
+    const unsigned __int128 uv = (unsigned __int128)(uint64_t)v;
+    const unsigned __int128 ua = (unsigned __int128)(uint64_t)a;
+    const unsigned __int128 rounded = ((uv + ua - 1) / ua) * ua;
+
+    if (rounded > (unsigned __int128)INT64_MAX) {
+        return INT64_MAX;
+    }
+
+    return (int64_t)rounded;
 }
 
 static inline bool triton_matmul_should_use_small_n_transpose(
@@ -3764,16 +3776,33 @@ static inline bool triton_matmul_should_use_small_n_transpose(
     const int64_t swap_M_pad = tsi_round_up_i64(N, shape.m_dim);
     const int64_t swap_N_pad = tsi_round_up_i64(M, shape.n_dim);
 
-    const int64_t orig_elems = orig_M_pad * orig_N_pad * K;
-    const int64_t swap_elems = swap_M_pad * swap_N_pad * K;
+    if (orig_M_pad == INT64_MAX || orig_N_pad == INT64_MAX ||
+        swap_M_pad == INT64_MAX || swap_N_pad == INT64_MAX) {
+        return false;
+    }
 
-    if (swap_elems >= orig_elems) {
+    const unsigned __int128 orig_work =
+        (unsigned __int128)(uint64_t)orig_M_pad *
+        (unsigned __int128)(uint64_t)orig_N_pad *
+        (unsigned __int128)(uint64_t)K;
+
+    const unsigned __int128 swap_work =
+        (unsigned __int128)(uint64_t)swap_M_pad *
+        (unsigned __int128)(uint64_t)swap_N_pad *
+        (unsigned __int128)(uint64_t)K;
+
+    if (orig_work > (unsigned __int128)INT64_MAX ||
+        swap_work > (unsigned __int128)INT64_MAX) {
+        return false;
+    }
+
+    if (swap_work >= orig_work) {
         return false;
     }
 
     // Use the transpose path only for clear small-N cases. This avoids changing
     // behavior for square matrices or cases where N is already large enough.
-    return (M >= 4 * N) || (N <= 8);
+    return (M / 4 >= N) || (N <= 8);
 }
 
 static float *g_triton_A_full = nullptr; // [M_cap x K_cap]

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3401,13 +3401,11 @@ void _mlir_ciface_txe_mul_mat_tile_f32_k2048_host  (void *A_tile, void *B_tile, 
 #define TRITON_MATMUL_1X8_N_DIM     64
 
 struct triton_matmul_txe_shape_t {
-    const char *name;
     int64_t m_dim;
     int64_t n_dim;
 };
 
 static constexpr triton_matmul_txe_shape_t TRITON_MATMUL_SHAPE_1X8 = {
-    "1x8",
     TRITON_MATMUL_1X8_M_DIM,
     TRITON_MATMUL_1X8_N_DIM,
 };
@@ -3737,7 +3735,12 @@ static inline bool triton_matmul_should_use_small_n_transpose(
     int64_t M,
     int64_t N,
     int64_t K) {
-    if (!triton_matmul_small_n_transpose_opt) {
+    // Current PR scope: small-N transpose is implemented for the single-TXE
+    // path only. Keep the flag explicit for multi-TXE deployments so enabling
+    // triton_matmul_small_n_transpose_opt does not silently imply multi-TXE
+    // transpose support.
+    if (!triton_matmul_small_n_transpose_opt ||
+        (multi_thread_enable && num_of_txes > 1)) {
         return false;
     }
 
@@ -3761,8 +3764,8 @@ static inline bool triton_matmul_should_use_small_n_transpose(
     const int64_t swap_M_pad = tsi_round_up_i64(N, shape.m_dim);
     const int64_t swap_N_pad = tsi_round_up_i64(M, shape.n_dim);
 
-    const int64_t orig_elems = orig_M_pad * K + K * orig_N_pad + orig_M_pad * orig_N_pad;
-    const int64_t swap_elems = swap_M_pad * K + K * swap_N_pad + swap_M_pad * swap_N_pad;
+    const int64_t orig_elems = orig_M_pad * orig_N_pad * K;
+    const int64_t swap_elems = swap_M_pad * swap_N_pad * K;
 
     if (swap_elems >= orig_elems) {
         return false;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -110,6 +110,7 @@ struct TsavoriteRuntimeState {
 #if TRITON_MAT_MUL
     void **loadResult_matmul = nullptr;
     bool advanced_matmul_shape_offload = false;
+    bool triton_matmul_small_n_transpose_opt = false;
 #endif
 
     // blob lifetime state machine
@@ -160,6 +161,7 @@ auto &loadResult_rms_norm     = g_rt.loadResult_rms_norm;
 #if TRITON_MAT_MUL
 auto &loadResult_matmul       = g_rt.loadResult_matmul;
 auto &advanced_matmul_shape_offload = g_rt.advanced_matmul_shape_offload;
+auto &triton_matmul_small_n_transpose_opt = g_rt.triton_matmul_small_n_transpose_opt;
 #endif
 } // anonymous namespace
 
@@ -254,6 +256,8 @@ struct tsi_deploy_cfg_t {
 #if TRITON_MAT_MUL
     bool advanced_matmul_shape_offload = false;
     bool has_advanced_matmul_shape_offload = false;
+    bool triton_matmul_small_n_transpose_opt = false;
+    bool has_triton_matmul_small_n_transpose_opt = false;
 #endif
 };
 
@@ -313,6 +317,14 @@ static tsi_deploy_cfg_t tsi_read_deploy_yaml(const std::string &path) {
             if (tsi_parse_bool_after_colon(t, &b)) {
                 cfg.advanced_matmul_shape_offload = b;
                 cfg.has_advanced_matmul_shape_offload = true;
+            }
+        }
+        if (t.find("triton_matmul_small_n_transpose_opt") != std::string::npos &&
+            t.find(':') != std::string::npos) {
+            bool b = false;
+            if (tsi_parse_bool_after_colon(t, &b)) {
+                cfg.triton_matmul_small_n_transpose_opt = b;
+                cfg.has_triton_matmul_small_n_transpose_opt = true;
             }
         }
 #endif
@@ -1452,6 +1464,10 @@ static void ensure_tsi_runtime_initialized() {
         cfg.has_advanced_matmul_shape_offload ?
         cfg.advanced_matmul_shape_offload :
         false;
+    triton_matmul_small_n_transpose_opt =
+        cfg.has_triton_matmul_small_n_transpose_opt ?
+        cfg.triton_matmul_small_n_transpose_opt :
+        false;
 #endif
 
     printf("\n TSI deploy yaml=%s txe_count=%u multi_thread_enable=%d",
@@ -1462,6 +1478,8 @@ static void ensure_tsi_runtime_initialized() {
 #if TRITON_MAT_MUL
     printf(" advanced_matmul_shape_offload=%d",
            (int)advanced_matmul_shape_offload);
+    printf(" triton_matmul_small_n_transpose_opt=%d",
+           (int)triton_matmul_small_n_transpose_opt);
 #endif
 
     printf("\n");
@@ -3362,9 +3380,37 @@ void _mlir_ciface_txe_mul_mat_tile_f32_k2048_host  (void *A_tile, void *B_tile, 
 
 #if TRITON_MAT_MUL
 
-// TXE Shape specific
+// TXE shape descriptor for Triton MAT_MUL.
+//
+// Current PR scope:
+//   - Uses only the 1x8 TXE shape.
+//   - 1x8 requires M to be aligned to 8 rows and N to be aligned to 64 columns.
+//   - When triton_matmul_small_n_transpose_opt is enabled, we may compute the
+//     mathematically equivalent transposed problem for M >> N:
+//       original: C[M,N] = A[K,M] x B[K,N]
+//       swapped : T[N,M] = B[K,N] x A[K,M], then copy back C[m,n] = T[n,m]
+//
+// Future extension:
+//   - Add another descriptor such as TRITON_MATMUL_SHAPE_2X4 when the 2x4 blob
+//     is introduced.
+//   - Reuse the same padding-cost heuristic and transpose decision logic by
+//     passing that shape descriptor instead of hard-coding dimensions.
+//   - The packing/copyback logic can stay common as long as the selected blob
+//     uses the same flattened A[M,K], B[K,N], C[M,N] contract.
 #define TRITON_MATMUL_1X8_M_DIM      8
 #define TRITON_MATMUL_1X8_N_DIM     64
+
+struct triton_matmul_txe_shape_t {
+    const char *name;
+    int64_t m_dim;
+    int64_t n_dim;
+};
+
+static constexpr triton_matmul_txe_shape_t TRITON_MATMUL_SHAPE_1X8 = {
+    "1x8",
+    TRITON_MATMUL_1X8_M_DIM,
+    TRITON_MATMUL_1X8_N_DIM,
+};
 
 
 // Data type specific
@@ -3684,6 +3730,47 @@ static inline void init_scalar_i32_memref_aligned(
 
 static inline int64_t tsi_round_up_i64(int64_t v, int64_t a) {
     return ((v + a - 1) / a) * a;
+}
+
+static inline bool triton_matmul_should_use_small_n_transpose(
+    const triton_matmul_txe_shape_t &shape,
+    int64_t M,
+    int64_t N,
+    int64_t K) {
+    if (!triton_matmul_small_n_transpose_opt) {
+        return false;
+    }
+
+    if (M <= 0 || N <= 0 || K <= 0) {
+        return false;
+    }
+
+    if (shape.m_dim <= 0 || shape.n_dim <= 0) {
+        return false;
+    }
+
+    if (N >= M) {
+        return false;
+    }
+
+    // Estimate total physical work for the selected TXE shape.
+    // This is intentionally shape-driven so the same decision path can be reused
+    // when a 2x4 shape is added in a later PR.
+    const int64_t orig_M_pad = tsi_round_up_i64(M, shape.m_dim);
+    const int64_t orig_N_pad = tsi_round_up_i64(N, shape.n_dim);
+    const int64_t swap_M_pad = tsi_round_up_i64(N, shape.m_dim);
+    const int64_t swap_N_pad = tsi_round_up_i64(M, shape.n_dim);
+
+    const int64_t orig_elems = orig_M_pad * K + K * orig_N_pad + orig_M_pad * orig_N_pad;
+    const int64_t swap_elems = swap_M_pad * K + K * swap_N_pad + swap_M_pad * swap_N_pad;
+
+    if (swap_elems >= orig_elems) {
+        return false;
+    }
+
+    // Use the transpose path only for clear small-N cases. This avoids changing
+    // behavior for square matrices or cases where N is already large enough.
+    return (M >= 4 * N) || (N <= 8);
 }
 
 static float *g_triton_A_full = nullptr; // [M_cap x K_cap]
@@ -4242,15 +4329,33 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     // ============================================================
     // Single-TXE / generated-host-wrapper path.
     //
-    // Note:
-    //   This path calls the generated wrapper. It does not expose tsi_wait()
-    //   directly, so the wrapper elapsed time is recorded as Launch_ms.
-    //   Multi-TXE manual path below gives true tsi_wait() timing.
+    // Current shape bucket:
+    //   TRITON_MATMUL_SHAPE_1X8
+    //
+    // Optional small-N transpose optimization:
+    //   Original: C[M,N] = A[K,M] x B[K,N]
+    //   Swapped : T[N,M] = B[K,N] x A[K,M], then copy back C[m,n] = T[n,m]
+    //
+    // Why this helps for 1x8:
+    //   The 1x8 blob pads N to 64 columns. For decode-style N=1 or small N,
+    //   running the original orientation can waste many padded columns. The
+    //   swapped orientation can reduce padded work when M is much larger than N.
+    //
+    // Future 2x4 extension:
+    //   Keep this shape-bucket pattern. Select TRITON_MATMUL_SHAPE_2X4 in the
+    //   future 2x4 path, then call the same transpose heuristic with that shape.
     // ============================================================
     if (!multi_thread_enable || num_of_txes <= 1) {
-        const int64_t M_pad = ((M + 7) / 8) * 8;
+        const triton_matmul_txe_shape_t &txe_shape = TRITON_MATMUL_SHAPE_1X8;
+        const bool use_small_n_transpose =
+            triton_matmul_should_use_small_n_transpose(txe_shape, M, N, K);
 
-        ensure_triton_full_buffers(M_pad, N_pad, K);
+        const int64_t M_work = use_small_n_transpose ? N : M;
+        const int64_t N_work = use_small_n_transpose ? M : N;
+        const int64_t M_pad = tsi_round_up_i64(M_work, txe_shape.m_dim);
+        const int64_t N_work_pad = tsi_round_up_i64(N_work, txe_shape.n_dim);
+
+        ensure_triton_full_buffers(M_pad, N_work_pad, K);
 
         for (int64_t d3 = 0; d3 < D3; ++d3) {
             for (int64_t d2 = 0; d2 < D2; ++d2) {
@@ -4268,36 +4373,59 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                 profile.padding_memset_us += tsavorite_elapsed_us(t0);
 
                 t0 = tsavorite_now_us();
-                for (int64_t r = 0; r < M; ++r) {
-                    const char *row = A_ptr + r * a_nb1;
-                    float *dst = g_triton_A_full + r * K;
+                if (use_small_n_transpose) {
+                    for (int64_t r = 0; r < N; ++r) {
+                        const char *row = B_ptr + r * b_nb1;
+                        float *dst = g_triton_A_full + r * K;
 
-                    if (a_nb0 == sizeof(float)) {
-                        memcpy(dst, row, (size_t)K * sizeof(float));
-                    } else {
                         for (int64_t k = 0; k < K; ++k) {
-                            dst[k] = *(float *)(row + k * a_nb0);
+                            dst[k] = *(const float *)(row + k * b_nb0);
+                        }
+                    }
+                } else {
+                    for (int64_t r = 0; r < M; ++r) {
+                        const char *row = A_ptr + r * a_nb1;
+                        float *dst = g_triton_A_full + r * K;
+
+                        if (a_nb0 == sizeof(float)) {
+                            memcpy(dst, row, (size_t)K * sizeof(float));
+                        } else {
+                            for (int64_t k = 0; k < K; ++k) {
+                                dst[k] = *(const float *)(row + k * a_nb0);
+                            }
                         }
                     }
                 }
                 profile.pack_a_us += tsavorite_elapsed_us(t0);
 
                 t0 = tsavorite_now_us();
-                memset(g_triton_B_full, 0, (size_t)K * (size_t)N_pad * sizeof(float));
+                memset(g_triton_B_full, 0, (size_t)K * (size_t)N_work_pad * sizeof(float));
                 profile.padding_memset_us += tsavorite_elapsed_us(t0);
 
                 t0 = tsavorite_now_us();
-                for (int64_t c = 0; c < N; ++c) {
-                    const char *col = B_ptr + c * b_nb1;
-                    for (int64_t k = 0; k < K; ++k) {
-                        g_triton_B_full[k * N_pad + c] =
-                            *(float *)(col + k * b_nb0);
+                if (use_small_n_transpose) {
+                    for (int64_t c = 0; c < M; ++c) {
+                        const char *col = A_ptr + c * a_nb1;
+
+                        for (int64_t k = 0; k < K; ++k) {
+                            g_triton_B_full[k * N_work_pad + c] =
+                                *(const float *)(col + k * a_nb0);
+                        }
+                    }
+                } else {
+                    for (int64_t c = 0; c < N; ++c) {
+                        const char *col = B_ptr + c * b_nb1;
+
+                        for (int64_t k = 0; k < K; ++k) {
+                            g_triton_B_full[k * N_work_pad + c] =
+                                *(const float *)(col + k * b_nb0);
+                        }
                     }
                 }
                 profile.pack_b_us += tsavorite_elapsed_us(t0);
 
                 t0 = tsavorite_now_us();
-                memset(g_triton_C_full, 0, (size_t)M_pad * (size_t)N_pad * sizeof(float));
+                memset(g_triton_C_full, 0, (size_t)M_pad * (size_t)N_work_pad * sizeof(float));
                 profile.padding_memset_us += tsavorite_elapsed_us(t0);
 
                 t0 = tsavorite_now_us();
@@ -4306,7 +4434,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                     g_triton_B_full,
                     g_triton_C_full,
                     (int32_t)M_pad,
-                    (int32_t)N_pad,
+                    (int32_t)N_work_pad,
                     (int32_t)K);
                 profile.launch_us += tsavorite_elapsed_us(t0);
 
@@ -4315,10 +4443,19 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                 }
 
                 t0 = tsavorite_now_us();
-                for (int64_t r = 0; r < M; ++r) {
-                    for (int64_t c = 0; c < N; ++c) {
-                        *(float *)(C_ptr + r * c_nb0 + c * c_nb1) =
-                            g_triton_C_full[r * N_pad + c];
+                if (use_small_n_transpose) {
+                    for (int64_t r = 0; r < M; ++r) {
+                        for (int64_t c = 0; c < N; ++c) {
+                            *(float *)(C_ptr + r * c_nb0 + c * c_nb1) =
+                                g_triton_C_full[c * N_work_pad + r];
+                        }
+                    }
+                } else {
+                    for (int64_t r = 0; r < M; ++r) {
+                        for (int64_t c = 0; c < N; ++c) {
+                            *(float *)(C_ptr + r * c_nb0 + c * c_nb1) =
+                                g_triton_C_full[r * N_work_pad + c];
+                        }
                     }
                 }
                 profile.copyback_us += tsavorite_elapsed_us(t0);

--- a/tsavorite-model-deployment.yaml
+++ b/tsavorite-model-deployment.yaml
@@ -6,3 +6,8 @@ multi_thread_enable: false
 # false = old behavior
 # true  = new offload shapes
 advanced_matmul_shape_offload: false
+
+# Enable Triton MAT_MUL small-N transpose optimization.
+# false = old behavior
+# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
+triton_matmul_small_n_transpose_opt: false

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1042,6 +1042,12 @@ update_one_tsavorite_deployment_yaml() {
       /^[[:space:]]*advanced_matmul_shape_offload[[:space:]]*:/ {
         v=$2
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+        dq=sprintf("%c", 34)
+        sq=sprintf("%c", 39)
+        if ((substr(v, 1, 1) == dq && substr(v, length(v), 1) == dq) ||
+            (substr(v, 1, 1) == sq && substr(v, length(v), 1) == sq)) {
+          v = substr(v, 2, length(v) - 2)
+        }
         print v
         exit
       }
@@ -1056,6 +1062,12 @@ update_one_tsavorite_deployment_yaml() {
       /^[[:space:]]*triton_matmul_small_n_transpose_opt[[:space:]]*:/ {
         v=$2
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+        dq=sprintf("%c", 34)
+        sq=sprintf("%c", 39)
+        if ((substr(v, 1, 1) == dq && substr(v, length(v), 1) == dq) ||
+            (substr(v, 1, 1) == sq && substr(v, length(v), 1) == sq)) {
+          v = substr(v, 2, length(v) - 2)
+        }
         print v
         exit
       }

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1032,6 +1032,7 @@ update_one_tsavorite_deployment_yaml() {
   local deployment_yaml_path="$1"
   local txe_count="$2"
   local advanced_matmul_shape_offload="false"
+  local triton_matmul_small_n_transpose_opt="false"
 
   mkdir -p "$(dirname "${deployment_yaml_path}")" || return 1
 
@@ -1049,6 +1050,20 @@ update_one_tsavorite_deployment_yaml() {
     if [ -n "${existing_advanced}" ]; then
       advanced_matmul_shape_offload="${existing_advanced}"
     fi
+
+    local existing_small_n_opt
+    existing_small_n_opt="$(awk -F: '
+      /^[[:space:]]*triton_matmul_small_n_transpose_opt[[:space:]]*:/ {
+        v=$2
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+        print v
+        exit
+      }
+    ' "${deployment_yaml_path}")"
+
+    if [ -n "${existing_small_n_opt}" ]; then
+      triton_matmul_small_n_transpose_opt="${existing_small_n_opt}"
+    fi
   fi
 
   cat > "${deployment_yaml_path}" <<EOF
@@ -1060,9 +1075,14 @@ multi_thread_enable: true
 # false = old behavior
 # true  = new offload shapes
 advanced_matmul_shape_offload: ${advanced_matmul_shape_offload}
+
+# Enable Triton MAT_MUL small-N transpose optimization.
+# false = old behavior
+# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
+triton_matmul_small_n_transpose_opt: ${triton_matmul_small_n_transpose_opt}
 EOF
 
-  echo "INFO: updated ${deployment_yaml_path} with txe_count:${txe_count}, multi_thread_enable:true; preserved advanced_matmul_shape_offload:${advanced_matmul_shape_offload}"
+  echo "INFO: updated ${deployment_yaml_path} with txe_count:${txe_count}, multi_thread_enable:true; preserved advanced_matmul_shape_offload:${advanced_matmul_shape_offload}, triton_matmul_small_n_transpose_opt:${triton_matmul_small_n_transpose_opt}"
   return 0
 }
 
@@ -1178,9 +1198,14 @@ multi_thread_enable: true
 # false = old behavior
 # true  = new offload shapes
 advanced_matmul_shape_offload: false
+
+# Enable Triton MAT_MUL small-N transpose optimization.
+# false = old behavior
+# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
+triton_matmul_small_n_transpose_opt: false
 EOF
 
-  log_info "included default tsavorite-model-deployment.yaml with txe_count:1, multi_thread_enable:true, advanced_matmul_shape_offload:false; ggml.sh updates txe_count and preserves advanced_matmul_shape_offload."
+  log_info "included default tsavorite-model-deployment.yaml with txe_count:1, multi_thread_enable:true, advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false; ggml.sh updates txe_count and preserves both MAT_MUL flags."
 
   tar -cvzf "${TSI_GGML_BUNDLE_INSTALL_DIR}-${TSI_GGML_VERSION}.tz" "${TSI_GGML_BUNDLE_INSTALL_DIR}"/* || return 1
 

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1028,6 +1028,34 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)
 
 TAOS_CONFIG_PATH="/etc/taos/taos.json"
 
+extract_deployment_yaml_value() {
+  local deployment_yaml_path="$1"
+  local yaml_key="$2"
+
+  awk -F: -v key="${yaml_key}" '
+    $0 ~ "^[[:space:]]*" key "[[:space:]]*:" {
+      v=$2
+
+      # Remove an inline YAML comment before quote normalization.
+      sub(/[[:space:]]+#.*/, "", v)
+
+      # Trim whitespace.
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+
+      # Normalize matching single or double quotes.
+      dq=sprintf("%c", 34)
+      sq=sprintf("%c", 39)
+      if ((substr(v, 1, 1) == dq && substr(v, length(v), 1) == dq) ||
+          (substr(v, 1, 1) == sq && substr(v, length(v), 1) == sq)) {
+        v = substr(v, 2, length(v) - 2)
+      }
+
+      print v
+      exit
+    }
+  ' "${deployment_yaml_path}"
+}
+
 update_one_tsavorite_deployment_yaml() {
   local deployment_yaml_path="$1"
   local txe_count="$2"
@@ -1038,40 +1066,14 @@ update_one_tsavorite_deployment_yaml() {
 
   if [ -f "${deployment_yaml_path}" ]; then
     local existing_advanced
-    existing_advanced="$(awk -F: '
-      /^[[:space:]]*advanced_matmul_shape_offload[[:space:]]*:/ {
-        v=$2
-        gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
-        dq=sprintf("%c", 34)
-        sq=sprintf("%c", 39)
-        if ((substr(v, 1, 1) == dq && substr(v, length(v), 1) == dq) ||
-            (substr(v, 1, 1) == sq && substr(v, length(v), 1) == sq)) {
-          v = substr(v, 2, length(v) - 2)
-        }
-        print v
-        exit
-      }
-    ' "${deployment_yaml_path}")"
+    local existing_small_n_opt
+
+    existing_advanced="$(extract_deployment_yaml_value "${deployment_yaml_path}" "advanced_matmul_shape_offload")"
+    existing_small_n_opt="$(extract_deployment_yaml_value "${deployment_yaml_path}" "triton_matmul_small_n_transpose_opt")"
 
     if [ -n "${existing_advanced}" ]; then
       advanced_matmul_shape_offload="${existing_advanced}"
     fi
-
-    local existing_small_n_opt
-    existing_small_n_opt="$(awk -F: '
-      /^[[:space:]]*triton_matmul_small_n_transpose_opt[[:space:]]*:/ {
-        v=$2
-        gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
-        dq=sprintf("%c", 34)
-        sq=sprintf("%c", 39)
-        if ((substr(v, 1, 1) == dq && substr(v, length(v), 1) == dq) ||
-            (substr(v, 1, 1) == sq && substr(v, length(v), 1) == sq)) {
-          v = substr(v, 2, length(v) - 2)
-        }
-        print v
-        exit
-      }
-    ' "${deployment_yaml_path}")"
 
     if [ -n "${existing_small_n_opt}" ]; then
       triton_matmul_small_n_transpose_opt="${existing_small_n_opt}"


### PR DESCRIPTION
Description

Implement a Triton MAT_MUL optimization for small-N (decode-style) shapes using the existing 1x8 TXE shape.

Currently, the Triton MAT_MUL 1x8 implementation pads the N dimension to 64 columns. For workloads where M is significantly larger than N, especially decode-phase shapes such as N=1, this results in substantial padding overhead and unnecessary computation.

This change introduces an optional runtime optimization that computes the mathematically equivalent transposed problem when it reduces the estimated padded work.

Original:

C[M,N] = A[K,M] x B[K,N]

Optimized:

T[N,M] = B[K,N] x A[K,M]

Then transpose the result during copyback:

C[m,n] = T[n,m]

The optimization is controlled through deployment configuration and is enabled only when the padded-work heuristic determines that the transposed execution path is beneficial.

In addition, this change refactors the current 1x8 TXE implementation into a shape-aware framework by introducing a TXE shape descriptor. While this PR is limited to the 1x8 TXE shape, the framework is designed to simplify future extensions for additional TXE shapes such as 2x4 and others without duplicating the transpose optimization logic.

Validation

TSISIM validation is not yet available. Validation has currently been performed on POSIX only.

Configuration (Optimization Disabled)

advanced_matmul_shape_offload=1
triton_matmul_small_n_transpose_opt=0

Configuration (Optimization Enabled)

advanced_matmul_shape_offload=1
triton_matmul_small_n_transpose_opt=1

Results

Model output remained unchanged and generated the expected response:

"My cat's name is Luna. She's a black and white ..."

Performance comparison (POSIX):

Total Runtime:
126.43 min -> 17.21 min
(~7.35x improvement)

Prompt Evaluation:
12.69 min -> 1.74 min
(~7.27x improvement)

Decode Evaluation:
113.65 min -> 15.40 min
(~7.38x improvement)

MAT_MUL OPU Offloads:
4094 -> 4094
(No change in offload count)

MAT_MUL OPU Accumulated Time:
581.45 min -> 78.46 min
(~7.41x improvement)

The results demonstrate that the optimization preserves correctness while significantly reducing padded work for small-N decode-style MAT_MUL shapes. In addition, the new shape-aware framework provides a clean path for future support of additional TXE shapes such as 2x4.





Log
############

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli-original   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf   --device tsavorite   -c 12288   --temp 0.0   --n-predict 10   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=1
 My cat's name is Luna. She's a black and white



llama_perf_sampler_print:    sampling time =      19.47 ms /    17 runs   (    1.15 ms per token,   873.23 tokens per second)
llama_perf_context_print:        load time =  108733.71 ms
llama_perf_context_print: prompt eval time =  104665.51 ms /     7 tokens (14952.22 ms per token,     0.07 tokens per second)
llama_perf_context_print:        eval time =  923704.02 ms /     9 runs   (102633.78 ms per token,     0.01 tokens per second)
llama_perf_context_print:       total time = 1032459.44 ms /    16 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU         2024            2276           1896927            937.22
  MUL              OPU         2070            2328           1675670            809.50
  RMS_NORM         OPU         2070            2070           1912724            924.02
  MUL_MAT          CPU        20142               0           8627209            428.32
  MUL_MAT          OPU         4094            4094        4707718896        1149906.91
  CONT             OPU         2024               0            329484            162.79
  RESHAPE          CPU        11037               0              5114              0.46
  VIEW             CPU        10309               0               877              0.09
  VIEW             OPU         2024               0               736              0.36
  PERMUTE          CPU         7648               0              1851              0.24
  PERMUTE          OPU         2024               0               377              0.19
  TRANSPOSE        CPU         3434               0               580              0.17
  GET_ROWS         OPU          138               0               867              6.28
  SET_ROWS         CPU         7691               0              8253              1.07
  SOFT_MAX         OPU         1012               0            305774            302.15
  ROPE             CPU         7914               0             43919              5.55
  GLU              OPU         1012            1138           2607029           2576.12

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ cat ts
tsavorite-model-deployment.yaml           tsi-pkg-build.sh_backup_local_libomp
tsi-ggml/                                 tsi-pkg-build.sh.bak-fpga-aarch64-libomp
tsi-ggml-0.4.19.tz                        tsi-pkg-build.sh.bak-fpga-libomp
tsi-op.txt                                tsi-pkg-build.sh_fpga_fix
tsi-pkg-build.sh                          tsi-pkg-build.sh_master
[akapoor@wspd0 llama.cpp]$ cat tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count: 1
multi_thread_enable: false

# Enable additional Triton MAT_MUL shapes beyond stable baseline.
# false = old behavior
# true  = new offload shapes
advanced_matmul_shape_offload: true

# Enable Triton MAT_MUL small-N transpose optimization.
# false = old behavior
# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
triton_matmul_small_n_transpose_opt: true
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ vi tsavorite-model-deployment.yaml 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ cat tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count: 1
multi_thread_enable: false

# Enable additional Triton MAT_MUL shapes beyond stable baseline.
# false = old behavior
# true  = new offload shapes
advanced_matmul_shape_offload: true

# Enable Triton MAT_MUL small-N transpose optimization.
# false = old behavior
# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
triton_matmul_small_n_transpose_opt: false
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli-original   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf   --device tsavorite   -c 12288   --temp 0.0   --n-predict 10   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=0
 My cat's name is Luna. She's a black and white



llama_perf_sampler_print:    sampling time =      18.77 ms /    17 runs   (    1.10 ms per token,   905.51 tokens per second)
llama_perf_context_print:        load time =  767091.86 ms
llama_perf_context_print: prompt eval time =  761388.18 ms /     7 tokens (108769.74 ms per token,     0.01 tokens per second)
llama_perf_context_print:        eval time = 6818855.29 ms /     9 runs   (757650.59 ms per token,     0.00 tokens per second)
llama_perf_context_print:       total time = 7585968.21 ms /    16 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU         2024            2276           1835771            907.00
  MUL              OPU         2070            2328           1652764            798.44
  RMS_NORM         OPU         2070            2070           1898149            916.98
  MUL_MAT          CPU        20076               0           8938809            445.25
  MUL_MAT          OPU         4094            4094       34887202684        8521544.38
  CONT             OPU         2024               0            358421            177.09
  RESHAPE          CPU        10484               0              4178              0.40
  VIEW             CPU        10344               0               810              0.08
  VIEW             OPU         2024               0               461              0.23
  PERMUTE          CPU         7491               0              1726              0.23
  PERMUTE          OPU         2024               0               316              0.16
  TRANSPOSE        CPU         3510               0               442              0.13
  GET_ROWS         OPU          138               0               836              6.06
  SET_ROWS         CPU         7819               0              9039              1.16
  SOFT_MAX         OPU         1012               0            310815            307.13
  ROPE             CPU         7889               0             43990              5.58
  GLU              OPU         1012            1138           2572813           2542.31

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes Triton MAT_MUL for small‑N (decode) shapes by swapping operands and transposing on copyback in the 1x8 single‑TXE path, cutting padded work and yielding ~7x faster POSIX runs with identical outputs. Addresses Linear FIR-2019 and introduces a shape-bucket framework for future TXE shapes.

- **New Features**
  - Shape-aware TXE descriptor (current: 1x8) with a heuristic that uses the transpose path only when estimated padded work is lower; applies to clear small‑N (M ≥ 4N or N ≤ 8); disabled for multi‑TXE.
  - New config flag `triton_matmul_small_n_transpose_opt`; printed at init and independent of `advanced_matmul_shape_offload`. `tsi-pkg-build.sh` now preserves both flags and robustly parses YAML values (strips inline comments, trims whitespace, normalizes quotes).
  - Refactored pack/copyback to support swapped A/B and transpose on copyback; added overflow‑safe padding via `tsi_round_up_i64` and guard checks in the decision logic.

- **Migration**
  - Off by default. To enable, set `triton_matmul_small_n_transpose_opt: true` in `tsavorite-model-deployment.yaml` (single‑TXE only).

<sup>Written for commit b13bd180c4c1f4ffb7c939f0d291d49663f52e19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/llama.cpp/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

