### PR TITLE
@FIR-2116 - Increase default user_dram_size_gb from 1GB to 8GB in Tsa…

### DIFF
--- a/tsavorite-model-deployment.yaml
+++ b/tsavorite-model-deployment.yaml
@@ -1,6 +1,6 @@
 # Tsavorite deployment config
 txe_count: 1
-multi_thread_enable: false
+multi_thread_enable: true
 
 ## Runtime user DRAM size in GiB.
 ##

--- a/tsavorite-model-deployment.yaml
+++ b/tsavorite-model-deployment.yaml
@@ -14,9 +14,10 @@ multi_thread_enable: false
 ##
 ## Examples:
 ##   user_dram_size_gb: 4
+##   user_dram_size_gb: 8
 ##   user_dram_size_gb: 12
 ##   user_dram_size_gb: 24
-user_dram_size_gb: 4
+user_dram_size_gb: 8
 
 # Enable additional Triton MAT_MUL shapes beyond stable baseline.
 # false = old behavior

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -77,20 +77,21 @@
 # - If present, the Tsavorite backend loads this file at runtime to determine
 #   TXE configuration and multi-threading behavior.
 #
-# ------------------------------------------------------------------------------
-# FPGA Packaging – Source Selection Order
-# ------------------------------------------------------------------------------
-#
-# When creating an FPGA bundle, the deployment file is picked up using the
-# following priority order:
-#
-# 1) TSAVORITE_DEPLOYMENT_YAML_SRC=/path/to/tsavorite-model-deployment.yaml
-# 2) ./tsavorite-model-deployment.yaml
-# 3) <script-dir>/tsavorite-model-deployment.yaml
-#
-# The resolved file is then copied into the FPGA bundle alongside the
-# Tsavorite shared libraries.
-# ------------------------------------------------------------------------------
+## ------------------------------------------------------------------------------
+## FPGA Packaging – Deployment File
+## ------------------------------------------------------------------------------
+##
+## FPGA packaging requires ./tsavorite-model-deployment.yaml to exist in the
+## current working directory.
+##
+## tsi-pkg-build.sh does not generate deployment configuration files.
+## The deployment configuration is maintained only in
+## tsavorite-model-deployment.yaml.
+##
+## During packaging, the file is copied directly into the FPGA bundle
+## alongside the Tsavorite shared libraries.
+##
+## ------------------------------------------------------------------------------
 #
 #
 # Build modes (optional):
@@ -237,10 +238,11 @@
 # 13) Package only (existing FPGA build dir already built):
 #     SDK_VERSION=0.4.1 source tsi-pkg-build.sh package
 #
-# 14) Override tsavorite-model-deployment.yaml source for packaging:
-#     TSAVORITE_DEPLOYMENT_YAML_SRC=/abs/path/tsavorite-model-deployment.yaml \
-#       SDK_VERSION=0.4.1 source tsi-pkg-build.sh build-fpga package
+# 14) FPGA packaging:
+#     Ensure ./tsavorite-model-deployment.yaml exists in the current
+#     working directory before running package.
 #
+#       SDK_VERSION=0.4.1 source tsi-pkg-build.sh build-fpga package
 # ==============================================================================
 
 log_error(){ echo "ERROR: $*" >&2; }

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1227,30 +1227,12 @@ EOL
   cp "${build_dir}/bin/libllama"*.so "${TSI_GGML_BUNDLE_INSTALL_DIR}/" || return 1
   cp "${build_dir}/bin/simple-backend-tsi" "${TSI_GGML_BUNDLE_INSTALL_DIR}/" || return 1
 
-  cat > "${TSI_GGML_BUNDLE_INSTALL_DIR}/tsavorite-model-deployment.yaml" <<'EOF'
-# Tsavorite deployment config
-txe_count: 1
-multi_thread_enable: true
+if [ ! -f "./tsavorite-model-deployment.yaml" ]; then
+    die "required ./tsavorite-model-deployment.yaml not found for FPGA package"
+fi
+cp "./tsavorite-model-deployment.yaml" "$TSI_GGML_BUNDLE_INSTALL_DIR/tsavorite-model-deployment.yaml" || return 1
+log_info "included ./tsavorite-model-deployment.yaml in FPGA package"
 
