### PR TITLE
@FIR-2139 - Triton ADD manual pack-args scalar encoding for multi-thr…

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -106,6 +106,9 @@ struct TsavoriteRuntimeState {
     BlobDescriptor **blobDescriptor_add = nullptr;
     BlobDescriptor **blobDescriptor_mult = nullptr;
     BlobDescriptor **blobDescriptor_rms_norm = nullptr;
+#if TRITON_ADD
+    BlobDescriptor **blobDescriptor_triton_add = nullptr;
+#endif
 #if TRITON_MAT_MUL
     BlobDescriptor **blobDescriptor_matmul = nullptr;
 #endif
@@ -114,6 +117,9 @@ struct TsavoriteRuntimeState {
     void **loadResult_add = nullptr;
     void **loadResult_mult = nullptr;
     void **loadResult_rms_norm = nullptr;
+#if TRITON_ADD
+    void **loadResult_triton_add = nullptr;
+#endif
 #if TRITON_MAT_MUL
     void **loadResult_matmul = nullptr;
     bool advanced_matmul_shape_offload = false;
@@ -157,6 +163,9 @@ auto &device_cv = g_rt.device_cv;
 auto &blobDescriptor_add      = g_rt.blobDescriptor_add;
 auto &blobDescriptor_mult     = g_rt.blobDescriptor_mult;
 auto &blobDescriptor_rms_norm = g_rt.blobDescriptor_rms_norm;
+#if TRITON_ADD
+auto &blobDescriptor_triton_add = g_rt.blobDescriptor_triton_add;
+#endif
 #if TRITON_MAT_MUL
 auto &blobDescriptor_matmul   = g_rt.blobDescriptor_matmul;
 #endif
@@ -165,6 +174,9 @@ auto &blobDescriptor_matmul   = g_rt.blobDescriptor_matmul;
 auto &loadResult_add          = g_rt.loadResult_add;
 auto &loadResult_mult         = g_rt.loadResult_mult;
 auto &loadResult_rms_norm     = g_rt.loadResult_rms_norm;
+#if TRITON_ADD
+auto &loadResult_triton_add = g_rt.loadResult_triton_add;
+#endif
 #if TRITON_MAT_MUL
 auto &loadResult_matmul       = g_rt.loadResult_matmul;
 auto &advanced_matmul_shape_offload = g_rt.advanced_matmul_shape_offload;
@@ -1165,6 +1177,17 @@ static inline void tsi_blob_unload_only() {
             }
         }
     }
