### PR TITLE
@FIR-2124 - Add Triton MAT_MUL buffer deallocation using tsi_dealloc …

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3892,12 +3892,6 @@ static inline void ensure_triton_full_buffers(
     const int64_t need_K =
         tsi_round_up_i64(K, TRITON_MATMUL_F32_K_DIM);
 
-    //
-    // IMPORTANT:
-    // tsi_free currently broken.
-    // Allocate ONCE and only grow when absolutely necessary.
-    // Never replace existing allocations with smaller shapes.
-    //
     if (g_triton_A_full &&
         g_triton_B_full &&
         g_triton_C_full &&
@@ -3906,6 +3900,10 @@ static inline void ensure_triton_full_buffers(
         need_K <= g_triton_K_cap) {
         return;
     }
+
+    float *old_A = g_triton_A_full;
+    float *old_B = g_triton_B_full;
+    float *old_C = g_triton_C_full;
 
     int64_t new_M =
         std::max<int64_t>(need_M,
@@ -3945,6 +3943,16 @@ static inline void ensure_triton_full_buffers(
     g_triton_M_cap = new_M;
     g_triton_N_cap = new_N;
     g_triton_K_cap = new_K;
+
+    if (old_A) {
+        tsi_dealloc(old_A);
+    }
+    if (old_B) {
+        tsi_dealloc(old_B);
+    }
+    if (old_C) {
+        tsi_dealloc(old_C);
+    }
 
 #if TRITON_DEBUG
     fprintf(stderr,
@@ -4099,11 +4107,10 @@ static inline void ensure_triton_full_buffers_for_device(
         return;
     }
 
-    /*
-     * tsi_free is currently not usable.
-     * Allocate persistent per-TXE buffers and grow only when required.
-     * Old smaller buffers are intentionally not freed due to runtime bug.
-     */
+    float *old_A = g_triton_A_full_mt[deviceId];
+    float *old_B = g_triton_B_full_mt[deviceId];
+    float *old_C = g_triton_C_full_mt[deviceId];
+
     const int64_t new_M =
         std::max<int64_t>(need_M,
         std::max<int64_t>(g_triton_M_cap_mt[deviceId], 64));
@@ -4140,6 +4147,16 @@ static inline void ensure_triton_full_buffers_for_device(
     g_triton_M_cap_mt[deviceId] = new_M;
     g_triton_N_cap_mt[deviceId] = new_N;
     g_triton_K_cap_mt[deviceId] = new_K;
+
+    if (old_A) {
+        tsi_dealloc(old_A);
+    }
+    if (old_B) {
+        tsi_dealloc(old_B);
+    }
+    if (old_C) {
+        tsi_dealloc(old_C);
+    }
 
 #if TRITON_DEBUG
     fprintf(stderr,


### PR DESCRIPTION
Tsisim Test result
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:8, multi_thread_enable:true; preserved advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=8 multi_thread_enable=1 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
[2026-07-30 17:03:12.604] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=4 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-07-30 17:03:12.647] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 4 chiplets, ral_tag=SKYLP_G0741
[2026-07-30 17:03:12.691] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 1
[2026-07-30 17:03:12.692] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xfe7019ac0000, size = 8589934592
[2026-07-30 17:03:12.692] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xfe7019ac0000, map_size = 8589934592
[2026-07-30 17:03:12.692] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xfe728acb03b8
[2026-07-30 17:03:12.692] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-07-30 17:03:12.692] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
 is Luna.




llama_perf_sampler_print:    sampling time =     213.61 ms /    11 runs   (   19.42 ms per token,    51.50 tokens per second)
llama_perf_context_print:        load time = 3265969.59 ms
llama_perf_context_print: prompt eval time = 3014123.55 ms /     6 tokens (502353.92 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time =   51834.79 ms /     4 runs   (12958.70 ms per token,     0.08 tokens per second)
llama_perf_context_print:       total time = 3318072.09 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          484             694          10529413          21754.99
  MUL              OPU          495             710           1403009           2834.36
  RMS_NORM         OPU          495             495            615095           1242.62
  MUL_MAT          CPU         8401               0         256171474          30492.97
  MUL_MAT          OPU           85             680        2975248035       35002918.06
  CONT             OPU          484               0           1893639           3912.48
  RESHAPE          CPU         2826               0             17242              6.10
  VIEW             CPU         2753               0             15318              5.56
  VIEW             OPU          484               0              1175              2.43
  PERMUTE          CPU         1795               0              8816              4.91
  PERMUTE          OPU          484               0               929              1.92
  TRANSPOSE        CPU          837               0              3038              3.63
  GET_ROWS         OPU           33               0              8240            249.70
  SET_ROWS         CPU         1893               0             62192             32.85
  SOFT_MAX         OPU          242               0           1355744           5602.25
  ROPE             CPU         1862               0            145319             78.04
  GLU              OPU          242             347          19644155          81174.19

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
