### PR TITLE
@FIR-2213 -Add runtime user DRAM size configuration through tsavorite…

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -260,8 +260,8 @@ struct tsi_deploy_cfg_t {
     bool mt_enable = false;
     bool has_mt    = false;
 
-int  user_dram_size_gb = -1;
-bool has_user_dram_size_gb = false;
+    int  user_dram_size_gb = -1;
+    bool has_user_dram_size_gb = false;
 
 #if TRITON_MAT_MUL
     bool advanced_matmul_shape_offload = false;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -48,6 +48,13 @@
 #include "tsi-rt/queues/Command.h"
 #include "HostShimCAPI.h"
 #include "tsi-rt/utils/Profiler.h"
+#ifdef GGML_TARGET_POSIX
+#include "device/posix/PosixSimDeviceConfig.h"
+using TsavoriteDeviceConfig = tsi::runtime::PosixDeviceConfig;
+#else
+#include "device/fpga/FPGADeviceConfig.h"
+using TsavoriteDeviceConfig = tsi::runtime::FPGADeviceConfig;
+#endif
 
 #include <thread>
 #include <vector>
@@ -253,6 +260,9 @@ struct tsi_deploy_cfg_t {
     bool mt_enable = false;
     bool has_mt    = false;
 
+int  user_dram_size_gb = -1;
+bool has_user_dram_size_gb = false;
+
 #if TRITON_MAT_MUL
     bool advanced_matmul_shape_offload = false;
     bool has_advanced_matmul_shape_offload = false;
@@ -310,6 +320,20 @@ static tsi_deploy_cfg_t tsi_read_deploy_yaml(const std::string &path) {
             if (tsi_parse_bool_after_colon(t, &b)) { cfg.mt_enable = b; cfg.has_mt = true; }
         }
 
+        const size_t user_dram_colon = t.find(':');
+
+        if (user_dram_colon != std::string::npos &&
+            tsi_trim_copy(t.substr(0, user_dram_colon)) == "user_dram_size_gb") {
+
+            const int v = tsi_parse_int_after_colon(t);
+
+            if (v > 0) {
+                cfg.user_dram_size_gb = v;
+                cfg.has_user_dram_size_gb = true;
+            }
+        }
+
+
 #if TRITON_MAT_MUL
         if (t.find("advanced_matmul_shape_offload") != std::string::npos &&
             t.find(':') != std::string::npos) {
@@ -355,6 +379,27 @@ static tsi_deploy_cfg_t tsi_read_deploy_yaml(const std::string &path) {
 
     if (txes_count > 0 && cfg.txe_count <= 0) cfg.txe_count = txes_count;
     return cfg;
+}
+
+static inline size_t tsi_user_dram_size_bytes_from_cfg(const tsi_deploy_cfg_t &cfg) {
+    if (!cfg.has_user_dram_size_gb || cfg.user_dram_size_gb <= 0) {
+        fprintf(stderr,
+               "WARNING: user_dram_size_gb=%d is invalid. Using runtime default DRAM size.\n",
+                                                                              cfg.user_dram_size_gb);
+        return 0;
+    }
+
+    const uint64_t gib = 1024ull * 1024ull * 1024ull;
+    const uint64_t gb = static_cast<uint64_t>(cfg.user_dram_size_gb);
+
+    if (gb > static_cast<uint64_t>(SIZE_MAX) / gib) {
+        fprintf(stderr,
+                "ERROR: user_dram_size_gb=%d is too large for size_t\n",
+                cfg.user_dram_size_gb);
+        abort();
+    }
+
+    return static_cast<size_t>(gb * gib);
 }
 
 // ============================================================================
@@ -1359,7 +1404,7 @@ static inline void tsi_init_per_txe_state_once() {
         scalar_grid3_args.assign(num_of_txes, nullptr);
         for (uint32_t i = 0; i < num_of_txes; ++i) {
             if (!packed_args[i]) {
-                packed_args[i] = tsi_alloc(kPackedArgsBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                packed_args[i] = tsi_alloc(kPackedArgsBytesMax);
                 if (!packed_args[i]) {
                     fprintf(stderr, "tsi_alloc failed for packed_args[%u]\n", i);
                     abort();
@@ -1367,14 +1412,14 @@ static inline void tsi_init_per_txe_state_once() {
             }
 
             if (!scalar_loop_args[i]) {
-                scalar_loop_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                scalar_loop_args[i] = tsi_alloc(scalarLoopBytesMax);
                 if (!scalar_loop_args[i]) {
                     fprintf(stderr, "tsi_alloc failed for scalar_loop_args[%u]\n", i);
                     abort();
                 }
             }
             if (!scalar_m_args[i]) {
-                scalar_m_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                scalar_m_args[i] = tsi_alloc(scalarLoopBytesMax);
                 if (!scalar_m_args[i]) {
                     fprintf(stderr, "tsi_alloc failed for scalar_m_args[%u]\n", i);
                     abort();
@@ -1382,7 +1427,7 @@ static inline void tsi_init_per_txe_state_once() {
             }
 
             if (!scalar_n_args[i]) {
-                scalar_n_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                scalar_n_args[i] = tsi_alloc(scalarLoopBytesMax);
                 if (!scalar_n_args[i]) {
                     fprintf(stderr, "tsi_alloc failed for scalar_n_args[%u]\n", i);
                     abort();
@@ -1390,7 +1435,7 @@ static inline void tsi_init_per_txe_state_once() {
             }
 
             if (!scalar_k_args[i]) {
-                scalar_k_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                scalar_k_args[i] = tsi_alloc(scalarLoopBytesMax);
                 if (!scalar_k_args[i]) {
                     fprintf(stderr, "tsi_alloc failed for scalar_k_args[%u]\n", i);
                     abort();
@@ -1399,21 +1444,21 @@ static inline void tsi_init_per_txe_state_once() {
 
 
             if (!scalar_grid1_args[i]) {
-                scalar_grid1_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                scalar_grid1_args[i] = tsi_alloc(scalarLoopBytesMax);
                 if (!scalar_grid1_args[i]) {
                     fprintf(stderr, "tsi_alloc failed for scalar_grid1_args[%u]\n", i);
                     abort();
                 }
             }
             if (!scalar_grid2_args[i]) {
-                scalar_grid2_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                scalar_grid2_args[i] = tsi_alloc(scalarLoopBytesMax);
                 if (!scalar_grid2_args[i]) {
                     fprintf(stderr, "tsi_alloc failed for scalar_grid2_args[%u]\n", i);
                     abort();
                 }
             }
             if (!scalar_grid3_args[i]) {
-                scalar_grid3_args[i] = tsi_alloc(scalarLoopBytesMax, tsi::MemorySpace::SHARED_DRAM_TS);
+                scalar_grid3_args[i] = tsi_alloc(scalarLoopBytesMax);
                 if (!scalar_grid3_args[i]) {
                     fprintf(stderr, "tsi_alloc failed for scalar_grid3_args[%u]\n", i);
                     abort();
@@ -1425,12 +1470,12 @@ static inline void tsi_init_per_txe_state_once() {
 
 // Centralized TSI runtime initialization - called once globally
 //
-
 static void ensure_tsi_runtime_initialized() {
     if (runtime_initialized) {
         GGML_TSAVORITE_LOG_INFO("\n tsavorite backend already initialized \n");
         return;
     }
+
     tsi_blob_free_tables();
 
     std::string mainProfilerName = "OPU ";
@@ -1470,10 +1515,28 @@ static void ensure_tsi_runtime_initialized() {
         false;
 #endif
 
+    static TsavoriteDeviceConfig deviceConfig{};
+    const size_t requested_user_dram_size =
+        tsi_user_dram_size_bytes_from_cfg(cfg);
+
+    TsavoriteDeviceConfig *deviceConfigPtr = NULL;
+    if (requested_user_dram_size > 0) {
+        deviceConfig.setUserDRAMSize(requested_user_dram_size);
+        deviceConfigPtr = &deviceConfig;
+    }
+
     printf("\n TSI deploy yaml=%s txe_count=%u multi_thread_enable=%d",
            yaml_path.c_str(),
            (unsigned)num_of_txes,
            (int)multi_thread_enable);
+
+    if (requested_user_dram_size > 0) {
+        printf(" user_dram_size_gb=%d user_dram_size_bytes=%zu",
+               cfg.user_dram_size_gb,
+               requested_user_dram_size);
+    } else {
+        printf(" user_dram_size_gb=default");
+    }
 
 #if TRITON_MAT_MUL
     printf(" advanced_matmul_shape_offload=%d",
@@ -1484,7 +1547,7 @@ static void ensure_tsi_runtime_initialized() {
 
     printf("\n");
 
-    tsi_initialize(num_of_txes, NULL);
+    tsi_initialize(num_of_txes, deviceConfigPtr);
     tsavorite_install_signal_handlers();
 
     if (multi_thread_enable) {
@@ -1503,6 +1566,7 @@ static void ensure_tsi_runtime_initialized() {
         tsi_finalize();
         abort();
     }
+
     workers.reserve(num_of_txes);
     runtime_initialized = true;
 

--- a/tsavorite-model-deployment.yaml
+++ b/tsavorite-model-deployment.yaml
@@ -2,6 +2,22 @@
 txe_count: 1
 multi_thread_enable: false
 
+## Runtime user DRAM size in GiB.
+##
+## Typical requirements:
+##   - Small models may work with lower memory allocations.
+##   - Llama 3.2 1B was observed to require ~1.8 GB with 20 TXEs.
+##   - For general use, 4 GB is a reasonable starting point.
+##   - Larger models may require significantly more memory (for example, 12 GB to 24 GB).
+##
+## If this key is omitted, the runtime DeviceConfig default memory size is used.
+##
+## Examples:
+##   user_dram_size_gb: 4
+##   user_dram_size_gb: 12
+##   user_dram_size_gb: 24
+user_dram_size_gb: 4
+
 # Enable additional Triton MAT_MUL shapes beyond stable baseline.
 # false = old behavior
 # true  = new offload shapes

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1061,12 +1061,14 @@ update_one_tsavorite_deployment_yaml() {
   local txe_count="$2"
   local advanced_matmul_shape_offload="false"
   local triton_matmul_small_n_transpose_opt="false"
+local user_dram_size_gb="1"
 
   mkdir -p "$(dirname "${deployment_yaml_path}")" || return 1
 
   if [ -f "${deployment_yaml_path}" ]; then
     local existing_advanced
     local existing_small_n_opt
+local existing_user_dram_size_gb
 
     existing_advanced="$(extract_deployment_yaml_value "${deployment_yaml_path}" "advanced_matmul_shape_offload")"
     existing_small_n_opt="$(extract_deployment_yaml_value "${deployment_yaml_path}" "triton_matmul_small_n_transpose_opt")"
@@ -1080,10 +1082,32 @@ update_one_tsavorite_deployment_yaml() {
     fi
   fi
 
-  cat > "${deployment_yaml_path}" <<EOF
+  
+existing_user_dram_size_gb="$(
+    awk -F: '
+    /^[[:space:]]*user_dram_size_gb[[:space:]]*:/ {
+        v=$2
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+        print v
+        exit
+    }' "$deployment_yaml_path"
+)"
+
+if [ -n "$existing_user_dram_size_gb" ]; then
+    user_dram_size_gb="$existing_user_dram_size_gb"
+fi
+
+cat > "${deployment_yaml_path}" <<EOF
 # Tsavorite deployment config
 txe_count: ${txe_count}
 multi_thread_enable: true
+
+## Runtime user DRAM size in GiB.
+## Example: 1 = 1GB, 2 = 2GB.
+## If this key is missing, runtime DeviceConfig default is used.
+
+user_dram_size_gb: $user_dram_size_gb
+
 
 # Enable additional Triton MAT_MUL shapes beyond stable baseline.
 # false = old behavior
@@ -1207,6 +1231,13 @@ EOL
 # Tsavorite deployment config
 txe_count: 1
 multi_thread_enable: true
+
+## Runtime user DRAM size in GiB.
+## Example: 1 = 1GB, 2 = 2GB.
+## If this key is missing, runtime DeviceConfig default is used.
+
+user_dram_size_gb: 1
+
 
 # Enable additional Triton MAT_MUL shapes beyond stable baseline.
 # false = old behavior


### PR DESCRIPTION
POSIX LOG
akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli-original   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf   --device tsavorite   -c 12288   --temp 0.0   --n-predict 2   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
 My cat's name is Luna

llama_perf_sampler_print:    sampling time =       3.89 ms /     9 runs   (    0.43 ms per token,  2311.25 tokens per second)


llama_perf_context_print:        load time =  692244.05 ms
llama_perf_context_print: prompt eval time =  687979.60 ms /     7 tokens (98282.80 ms per token,     0.01 tokens per second)
llama_perf_context_print:        eval time =    1033.77 ms /     1 runs   ( 1033.77 ms per token,     0.97 tokens per second)
llama_perf_context_print:       total time =  693285.37 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU           88             340            264112           3001.27
  MUL              OPU           90             348            282386           3137.62
  RMS_NORM         OPU           90              90            215291           2392.12
  MUL_MAT          CPU         1198               0           2298016           1918.21
  MUL_MAT          OPU           85              85         686388584        8075159.81
  CONT             OPU           88               0             14142            160.70
  RESHAPE          CPU          465               0               312              0.67
  VIEW             CPU          455               0                44              0.10
  VIEW             OPU           88               0                29              0.33
  PERMUTE          CPU          328               0               127              0.39
  PERMUTE          OPU           88               0                17              0.19
  TRANSPOSE        CPU          159               0                21              0.13
  GET_ROWS         OPU            6               0                81             13.50
  SET_ROWS         CPU          340               0               502              1.48
  SOFT_MAX         OPU           44               0             47381           1076.84
  ROPE             CPU          342               0              4016             11.74
  GLU              OPU           44             170            507355          11530.80

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$




TSISIM LOG


root@tsisim:/usr/bin/tsi/bin# 
**## Tiny-Llama-v0.3-FP32-1.1B-F32.gguf ---here advance MAT_MUL flag disable we tested at 8 txe and MAT_MUL-optimization disable
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh** 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=8 multi_thread_enable=1 user_dram_size_gb=16 user_dram_size_bytes=17179869184 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
[2026-07-29 00:01:04.459] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=4 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-07-29 00:01:04.492] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 4 chiplets, ral_tag=SKYLP_G0741
[2026-07-29 00:01:04.526] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma_mproc.c:2002> Checking small memory allocation request of size 4096 available size: 4194304
[2026-07-29 00:01:04.526] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma_mproc.c:2005> devbuf_node.devbuf_smallmem_avail_size: 4194304
[2026-07-29 00:01:04.541] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 2
[2026-07-29 00:01:04.542] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xe51c3de15000, size = 17079185408
[2026-07-29 00:01:04.542] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xe51c3de15000, map_size = 17079185408
[2026-07-29 00:01:04.542] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xe520a8ff03b8
[2026-07-29 00:01:04.542] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-07-29 00:01:04.543] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-07-29 00:01:04.543] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xe51c37e11000, size = 100679680
[2026-07-29 00:01:04.543] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xe51c37e11000, map_size = 100679680
[2026-07-29 00:01:04.543] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xe520a8ff0490
[2026-07-29 00:01:04.543] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-07-29 00:01:04.543] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
 is Luna.


llama_perf_sampler_print:    sampling time =     253.95 ms /    11 runs   (   23.09 ms per token,    43.32 tokens per second)


llama_perf_context_print:        load time = 3198706.65 ms
llama_perf_context_print: prompt eval time = 2938092.25 ms /     6 tokens (489682.04 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time =   50542.61 ms /     4 runs   (12635.65 ms per token,     0.08 tokens per second)
llama_perf_context_print:       total time = 3249559.06 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          484             694          10553017          21803.75
  MUL              OPU          495             710            985430           1990.77
  RMS_NORM         OPU          495             495            641378           1295.71
  MUL_MAT          CPU         8405               0         241985297          28790.64
  MUL_MAT          OPU           85             680        2900498489       34123511.64
  CONT             OPU          484               0           2038864           4212.53
  RESHAPE          CPU         2843               0             18583              6.54
  VIEW             CPU         2833               0             11695              4.13
  VIEW             OPU          484               0              1380              2.85
  PERMUTE          CPU         1798               0             11070              6.16
  PERMUTE          OPU          484               0              1031              2.13
  TRANSPOSE        CPU          874               0              4603              5.27
  GET_ROWS         OPU           33               0              8507            257.79
  SET_ROWS         CPU         1894               0             69051             36.46
  SOFT_MAX         OPU          242               0           1434146           5926.22
  ROPE             CPU         1828               0            144792             79.21
  GLU              OPU          242             347          19166182          79199.10

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# vi ./tsi-ggml/tsavorite-model-deployment.yaml 

**## tinyllama-vo-5m-para.gguf---here advance MAT_MUL flag disable we tested at 8 txe and MAT_MUL-optimization disable
[>4;mroot@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh** 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=8 multi_thread_enable=1 user_dram_size_gb=16 user_dram_size_bytes=17179869184 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=1
[2026-07-29 01:05:32.974] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=4 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-07-29 01:05:33.012] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 4 chiplets, ral_tag=SKYLP_G0741
[2026-07-29 01:05:33.053] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma_mproc.c:2002> Checking small memory allocation request of size 4096 available size: 4194304
[2026-07-29 01:05:33.053] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma_mproc.c:2005> devbuf_node.devbuf_smallmem_avail_size: 4194304
[2026-07-29 01:05:33.069] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 2
[2026-07-29 01:05:33.069] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xe68d478b5000, size = 17079185408
[2026-07-29 01:05:33.070] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xe68d478b5000, map_size = 17079185408
[2026-07-29 01:05:33.070] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xe691b2a903b8
[2026-07-29 01:05:33.070] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-07-29 01:05:33.070] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-07-29 01:05:33.070] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xe68d418b1000, size = 100679680
[2026-07-29 01:05:33.070] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xe68d418b1000, map_size = 100679680
[2026-07-29 01:05:33.070] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xe691b2a90490
[2026-07-29 01:05:33.071] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-07-29 01:05:33.071] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
 was Tim. He loved

llama_perf_sampler_print:    sampling time =     219.43 ms /    11 runs   (   19.95 ms per token,    50.13 tokens per second)


llama_perf_context_print:        load time =   10753.14 ms
llama_perf_context_print: prompt eval time =    3029.24 ms /     6 tokens (  504.87 ms per token,     1.98 tokens per second)
llama_perf_context_print:        eval time =    2657.59 ms /     4 runs   (  664.40 ms per token,     1.51 tokens per second)
llama_perf_context_print:       total time =   13672.25 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          176             246           2111496          11997.14
  MUL              OPU          187             262           1153266           6167.20
  RMS_NORM         OPU          187             187            162670            869.89
  MUL_MAT          CPU         3209               0           2643435            823.76
  CONT             OPU          176               0            190637           1083.16
  RESHAPE          CPU         1043               0              4868              4.67
  VIEW             CPU         1044               0              2635              2.52
  VIEW             OPU          176               0               533              3.03
  PERMUTE          CPU          696               0              2137              3.07
  PERMUTE          OPU          176               0               470              2.67
  TRANSPOSE        CPU          343               0               963              2.81
  GET_ROWS         OPU           33               0              1112             33.70
  SET_ROWS         CPU          703               0              8918             12.69
  SOFT_MAX         OPU           88               0            258305           2935.28
  ROPE             CPU          704               0             19944             28.33
  GLU              OPU           88             123           1331565          15131.42

OPU Profiling Results:
Profiler disabled


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
FIR-2213: Add runtime DRAM sizing via `user_dram_size_gb` in `tsavorite-model-deployment.yaml`, passed to `tsi_initialize` with an optional `TsavoriteDeviceConfig`. This lets us tune memory for pack-args workloads at runtime without code changes, with clear logging of the effective size or default.

- **New Features**
  - Read and validate `user_dram_size_gb` (GiB) from YAML; convert to bytes with overflow guard; pass via optional `TsavoriteDeviceConfig` to `tsi_initialize`; log effective size or default.
  - Add cross-target alias for `TsavoriteDeviceConfig` (POSIX/FPGA); `tsi-pkg-build.sh` preserves and writes `user_dram_size_gb` when regenerating; update deployment YAML with examples and default `user_dram_size_gb: 4`.

- **Refactors**
  - Remove explicit `SHARED_DRAM_TS` from per-TXE allocations.
  - Clearer init flow and failure handling around `tsi_initialize`; minor indentation fix in packaging script.

<sup>Written for commit 388e6c064a8675116f10e0dca719e0c10b9dd845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/llama.cpp/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

