### PR TITLE
@FIR-2125 - llama.cpp multi-threading support for posix

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -1105,6 +1105,12 @@ static std::string blob_prefix(const char *rel) {
     return tsavorite_llama_root() + rel;
 }
 
+#ifdef GGML_TARGET_POSIX
+#define TSAVORITE_BLOB_BUILD_ROOT "/ggml-tsi-kernel/posix-kernel/build-posix"
+#else
+#define TSAVORITE_BLOB_BUILD_ROOT "/ggml-tsi-kernel/fpga-kernel/build-fpga"
+#endif
+
 static inline void tsi_blob_free_tables() {
     // free pointer tables only (does NOT unload blobs)
     if (loadResult_add) {
@@ -1267,11 +1273,20 @@ static void tsi_load_all_blobs() {
 #endif
 
 
+#ifdef GGML_TARGET_POSIX
+        snprintf(name_add,  sizeof(name_add),  "txe_add");
+        snprintf(name_mult, sizeof(name_mult), "txe_mult");
+        snprintf(name_rms,  sizeof(name_rms),  "txe_rms_norm");
+#if TRITON_MAT_MUL
+        snprintf(name_matmul, sizeof(name_matmul), "txe_blob_0");
+#endif
+#else
         snprintf(name_add,  sizeof(name_add),  "txe_add_dev%u",  i);
         snprintf(name_mult, sizeof(name_mult), "txe_mult_dev%u", i);
         snprintf(name_rms,  sizeof(name_rms),  "txe_rms_norm_dev%u", i);
 #if TRITON_MAT_MUL
         snprintf(name_matmul, sizeof(name_matmul), "txe_triton_mat_mul_dev%u", i);
+#endif
 #endif
         failed_txe = i;
 
@@ -1280,7 +1295,7 @@ static void tsi_load_all_blobs() {
             i,
             name_add,
             blob_prefix(
-                "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_add/blobs/txe_add"
+                TSAVORITE_BLOB_BUILD_ROOT "/txe_add/blobs/txe_add"
             ).c_str()
         );
         if (!loadResult_add[i]) {
@@ -1295,7 +1310,7 @@ static void tsi_load_all_blobs() {
             i,
             name_mult,
             blob_prefix(
-                "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_mult/blobs/txe_mult"
+                TSAVORITE_BLOB_BUILD_ROOT "/txe_mult/blobs/txe_mult"
             ).c_str()
         );
         if (!loadResult_mult[i]) {
@@ -1310,7 +1325,7 @@ static void tsi_load_all_blobs() {
             i,
             name_rms,
             blob_prefix(
-                "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_rms_norm/blobs/txe_rms_norm"
+                TSAVORITE_BLOB_BUILD_ROOT "/txe_rms_norm/blobs/txe_rms_norm"
             ).c_str()
         );
         if (!loadResult_rms_norm[i]) {
@@ -1327,7 +1342,7 @@ static void tsi_load_all_blobs() {
             i,
             name_matmul,
             blob_prefix(
-                "/ggml-tsi-kernel/fpga-kernel/build-fpga/txe_triton_mat_mul/blobs/txe_blob_0"
+                TSAVORITE_BLOB_BUILD_ROOT "/txe_triton_mat_mul/blobs/txe_blob_0"
             ).c_str()
         );
 


### PR DESCRIPTION
[akapoor@wspd0 llama.cpp]$ cat tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count: 1
multi_thread_enable: true

## Runtime user DRAM size in GiB.
##
## Typical requirements:
##   - Small models may work with lower memory allocations.
##   - Llama 3.2 1B was observed to require ~1.8 GB with 20 TXEs.
##   - For general use, 4 GB is a reasonable starting point.
##   - Larger models may require significantly more memory (for example, 12 GB to 24 GB).
##
## If this key is omitted, the runtime DeviceConfig default memory size is used.
##
## Examples:
##   user_dram_size_gb: 4
##   user_dram_size_gb: 8
##   user_dram_size_gb: 12
##   user_dram_size_gb: 24
user_dram_size_gb: 8

# Enable additional Triton MAT_MUL shapes beyond stable baseline.
# false = old behavior
# true  = new offload shapes
advanced_matmul_shape_offload: false

# Enable Triton MAT_MUL small-N transpose optimization.
# false = old behavior
# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
triton_matmul_small_n_transpose_opt: false
[akapoor@wspd0 llama.cpp]$ 


POSIX REsult:
akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli-original   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf   --device tsavorite   -c 12288   --temp 0.0   --n-predict 2   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
 My cat's name is Luna



llama_perf_sampler_print:    sampling time =       9.14 ms /     9 runs   (    1.02 ms per token,   984.47 tokens per second)
llama_perf_context_print:        load time =  802713.36 ms
llama_perf_context_print: prompt eval time =  733051.79 ms /     7 tokens (104721.68 ms per token,     0.01 tokens per second)
llama_perf_context_print:        eval time =    2382.64 ms /     1 runs   ( 2382.64 ms per token,     0.42 tokens per second)
llama_perf_context_print:       total time =  805118.36 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU           88             340            295878           3362.25
  MUL              OPU           90             348            305785           3397.61
  RMS_NORM         OPU           90              90            277007           3077.86
  MUL_MAT          CPU         1200               0           2787524           2322.94
  MUL_MAT          OPU           85              85         728513338        8570745.15
  CONT             OPU           88               0             15944            181.18
  RESHAPE          CPU          492               0               374              0.76
  VIEW             CPU          455               0                57              0.13
  VIEW             OPU           88               0                30              0.34
  PERMUTE          CPU          310               0               121              0.39
  PERMUTE          OPU           88               0                23              0.26
  TRANSPOSE        CPU          157               0                42              0.27
  GET_ROWS         OPU            6               0             36564           6094.00
  SET_ROWS         CPU          337               0              2866              8.50
  SOFT_MAX         OPU           44               0             48135           1093.98
  ROPE             CPU          345               0              4400             12.75
  GLU              OPU           44             170            458585          10422.39

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 


TSISIM Result


root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
Using model: tinyllama-vo-5m-para.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
[2026-07-31 01:11:24.044] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-07-31 01:11:24.047] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-07-31 01:11:24.048] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 1
[2026-07-31 01:11:24.048] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xe1254c350000, size = 8589934592
[2026-07-31 01:11:24.048] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xe1254c350000, map_size = 8589934592
[2026-07-31 01:11:24.048] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xe128655403b8
[2026-07-31 01:11:24.048] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-07-31 01:11:24.048] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
 was Tim. He loved



llama_perf_sampler_print:    sampling time =       8.44 ms /    11 runs   (    0.77 ms per token,  1303.16 tokens per second)
llama_perf_context_print:        load time =    1400.67 ms
llama_perf_context_print: prompt eval time =    1126.07 ms /     6 tokens (  187.68 ms per token,     5.33 tokens per second)
llama_perf_context_print:        eval time =    1438.25 ms /     4 runs   (  359.56 ms per token,     2.78 tokens per second)
llama_perf_context_print:       total time =    2850.11 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          176             246           1192365           6774.80
  MUL              OPU          187             262             12848             68.71
  RMS_NORM         OPU          187             187              8957             47.90
  MUL_MAT          CPU         2760               0            182886             66.26
  CONT             OPU          176               0              5002             28.42
  RESHAPE          CPU          723               0               126              0.17
  VIEW             CPU          667               0                46              0.07
  VIEW             OPU          176               0                76              0.43
  PERMUTE          CPU          480               0                56              0.12
  PERMUTE          OPU          176               0                32              0.18
  TRANSPOSE        CPU          212               0                32              0.15
  GET_ROWS         OPU           33               0                85              2.58
  SET_ROWS         CPU          587               0               660              1.12
  SOFT_MAX         OPU           88               0             21087            239.62
  ROPE             CPU          546               0               818              1.50
  GLU              OPU           88             123            849441           9652.74

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 



root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
Using model: Llama3.2:1B-1.2B-F32.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=30 user_dram_size_bytes=32212254720 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
[2026-07-31 01:13:39.928] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-07-31 01:13:39.930] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 3
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xf926b9dd5000, size = 17079185408
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf926b9dd5000, map_size = 17079185408
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf92bccfc03b8
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xf924b9dd5000, size = 8589934592
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf924b9dd5000, map_size = 8589934592
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf92bccfc0490
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
[2026-07-31 01:13:39.931] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 2: start_addr = 0xf92333dd0000, size = 6543134720
[2026-07-31 01:13:39.932] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf92333dd0000, map_size = 6543134720
[2026-07-31 01:13:39.932] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf92bccfc0568
[2026-07-31 01:13:39.932] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 3
[2026-07-31 01:13:39.932] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
 is molly and she

llama_perf_sampler_print:    sampling time =      32.58 ms /    10 runs   (    3.26 ms per token,   306.90 tokens per second)


llama_perf_context_print:        load time = 1147460.72 ms
llama_perf_context_print: prompt eval time = 1144041.38 ms /     5 tokens (228808.28 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time =   17014.54 ms /     4 runs   ( 4253.63 ms per token,     0.24 tokens per second)
llama_perf_context_print:       total time = 1164512.79 ms /     9 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          352             472           4628577          13149.37
  MUL              OPU          363             487             58526            161.23
  RMS_NORM         OPU          363             363             40255            110.90
  MUL_MAT          CPU         6037               0          20122776           3333.24
  MUL_MAT          OPU           61            1220        1130524929       18533195.56
  CONT             OPU          352               0             85759            243.63
  RESHAPE          CPU         1505               0              1090              0.72
  VIEW             CPU         1403               0               267              0.19
  VIEW             OPU          352               0               227              0.64
  PERMUTE          CPU          881               0               213              0.24
  PERMUTE          OPU          352               0               101              0.29
  TRANSPOSE        CPU          463               0                87              0.19
  GET_ROWS         OPU           33               0               342             10.36
  SET_ROWS         CPU         1132               0              7711              6.81
  SOFT_MAX         OPU          176               0             78304            444.91
  ROPE             CPU         1121               0              9234              8.24
  GLU              OPU          176             236          15459193          87836.32

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# cat ./tsi-ggml/tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count: 20
multi_thread_enable: true

## Runtime user DRAM size in GiB.
## Example: 1 = 1GB, 2 = 2GB.
## If this key is missing, runtime DeviceConfig default is used.

user_dram_size_gb: 30


# Enable additional Triton MAT_MUL shapes beyond stable baseline.
# false = old behavior
# true  = new offload shapes
advanced_matmul_shape_offload: false

# Enable Triton MAT_MUL small-N transpose optimization.
# false = old behavior
# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
triton_matmul_small_n_transpose_opt: false
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 