-## Runtime user DRAM size in GiB.
-## Example: 1 = 1GB, 2 = 2GB.
-## If this key is missing, runtime DeviceConfig default is used.
-
-user_dram_size_gb: 8
-
-
-# Enable additional Triton MAT_MUL shapes beyond stable baseline.
-# false = old behavior
-# true  = new offload shapes
-advanced_matmul_shape_offload: false
-
-# Enable Triton MAT_MUL small-N transpose optimization.
-# false = old behavior
-# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
-triton_matmul_small_n_transpose_opt: false
-EOF
-
-  log_info "included default tsavorite-model-deployment.yaml with txe_count:1, multi_thread_enable:true, advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false; ggml.sh updates txe_count and preserves both MAT_MUL flags."
 
   tar -cvzf "${TSI_GGML_BUNDLE_INSTALL_DIR}-${TSI_GGML_VERSION}.tz" "${TSI_GGML_BUNDLE_INSTALL_DIR}"/* || return 1
 

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1061,7 +1061,7 @@ update_one_tsavorite_deployment_yaml() {
   local txe_count="$2"
   local advanced_matmul_shape_offload="false"
   local triton_matmul_small_n_transpose_opt="false"
-local user_dram_size_gb="1"
+local user_dram_size_gb="8"
 
   mkdir -p "$(dirname "${deployment_yaml_path}")" || return 1
 
@@ -1236,7 +1236,7 @@ multi_thread_enable: true
 ## Example: 1 = 1GB, 2 = 2GB.
 ## If this key is missing, runtime DeviceConfig default is used.
 
-user_dram_size_gb: 1
+user_dram_size_gb: 8
 
 
 # Enable additional Triton MAT_MUL shapes beyond stable baseline.


### PR DESCRIPTION
tested at tsisim

oot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
[2026-07-29 16:32:19.678] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-07-29 16:32:19.880] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-07-29 16:32:19.971] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma_mproc.c:2002> Checking small memory allocation request of size 4096 available size: 4194304
[2026-07-29 16:32:19.972] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma_mproc.c:2005> devbuf_node.devbuf_smallmem_avail_size: 4194304
[2026-07-29 16:32:19.998] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 1
[2026-07-29 16:32:19.998] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xe52f3f881000, size = 8589930496
[2026-07-29 16:32:19.999] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xe52f3f881000, map_size = 8589930496
[2026-07-29 16:32:19.999] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xe53258a603b8
[2026-07-29 16:32:19.999] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-07-29 16:32:20.000] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
 was Tim. He loved



llama_perf_sampler_print:    sampling time =     478.78 ms /    11 runs   (   43.53 ms per token,    22.98 tokens per second)
llama_perf_context_print:        load time =   23037.45 ms
llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =    6181.23 ms /     4 runs   ( 1545.31 ms per token,     0.65 tokens per second)
llama_perf_context_print:       total time =   27941.09 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          160             160           3190947          19943.42
  MUL              OPU          170             170            424687           2498.16
  RMS_NORM         OPU          170             170            467189           2748.17
  MUL_MAT          CPU         2903               0           5573791           1920.01
  CONT             OPU          160               0            398993           2493.71
  RESHAPE          CPU          950               0             15089             15.88
  VIEW             CPU          945               0              9221              9.76
  VIEW             OPU          160               0               825              5.16
  PERMUTE          CPU          631               0             12895             20.44
  PERMUTE          OPU          160               0               730              4.56
  TRANSPOSE        CPU          315               0              2435              7.73
  GET_ROWS         OPU           30               0             10581            352.70
  SET_ROWS         CPU          636               0             50926             80.07
  SOFT_MAX         OPU           80               0            362915           4536.44
  ROPE             CPU          638               0             99973            156.70
  GLU              OPU           80              80           1935884          24198.55

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the default `user_dram_size_gb` to 8 GB in `tsi-pkg-build.sh` and `tsavorite-model-deployment.yaml` (and set `multi_thread_enable: true`) to reduce OOMs and support larger models (FIR-2116). Removed the embedded template from `tsi-pkg-build.sh`; FPGA packaging now copies `./tsavorite-model-deployment.yaml` from the CWD—set `user_dram_size_gb: 1` there to keep the old 1 GB default.

<sup>Written for commit 611a6eb2ba54d385e670eabfee06527655a9fb30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/llama.cpp/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