+#if TRITON_ADD
+    if (blobDescriptor_triton_add) {
+        for (uint32_t i = 0; i < TSI_RUN_TIME_INSTANCE; ++i) {
+            if (blobDescriptor_triton_add[i]) {
+                tsi_unload_blob(blobDescriptor_triton_add[i]);
+                blobDescriptor_triton_add[i] = nullptr;
+            }
+        }
+    }
+#endif
+
     if (blobDescriptor_mult) {
         for (uint32_t i = 0; i < TSI_RUN_TIME_INSTANCE; ++i) {
             if (blobDescriptor_mult[i]) {
@@ -1181,6 +1204,11 @@ static inline void tsi_blob_unload_only() {
             }
         }
     }
+#if TRITON_ADD
+    if (loadResult_triton_add) {
+        memset(loadResult_triton_add, 0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
+    }
+#endif
 #if TRITON_MAT_MUL
     if (blobDescriptor_matmul) {
         for (uint32_t i = 0; i < TSI_RUN_TIME_INSTANCE; ++i) {
@@ -1219,6 +1247,9 @@ static inline void tsi_blob_ensure_tables_allocated() {
     loadResult_add      = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
     loadResult_mult     = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
     loadResult_rms_norm = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
+#if TRITON_ADD
+    loadResult_triton_add = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
+#endif
 #if TRITON_MAT_MUL
     loadResult_matmul   = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
 #endif
@@ -1226,6 +1257,14 @@ static inline void tsi_blob_ensure_tables_allocated() {
     blobDescriptor_add      = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
     blobDescriptor_mult     = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
     blobDescriptor_rms_norm = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
+#if TRITON_ADD
+    blobDescriptor_triton_add = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
+    if (!loadResult_triton_add || !blobDescriptor_triton_add) {
+        tsi_blob_free_tables();
+        fprintf(stderr, "Failed to allocate Triton ADD blob tables\n");
+        abort();
+    }
+#endif
 #if TRITON_MAT_MUL
     blobDescriptor_matmul   = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
 #endif
@@ -1271,6 +1310,9 @@ static void tsi_load_all_blobs() {
 #if TRITON_MAT_MUL
         char name_matmul[64];
 #endif
+#if TRITON_ADD
+        char name_triton_add[64];
+#endif
 
 
 #ifdef GGML_TARGET_POSIX
@@ -1280,12 +1322,18 @@ static void tsi_load_all_blobs() {
 #if TRITON_MAT_MUL
         snprintf(name_matmul, sizeof(name_matmul), "txe_blob_0");
 #endif
+#if TRITON_ADD
+        snprintf(name_triton_add, sizeof(name_triton_add), "txe_blob_0");
+#endif
 #else
         snprintf(name_add,  sizeof(name_add),  "txe_add_dev%u",  i);
         snprintf(name_mult, sizeof(name_mult), "txe_mult_dev%u", i);
         snprintf(name_rms,  sizeof(name_rms),  "txe_rms_norm_dev%u", i);
 #if TRITON_MAT_MUL
         snprintf(name_matmul, sizeof(name_matmul), "txe_triton_mat_mul_dev%u", i);
+#endif
+#if TRITON_ADD
+        snprintf(name_triton_add, sizeof(name_triton_add), "txe_blob_0");
 #endif
 #endif
         failed_txe = i;
@@ -1353,6 +1401,24 @@ static void tsi_load_all_blobs() {
 
         blobDescriptor_matmul[i] =
             static_cast<BlobDescriptor *>(loadResult_matmul[i]);
+    #endif
+#if TRITON_ADD
+        // Triton ADD
+        loadResult_triton_add[i] = tsi_load_blob(
+            i,
+            name_triton_add,
+            blob_prefix(
+                TSAVORITE_BLOB_BUILD_ROOT "/txe_triton_add/blobs/txe_blob_0"
+            ).c_str()
+        );
+
+        if (!loadResult_triton_add[i]) {
+            strcpy(blob_name, name_triton_add);
+            goto error;
+        }
+
+        blobDescriptor_triton_add[i] =
+            static_cast<BlobDescriptor *>(loadResult_triton_add[i]);
     #endif
     }
 
@@ -3549,6 +3615,42 @@ extern "C" void _mlir_ciface_matmul_kernel_device_wrapper(
 // -----------------------------------------------------------------------------
 
 
+
+// Triton ADD direct blob pack helper.
+// Direct blob ABI packs only kernel args plus program_id.
+// Generated-wrapper grid args are not packed here.
+static inline void tsi_pack_triton_add_arg(
+    int64_t *p,
+    int &idx,
+    MemRefDescriptor<Rank_Triton> *d,
+    const char *name) {
+    if (!p || !d || !d->data) {
+        fprintf(stderr,
+                "ERROR: Triton ADD arg %s NULL p/desc/data p=%p desc=%p data=%p\n",
+                name,
+                (void *)p,
+                (void *)d,
+                d ? d->data : nullptr);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    p[idx++] = tsi_shmem_handle_from_ptr(d->data);
+    p[idx++] = (int64_t)d->shape[0];
+
+#if TRITON_DEBUG
+    fprintf(stderr,
+            "TRITON_ADD_PACK_ARG: %s data=%p handle=%ld shape0=%ld offset=%ld stride0=%ld\n",
+            name,
+            d->data,
+            (long)p[idx - 2],
+            (long)d->shape[0],
+            (long)d->offset,
+            (long)d->strides[0]);
+#endif
+}
+
 static inline void tsi_pack_triton_matmul_arg(
     int64_t *p,
     int &idx,
@@ -3591,6 +3693,215 @@ static inline void tsi_pack_triton_matmul_arg(
 // Note:
 //   Current implementation supports F32 only. BF16/F16 and mixed-precision
 //   are not supported in ggml-tsavorite.cpp.
+
+
+// Triton ADD manual direct-blob path.
+//
+// Host-wrapper path uses:
+//   A, B, C, n_elements, grid_x, grid_y, grid_z, max_txes
+//
+// Direct blob path packs only:
+//   A, B, C, n_elements, program_id
+//
+// Each packed arg is:
+//   handle, shape0
+//
+// Total:
+//   5 args * 2 int64 = 10 int64 = 80 bytes
+static void *_mlir_ciface_add_kernel_device_wrapper_triton_manual_internal(
+    void *A_desc_v,
+    void *B_desc_v,
+    void *C_desc_v,
+    void *n_elements_desc_v,
+    void *program_id_desc_v,
+    int32_t program_id,
+    TSI_DeviceIdType deviceId) {
+
+    constexpr int64_t kPackedArgsI64   = 10;
+    constexpr int64_t kPackedArgsBytes = kPackedArgsI64 * (int64_t)sizeof(int64_t);
+
+    std::lock_guard<std::mutex> lock(tsi_pack_mutex);
+
+    if ((uint32_t)deviceId >= num_of_txes) {
+        fprintf(stderr,
+                "ERROR: Triton ADD deviceId=%d out of range num_of_txes=%u\n",
+                (int)deviceId,
+                (unsigned)num_of_txes);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    if (packed_args.size() != num_of_txes || !packed_args[deviceId]) {
+        fprintf(stderr,
+                "ERROR: Triton ADD packed_args not initialized deviceId=%d size=%zu num_of_txes=%u\n",
+                (int)deviceId,
+                packed_args.size(),
+                (unsigned)num_of_txes);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    auto *A_desc = (MemRefDescriptor<Rank_Triton> *)A_desc_v;
+    auto *B_desc = (MemRefDescriptor<Rank_Triton> *)B_desc_v;
+    auto *C_desc = (MemRefDescriptor<Rank_Triton> *)C_desc_v;
+    auto *n_elements_desc = (MemRefDescriptor<Rank_Triton> *)n_elements_desc_v;
+    auto *program_id_desc = (MemRefDescriptor<Rank_Triton> *)program_id_desc_v;
+
+    if (!program_id_desc || !program_id_desc->data) {
+        fprintf(stderr, "ERROR: Triton ADD program_id descriptor/data is NULL\n");
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    int64_t *p = static_cast<int64_t *>(packed_args[deviceId]);
+    memset(p, 0, (size_t)kPackedArgsBytes);
+
+    A_desc->offset = 0;
+    B_desc->offset = 0;
+    C_desc->offset = 0;
+    n_elements_desc->offset = 0;
+    program_id_desc->offset = 0;
+    program_id_desc->shape[0] = (int64_t)program_id + 1;
+    program_id_desc->strides[0] = 1;
+    *((int32_t *)program_id_desc->data) = program_id;
+
+    int idx = 0;
+
+    tsi_pack_triton_add_arg(p, idx, A_desc, "A");
+    tsi_pack_triton_add_arg(p, idx, B_desc, "B");
+    tsi_pack_triton_add_arg(p, idx, C_desc, "C");
+    tsi_pack_triton_add_arg(p, idx, n_elements_desc, "n_elements");
+    tsi_pack_triton_add_arg(p, idx, program_id_desc, "program_id");
+
+    if (idx != kPackedArgsI64) {
+        fprintf(stderr,
+                "ERROR: Triton ADD packed idx=%d expected=%ld\n",
+                idx,
+                (long)kPackedArgsI64);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    void *commandList = tsi_create_command_list(deviceId);
+    if (!commandList) {
+        fprintf(stderr,
+                "ERROR: tsi_create_command_list failed for Triton ADD device=%d\n",
+                (int)deviceId);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    const int64_t packedHandle =
+        tsi_shmem_handle_from_ptr(packed_args[deviceId]);
+
+    if (!blobDescriptor_triton_add || !blobDescriptor_triton_add[0]) {
+        fprintf(stderr, "ERROR: Triton ADD blob descriptor is not loaded\n");
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    void *blobExecuteCmd = tsi_launch_blob(
+        blobDescriptor_triton_add[0],
+        packedHandle,
+        kPackedArgsBytes);
+
+    if (!blobExecuteCmd) {
+        fprintf(stderr,
+                "ERROR: tsi_launch_blob failed for Triton ADD device=%d blob_desc=%p packedHandle=%ld bytes=%ld\n",
+                (int)deviceId,
+                (void *)blobDescriptor_triton_add[0],
+                (long)packedHandle,
+                (long)kPackedArgsBytes);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
+    tsi_add_command_to_list(commandList, blobExecuteCmd);
+    return commandList;
+}
+
+
+static void _mlir_ciface_add_kernel_device_wrapper_triton_dispatch(
+    void *A_desc_v,
+    void *B_desc_v,
+    void *C_desc_v,
+    void *n_elements_desc_v,
+    void *grid1_desc_v,
+    void *grid2_desc_v,
+    void *grid3_desc_v,
+    void *max_txes_desc_v) {
+
+    tsi_init_per_txe_state_once();
+
+    if (!multi_thread_enable) {
+        _mlir_ciface_add_kernel_device_wrapper(
+            A_desc_v,
+            B_desc_v,
+            C_desc_v,
+            n_elements_desc_v,
+            grid1_desc_v,
+            grid2_desc_v,
+            grid3_desc_v,
+            max_txes_desc_v);
+        return;
+    }
+
+    static MemRefDescriptor<Rank_Triton> *triton_add_program_id_desc = nullptr;
+    static int32_t *triton_add_program_id_payload = nullptr;
+
+    if (!triton_add_program_id_desc || !triton_add_program_id_payload) {
+        triton_add_program_id_desc = (MemRefDescriptor<Rank_Triton> *)tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        triton_add_program_id_payload = (int32_t *)tsi_alloc(TRITON_MATMUL_ALIGNMENT_BYTES);
+        TSAVORITE_GGML_ASSERT(triton_add_program_id_desc);
+        TSAVORITE_GGML_ASSERT(triton_add_program_id_payload);
+    }
+
+    memset(triton_add_program_id_desc, 0, sizeof(MemRefDescriptor<Rank_Triton>));
+    triton_add_program_id_desc->base = triton_add_program_id_payload;
+    triton_add_program_id_desc->data = triton_add_program_id_payload;
+    triton_add_program_id_desc->offset = 0;
+    triton_add_program_id_desc->shape[0] = 1;
+    triton_add_program_id_desc->strides[0] = 1;
+    *triton_add_program_id_payload = 0;
+
+    int deviceId = acquire_device_blocking();
+
+    void *commandList =
+        _mlir_ciface_add_kernel_device_wrapper_triton_manual_internal(
+            A_desc_v,
+            B_desc_v,
+            C_desc_v,
+            n_elements_desc_v,
+            triton_add_program_id_desc,
+            0,
+            deviceId);
+
+    if (!commandList) {
+        fprintf(stderr,
+                "Command List Empty for Triton ADD on device %d\n",
+                deviceId);
+        fflush(stderr);
+        release_device(deviceId);
+        tsi_cleanup();
+        abort();
+    }
+
+    {
+        std::lock_guard<std::mutex> lk(workers_mutex);
+        workers.emplace_back([=]() {
+            tsi_blob_execution_internal(commandList);
+            release_device(deviceId);
+        });
+    }
+}
+
 
 static void *_mlir_ciface_matmul_kernel_device_wrapper_triton_manual_internal(
     void *A_desc_v,
@@ -5750,7 +6061,8 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
                         memset(scalar_grid2, 0, sizeof(MemRefDescriptor<Rank>));
                         memset(scalar_grid3, 0, sizeof(MemRefDescriptor<Rank>));
 
-                        scalar_loop->shape[0] = 1;
+                        //scalar_loop->shape[0] = 1;
+                        scalar_loop->shape[0] = (int32_t)srcP0->shape[0] +1;
                         scalar_loop->data = scalar_loop->base = (void *)(scalar_loop+1);
                         scalar_loop->offset = 0;
 
@@ -5791,8 +6103,8 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
 
                         init_scalar_i32_memref_aligned(scalar_max_txes, scalar_max_txes_payload, (int32_t)num_of_txes);
 
-                        _mlir_ciface_add_kernel_device_wrapper(srcP0, srcP1, nodeP,
-                                        scalar_loop, scalar_grid1, scalar_grid2, scalar_grid3, scalar_max_txes);
+                        _mlir_ciface_add_kernel_device_wrapper_triton_dispatch(srcP0, srcP1, nodeP,
+                                scalar_loop, scalar_grid1, scalar_grid2, scalar_grid3, scalar_max_txes);
                     } else {
 #endif /* TRITON_ADD */
                         ctx->kernels[kernel_type].pipeline->_mlir_fptr_2_input[kernel_sub_type](srcP0, srcP1, nodeP);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -6072,7 +6072,6 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
                         memset(scalar_grid2, 0, sizeof(MemRefDescriptor<Rank>));
                         memset(scalar_grid3, 0, sizeof(MemRefDescriptor<Rank>));
 
-                        //scalar_loop->shape[0] = 1;
                         scalar_loop->shape[0] = (int32_t)srcP0->shape[0] +1;
                         scalar_loop->data = scalar_loop->base = (void *)(scalar_loop+1);
                         scalar_loop->offset = 0;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -1163,6 +1163,17 @@ static inline void tsi_blob_free_tables() {
     }
 #endif
 
+#if TRITON_ADD
+    if (loadResult_triton_add) {
+        free(loadResult_triton_add);
+        loadResult_triton_add = nullptr;
+    }
+    if (blobDescriptor_triton_add) {
+        free(blobDescriptor_triton_add);
+        blobDescriptor_triton_add = nullptr;
+    }
+#endif
+
     g_rt.blob_tables_txes = 0;
     g_rt.blob_state = TsavoriteRuntimeState::BLOB_UNINITIALIZED;
 }


### PR DESCRIPTION
TSISIM
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# cat tsi-ggml/tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count: 20
multi_thread_enable: true

## Runtime user DRAM size in GiB.
## Example: 1 = 1GB, 2 = 2GB.
## If this key is missing, runtime DeviceConfig default is used.

user_dram_size_gb: 30


# Enable additional Triton MAT_MUL shapes beyond stable baseline.
# false = old behavior
# true  = new offload shapes
advanced_matmul_shape_offload: true

# Enable Triton MAT_MUL small-N transpose optimization.
# false = old behavior
# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
triton_matmul_small_n_transpose_opt: false
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
Using model: Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:true, triton_matmul_small_n_transpose_opt:false

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=30 user_dram_size_bytes=32212254720 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=0
[2026-08-01 03:03:01.412] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-08-01 03:03:01.415] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 3
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xf517bb405000, size = 17079185408
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf517bb405000, map_size = 17079185408
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf51cce5f03b8
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xf515bb405000, size = 8589934592
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf515bb405000, map_size = 8589934592
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf51cce5f0490
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 2: start_addr = 0xf51435400000, size = 6543134720
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf51435400000, map_size = 6543134720
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf51cce5f0568
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 3
[2026-08-01 03:03:01.416] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
 is Luna.


llama_perf_sampler_print:    sampling time =       8.79 ms /    11 runs   (    0.80 ms per token,  1251.28 tokens per second)
llama_perf_context_print:        load time = 1264866.14 ms
llama_perf_context_print: prompt eval time = 1262961.82 ms /     6 tokens (210493.64 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time = 5125628.13 ms /     4 runs   (1281407.03 ms per token,     0.00 tokens per second)
llama_perf_context_print:       total time = 6392583.28 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          484             694            236852            489.36
  MUL              OPU          495             710            207348            418.88
  RMS_NORM         OPU          495             495            111846            225.95
  MUL_MAT          CPU         4709               0           4566304            969.70
  MUL_MAT          OPU          979           19580       13833044570       14129769.73
  CONT             OPU          484               0             71687            148.11
  RESHAPE          CPU         2088               0              2119              1.01
  VIEW             CPU         1957               0               393              0.20
  VIEW             OPU          484               0               363              0.75
  PERMUTE          CPU         1357               0               737              0.54
  PERMUTE          OPU          484               0               261              0.54
  TRANSPOSE        CPU          637               0               145              0.23
  GET_ROWS         OPU           33               0               588             17.82
  SET_ROWS         CPU         1504               0             20889             13.89
  SOFT_MAX         OPU          242               0            120150            496.49
  ROPE             CPU         1556               0             11471              7.37
  GLU              OPU          242             347          16620083          68678.03



OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# cat ./tsi-ggml/tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count: 20
multi_thread_enable: true

## Runtime user DRAM size in GiB.
## Example: 1 = 1GB, 2 = 2GB.
## If this key is missing, runtime DeviceConfig default is used.

user_dram_size_gb: 30


# Enable additional Triton MAT_MUL shapes beyond stable baseline.
# false = old behavior
# true  = new offload shapes
advanced_matmul_shape_offload: true

# Enable Triton MAT_MUL small-N transpose optimization.
# false = old behavior
# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
triton_matmul_small_n_transpose_opt: false



oot@tsisim:/usr/bin/tsi/bin# cat tsi-ggml/tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count: 20
multi_thread_enable: true

## Runtime user DRAM size in GiB.
## Example: 1 = 1GB, 2 = 2GB.
## If this key is missing, runtime DeviceConfig default is used.

user_dram_size_gb: 30


# Enable additional Triton MAT_MUL shapes beyond stable baseline.
# false = old behavior
# true  = new offload shapes
advanced_matmul_shape_offload: false

# Enable Triton MAT_MUL small-N transpose optimization.
# false = old behavior
# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
triton_matmul_small_n_transpose_opt: false
root@tsisim:/usr/bin/tsi/bin# 



root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# vi ./tsi-ggml/tsavorite-model-deployment.yaml 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
Using model: tinyllama-vo-5m-para.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
[2026-07-31 19:15:04.992] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-07-31 19:15:04.996] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-07-31 19:15:04.997] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 1
[2026-07-31 19:15:04.998] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xe865e73b0000, size = 8589934592
[2026-07-31 19:15:04.998] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xe865e73b0000, map_size = 8589934592
[2026-07-31 19:15:04.998] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xe869005a03b8
[2026-07-31 19:15:04.998] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-07-31 19:15:04.998] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
 was?" late." and



llama_perf_sampler_print:    sampling time =       8.33 ms /    11 runs   (    0.76 ms per token,  1320.85 tokens per second)
llama_perf_context_print:        load time =     585.37 ms
llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =    1428.02 ms /     4 runs   (  357.01 ms per token,     2.80 tokens per second)
llama_perf_context_print:       total time =    1660.64 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          160             160              9796             61.23
  MUL              OPU          170             170              6981             41.06
  RMS_NORM         OPU          170             170              8291             48.77
  MUL_MAT          CPU         2593               0            129130             49.80
  CONT             OPU          160               0              4540             28.38
  RESHAPE          CPU          627               0               107              0.17
  VIEW             CPU          599               0                50              0.08
  VIEW             OPU          160               0                70              0.44
  PERMUTE          CPU          407               0                38              0.09
  PERMUTE          OPU          160               0                35              0.22
  TRANSPOSE        CPU          219               0                30              0.14
  GET_ROWS         OPU           30               0               129              4.30
  SET_ROWS         CPU          506               0               771              1.52
  SOFT_MAX         OPU           80               0             13552            169.40
  ROPE             CPU          499               0              1076              2.16
  GLU              OPU           80              80            556994           6962.43

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
Using model: tinyllama-vo-5m-para.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
[2026-07-31 19:16:16.264] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-07-31 19:16:16.268] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-07-31 19:16:16.270] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 1
[2026-07-31 19:16:16.270] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xf0ef30ff0000, size = 8589934592
[2026-07-31 19:16:16.270] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf0ef30ff0000, map_size = 8589934592
[2026-07-31 19:16:16.270] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf0f24a1e03b8
[2026-07-31 19:16:16.270] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-07-31 19:16:16.270] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
 was?" late." and

llama_perf_sampler_print:    sampling time =       8.55 ms /    11 runs   (    0.78 ms per token,  1286.70 tokens per second)
llama_perf_context_print:        load time =     586.10 ms
llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =    1434.35 ms /     4 runs   (  358.59 ms per token,     2.79 tokens per second)
llama_perf_context_print:       total time =    1668.05 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us


  ADD              OPU          160             160              7905             49.41
  MUL              OPU          170             170              7801             45.89
  RMS_NORM         OPU          170             170              9393             55.25
  MUL_MAT          CPU         2586               0            120267             46.51
  CONT             OPU          160               0              4572             28.57
  RESHAPE          CPU          619               0               151              0.24
  VIEW             CPU          619               0                70              0.11
  VIEW             OPU          160               0                71              0.44
  PERMUTE          CPU          402               0                47              0.12
  PERMUTE          OPU          160               0                47              0.29
  TRANSPOSE        CPU          208               0                54              0.26
  GET_ROWS         OPU           30               0               115              3.83
  SET_ROWS         CPU          517               0               664              1.28
  SOFT_MAX         OPU           80               0             13651            170.64
  ROPE             CPU          522               0              1385              2.65
  GLU              OPU           80              80            555435           6942.94

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# vi ./tsi-ggml/tsa^C
root@tsisim:/usr/bin/tsi/bin# cd tsi-ggml
-bash: cd: tsi-ggml: No such file or directory
root@tsisim:/usr/bin/tsi/bin# ls -lrt
total 2664
-rwxr-xr-x 1 root root   47540 Jul 29 22:13 vecadd_blob_tvu_main.blob
-rwxr-xr-x 1 root root  128712 Jul 29 22:13 tsictl
-rwxr-xr-x 1 root root 1014150 Jul 29 22:13 tsi_txe_kernel.lst
-rwxr-xr-x 1 root root  139820 Jul 29 22:13 tsi_txe_kernel.elf
-rwxr-xr-x 1 root root   37468 Jul 29 22:13 tsi_txe_kernel.bin
-rwxr-xr-x 1 root root  647288 Jul 29 22:13 tnApcMgr
-rwxr-xr-x 1 root root   79976 Jul 29 22:13 sys-diagtool
-rwxr-xr-x 1 root root    1967 Jul 29 22:13 run_platform_test.sh
-rwxr-xr-x 1 root root   81216 Jul 29 22:13 recvFromHost
-rw-r--r-- 1 root root     546 Jul 29 22:13 platform_layout.json
lrwxrwxrwx 1 root root      46 Jul 29 22:13 aot-tests -> /tsi/tsi-sw/sdk/sdk-r.0.4.20/fpga/qa/aot-tests
-rwxr-xr-x 1 root root  516360 Jul 29 22:13 UAP
lrwxrwxrwx 1 root root      33 Jul 31 01:09 tsi-ggml -> /tsi/tsi-sw/anoop-sdk-20/tsi-ggml
-rwxr-xr-x 1 root root    1722 Jul 31 18:39 run_llama_cli.sh
root@tsisim:/usr/bin/tsi/bin# vi ./tsi-ggml/tsavorite-model-deployment.yaml 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
Using model: tinyllama-vo-5m-para.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=30 user_dram_size_bytes=32212254720 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
[2026-08-01 02:33:12.088] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-08-01 02:33:12.091] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 3
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xee422df85000, size = 17079185408
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xee422df85000, map_size = 17079185408
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xee47411703b8
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xee402df85000, size = 8589934592
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xee402df85000, map_size = 8589934592
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xee4741170490
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 2: start_addr = 0xee3ea7f80000, size = 6543134720
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xee3ea7f80000, map_size = 6543134720
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xee4741170568
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 3
[2026-08-01 02:33:12.093] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
 was Tim. He loved



llama_perf_sampler_print:    sampling time =       8.46 ms /    11 runs   (    0.77 ms per token,  1300.24 tokens per second)
llama_perf_context_print:        load time =     606.98 ms
llama_perf_context_print: prompt eval time =       0.00 ms /     1 tokens (    0.00 ms per token,      inf tokens per second)
llama_perf_context_print:        eval time =    1492.34 ms /     4 runs   (  373.08 ms per token,     2.68 tokens per second)
llama_perf_context_print:       total time =    1727.08 ms /     5 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          160             160              9381             58.63
  MUL              OPU          170             170              8690             51.12
  RMS_NORM         OPU          170             170              9508             55.93
  MUL_MAT          CPU         2549               0            124726             48.93
  CONT             OPU          160               0              4629             28.93
  RESHAPE          CPU          658               0               118              0.18
  VIEW             CPU          617               0                45              0.07
  VIEW             OPU          160               0                77              0.48
  PERMUTE          CPU          410               0                78              0.19
  PERMUTE          OPU          160               0                46              0.29
  TRANSPOSE        CPU          227               0                31              0.14
  GET_ROWS         OPU           30               0               128              4.27
  SET_ROWS         CPU          526               0               768              1.46
  SOFT_MAX         OPU           80               0             13469            168.36
  ROPE             CPU          516               0              1749              3.39
  GLU              OPU           80              80            564389           7054.86

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
Using model: Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=30 user_dram_size_bytes=32212254720 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
[2026-08-01 02:33:47.744] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-08-01 02:33:47.747] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-08-01 02:33:47.748] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 3
[2026-08-01 02:33:47.748] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xfc4283195000, size = 17079185408
[2026-08-01 02:33:47.748] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xfc4283195000, map_size = 17079185408
[2026-08-01 02:33:47.748] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xfc47963803b8
[2026-08-01 02:33:47.748] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xfc4083195000, size = 8589934592
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xfc4083195000, map_size = 8589934592
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xfc4796380490
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 2: start_addr = 0xfc3efd190000, size = 6543134720
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xfc3efd190000, map_size = 6543134720
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xfc4796380568
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 3
[2026-08-01 02:33:47.749] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
 is Luna.




llama_perf_sampler_print:    sampling time =       8.76 ms /    11 runs   (    0.80 ms per token,  1256.14 tokens per second)
llama_perf_context_print:        load time = 1129411.71 ms
llama_perf_context_print: prompt eval time = 1127479.83 ms /     6 tokens (187913.31 ms per token,     0.01 tokens per second)
llama_perf_context_print:        eval time =   19884.85 ms /     4 runs   ( 4971.21 ms per token,     0.20 tokens per second)
llama_perf_context_print:       total time = 1149308.65 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          484             694            108127            223.40
  MUL              OPU          495             710             80645            162.92
  RMS_NORM         OPU          495             495             41853             84.55
  MUL_MAT          CPU         8290               0          21281499           2567.13
  MUL_MAT          OPU           85            1700        1110576657       13065607.73
  CONT             OPU          484               0             59543            123.02
  RESHAPE          CPU         2043               0              1778              0.87
  VIEW             CPU         1930               0               351              0.18
  VIEW             OPU          484               0               321              0.66
  PERMUTE          CPU         1243               0               228              0.18
  PERMUTE          OPU          484               0               159              0.33
  TRANSPOSE        CPU          634               0               150              0.24
  GET_ROWS         OPU           33               0               351             10.64
  SET_ROWS         CPU         1515               0             10876              7.18
  SOFT_MAX         OPU          242               0            115547            477.47
  ROPE             CPU         1438               0              9344              6.50
  GLU              OPU          242             347          16898841          69829.92

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# vi run_llama_cli.sh 
[>4;mroot@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
Using model: tinyllama-vo-5m-para.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:false, triton_matmul_small_n_transpose_opt:false

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=30 user_dram_size_bytes=32212254720 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
[2026-08-01 03:00:08.667] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-08-01 03:00:08.670] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 3
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xfc53d15e5000, size = 17079185408
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xfc53d15e5000, map_size = 17079185408
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xfc58e47d03b8
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xfc51d15e5000, size = 8589934592
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xfc51d15e5000, map_size = 8589934592
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xfc58e47d0490
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 2: start_addr = 0xfc504b5e0000, size = 6543134720
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xfc504b5e0000, map_size = 6543134720
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xfc58e47d0568
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 3
[2026-08-01 03:00:08.671] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
 was Tim. He loved



llama_perf_sampler_print:    sampling time =      13.75 ms /    11 runs   (    1.25 ms per token,   799.83 tokens per second)
llama_perf_context_print:        load time =    1070.55 ms
llama_perf_context_print: prompt eval time =     843.18 ms /     6 tokens (  140.53 ms per token,     7.12 tokens per second)
llama_perf_context_print:        eval time =    1485.91 ms /     4 runs   (  371.48 ms per token,     2.69 tokens per second)
llama_perf_context_print:       total time =    2572.79 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          176             246             12203             69.34
  MUL              OPU          187             262             11019             58.93
  RMS_NORM         OPU          187             187              9230             49.36
  MUL_MAT          CPU         2850               0            183873             64.52
  CONT             OPU          176               0              5037             28.62
  RESHAPE          CPU          694               0               139              0.20
  VIEW             CPU          689               0                59              0.09
  VIEW             OPU          176               0                83              0.47
  PERMUTE          CPU          483               0                82              0.17
  PERMUTE          OPU          176               0                39              0.22
  TRANSPOSE        CPU          234               0                33              0.14
  GET_ROWS         OPU           33               0                78              2.36
  SET_ROWS         CPU          592               0               695              1.17
  SOFT_MAX         OPU           88               0             21248            241.45
  ROPE             CPU          547               0              1001              1.83
  GLU              OPU           88             123            875085           9944.15

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 











POSIX

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ cat tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count: 1
multi_thread_enable: true

## Runtime user DRAM size in GiB.
##
## Typical requirements:
##   - Small models may work with lower memory allocations.
##   - Llama 3.2 1B was observed to require ~1.8 GB with 20 TXEs.
##   - For general use, 4 GB is a reasonable starting point.
##   - Larger models may require significantly more memory (for example, 12 GB to 24 GB).
##
## If this key is omitted, the runtime DeviceConfig default memory size is used.
##
## Examples:
##   user_dram_size_gb: 4
##   user_dram_size_gb: 8
##   user_dram_size_gb: 12
##   user_dram_size_gb: 24
user_dram_size_gb: 8

# Enable additional Triton MAT_MUL shapes beyond stable baseline.
# false = old behavior
# true  = new offload shapes
advanced_matmul_shape_offload: false

# Enable Triton MAT_MUL small-N transpose optimization.
# false = old behavior
# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
triton_matmul_small_n_transpose_opt: false
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli-original   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/tinyllama-vo-5m-para.gguf   --device tsavorite   -c 12288   --temp 0.0   --n-predict 20   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
 My cat's name is Tim. He has a big, red ball. Tim likes to play with his ball. He likes



llama_perf_sampler_print:    sampling time =      50.32 ms /    27 runs   (    1.86 ms per token,   536.54 tokens per second)
llama_perf_context_print:        load time =     664.40 ms
llama_perf_context_print: prompt eval time =     254.67 ms /     7 tokens (   36.38 ms per token,    27.49 tokens per second)
llama_perf_context_print:        eval time =    1058.12 ms /    19 runs   (   55.69 ms per token,    17.96 tokens per second)
llama_perf_context_print:       total time =    1777.51 ms /    26 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU         3056            3140            189826             62.12
  MUL              OPU         3247            3337           3081764            949.11
  RMS_NORM         OPU         3247            3247           2771092            853.43
  MUL_MAT          CPU        53995               0           1904807             35.28
  CONT             OPU         3056               0            151175             49.47
  RESHAPE          CPU        15720               0              2676              0.17
  VIEW             CPU        15075               0              1707              0.11
  VIEW             OPU         3056               0               354              0.12
  PERMUTE          CPU         9351               0              1403              0.15
  PERMUTE          OPU         3056               0               385              0.13
  TRANSPOSE        CPU         5637               0               787              0.14
  GET_ROWS         OPU          573               0               549              0.96
  SET_ROWS         CPU        11368               0              5371              0.47
  SOFT_MAX         OPU         1528               0            222686            145.74
  ROPE             CPU        11539               0             13525              1.17
  GLU              OPU         1528            1570           1618576           1059.28

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ vi tsavorite-model-deployment.yaml 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ cat tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count: 1
multi_thread_enable: false

## Runtime user DRAM size in GiB.
##
## Typical requirements:
##   - Small models may work with lower memory allocations.
##   - Llama 3.2 1B was observed to require ~1.8 GB with 20 TXEs.
##   - For general use, 4 GB is a reasonable starting point.
##   - Larger models may require significantly more memory (for example, 12 GB to 24 GB).
##
## If this key is omitted, the runtime DeviceConfig default memory size is used.
##
## Examples:
##   user_dram_size_gb: 4
##   user_dram_size_gb: 8
##   user_dram_size_gb: 12
##   user_dram_size_gb: 24
user_dram_size_gb: 8

# Enable additional Triton MAT_MUL shapes beyond stable baseline.
# false = old behavior
# true  = new offload shapes
advanced_matmul_shape_offload: false

# Enable Triton MAT_MUL small-N transpose optimization.
# false = old behavior
# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
triton_matmul_small_n_transpose_opt: false
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli-original   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/tinyllama-vo-5m-para.gguf   --device tsavorite   -c 12288   --temp 0.0   --n-predict 20   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
 My cat's name is Tim. He has a big, red ball. Tim likes to play with his ball. He likes

llama_perf_sampler_print:    sampling time =      48.56 ms /    27 runs   (    1.80 ms per token,   556.04 tokens per second)


llama_perf_context_print:        load time =     673.35 ms
llama_perf_context_print: prompt eval time =     263.67 ms /     7 tokens (   37.67 ms per token,    26.55 tokens per second)
llama_perf_context_print:        eval time =    1186.39 ms /    19 runs   (   62.44 ms per token,    16.01 tokens per second)
llama_perf_context_print:       total time =    1912.97 ms /    26 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU         3056            3140           2192826            717.55
  MUL              OPU         3247            3337           2523806            777.27
  RMS_NORM         OPU         3247            3247           2911513            896.68
  MUL_MAT          CPU        53489               0           1783311             33.34
  CONT             OPU         3056               0            142059             46.49
  RESHAPE          CPU        16062               0              2394              0.15
  VIEW             CPU        14869               0              1633              0.11
  VIEW             OPU         3056               0               399              0.13
  PERMUTE          CPU         9700               0              1303              0.13
  PERMUTE          OPU         3056               0               346              0.11
  TRANSPOSE        CPU         5891               0               893              0.15
  GET_ROWS         OPU          573               0               563              0.98
  SET_ROWS         CPU        11261               0              5802              0.52
  SOFT_MAX         OPU         1528               0            361337            236.48
  ROPE             CPU        11750               0             14242              1.21
  GLU              OPU         1528            1570           1817584           1189.52

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli-original   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/tinyllama-vo-5m-para.gguf   --device none   -c 12288   --temp 0.0   --n-predict 20   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=0 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=0 triton_matmul_small_n_transpose_opt=0
 My cat's name is Tim. He has a big, red ball. Tim likes to play with his ball. He likes



llama_perf_sampler_print:    sampling time =      39.18 ms /    27 runs   (    1.45 ms per token,   689.14 tokens per second)
llama_perf_context_print:        load time =     170.37 ms
llama_perf_context_print: prompt eval time =      19.98 ms /     7 tokens (    2.85 ms per token,   350.42 tokens per second)
llama_perf_context_print:        eval time =      36.96 ms /    19 runs   (    1.95 ms per token,   514.01 tokens per second)
llama_perf_context_print:       total time =     249.64 ms /    26 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              CPU        11294               0              4810              0.43
  MUL              CPU        11965               0             21032              1.76
  RMS_NORM         CPU        11858               0              2590              0.22
  MUL_MAT          CPU        38599               0            943332             24.44
  CPY              CPU          764               0             67315             88.11
  RESHAPE          CPU        19007               0              1767              0.09
  VIEW             CPU        22903               0              1644              0.07
  PERMUTE          CPU        13842               0              1063              0.08
  GET_ROWS         CPU         2181               0              1492              0.68
  SET_ROWS         CPU        11100               0              2073              0.19
  ROPE             CPU        11167               0              7223              0.65
  FLASH_ATTN_EXT   CPU         6096               0            160881             26.39
  GLU              CPU         5636               0              7603              1.35
[akapoor@wspd0 llama.cpp]$ 





##########





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds manual arg packing and direct-blob execution for Triton ADD to enable safe multi-threaded runs on Tsavorite. Addresses Linear `FIR-2139` and falls back to the existing host wrapper when `multi_thread_enable` is off.

- **New Features**
  - Adds Triton ADD blob tables/descriptors with load/unload/free; loads `txe_blob_0` across TXEs.
  - Implements `tsi_pack_triton_add_arg` and `_mlir_ciface_add_kernel_device_wrapper_triton_manual_internal` to pack A/B/C, `n_elements`, and `program_id` (handle + shape) and launch via `tsi_launch_blob` with command lists.
  - Introduces `_mlir_ciface_add_kernel_device_wrapper_triton_dispatch` to route to the manual path when `multi_thread_enable` is true, allocate the `program_id` scalar, acquire a device, and queue work on worker threads; otherwise uses the host wrapper.
  - Updates the ADD call site to use the dispatch wrapper and sets `scalar_loop->shape[0] = srcP0->shape[0] + 1` for correct `program_id` encoding.
  - Adds allocation checks and unload/cleanup for Triton ADD blob tables to guard against invalid state.

<sup>Written for commit bac529fad8ec73743f38640756028361043448d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/llama.cpp/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



