### PR TITLE
@FIR-2147 Add llama.cpp Runtime Support for Triton MAT_MUL 1x8 and 2x…

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -4758,8 +4758,6 @@ static inline triton_matmul_dispatch_profile_t call_triton_matmul_full_packed_on
 
     TSAVORITE_GGML_ASSERT(deviceId >= 0);
     TSAVORITE_GGML_ASSERT((uint32_t)deviceId < num_of_txes);
-    TSAVORITE_GGML_ASSERT((M_pad % TRITON_MATMUL_1X8_M_DIM) == 0);
-    TSAVORITE_GGML_ASSERT((N_pad % TRITON_MATMUL_1X8_N_DIM) == 0);
     TSAVORITE_GGML_ASSERT((K % TRITON_MATMUL_F32_K_DIM) == 0);
 
     triton_matmul_desc_set_t *s = ensure_triton_desc_for_device(deviceId);
@@ -4956,8 +4954,10 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     //   future 2x4 path, then call the same transpose heuristic with that shape.
     // ============================================================
     if (!multi_thread_enable || num_of_txes <= 1) {
+        const triton_matmul_txe_shape_t &transpose_decision_shape =
+            triton_matmul_select_shape(M, N);
         const bool use_small_n_transpose =
-            triton_matmul_should_use_small_n_transpose(TRITON_MATMUL_SHAPE_1X8, M, N, K);
+            triton_matmul_should_use_small_n_transpose(transpose_decision_shape, M, N, K);
 
         const int64_t M_work = use_small_n_transpose ? N : M;
         const int64_t N_work = use_small_n_transpose ? M : N;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -110,7 +110,8 @@ struct TsavoriteRuntimeState {
     BlobDescriptor **blobDescriptor_triton_add = nullptr;
 #endif
 #if TRITON_MAT_MUL
-    BlobDescriptor **blobDescriptor_matmul = nullptr;
+    BlobDescriptor **blobDescriptor_matmul_1x8 = nullptr;
+    BlobDescriptor **blobDescriptor_matmul_2x4 = nullptr;
 #endif
 
 
@@ -121,7 +122,8 @@ struct TsavoriteRuntimeState {
     void **loadResult_triton_add = nullptr;
 #endif
 #if TRITON_MAT_MUL
-    void **loadResult_matmul = nullptr;
+    void **loadResult_matmul_1x8 = nullptr;
+    void **loadResult_matmul_2x4 = nullptr;
     bool advanced_matmul_shape_offload = false;
     bool triton_matmul_small_n_transpose_opt = false;
 #endif
@@ -167,7 +169,8 @@ auto &blobDescriptor_rms_norm = g_rt.blobDescriptor_rms_norm;
 auto &blobDescriptor_triton_add = g_rt.blobDescriptor_triton_add;
 #endif
 #if TRITON_MAT_MUL
-auto &blobDescriptor_matmul   = g_rt.blobDescriptor_matmul;
+auto &blobDescriptor_matmul_1x8 = g_rt.blobDescriptor_matmul_1x8;
+auto &blobDescriptor_matmul_2x4 = g_rt.blobDescriptor_matmul_2x4;
 #endif
 
 
@@ -178,7 +181,8 @@ auto &loadResult_rms_norm     = g_rt.loadResult_rms_norm;
 auto &loadResult_triton_add = g_rt.loadResult_triton_add;
 #endif
 #if TRITON_MAT_MUL
-auto &loadResult_matmul       = g_rt.loadResult_matmul;
+auto &loadResult_matmul_1x8     = g_rt.loadResult_matmul_1x8;
+auto &loadResult_matmul_2x4     = g_rt.loadResult_matmul_2x4;
 auto &advanced_matmul_shape_offload = g_rt.advanced_matmul_shape_offload;
 auto &triton_matmul_small_n_transpose_opt = g_rt.triton_matmul_small_n_transpose_opt;
 #endif
@@ -1152,14 +1156,22 @@ static inline void tsi_blob_free_tables() {
     }
 
 #if TRITON_MAT_MUL
-    if (loadResult_matmul) {
-        free(loadResult_matmul);
-        loadResult_matmul = nullptr;
+    if (loadResult_matmul_1x8) {
+        free(loadResult_matmul_1x8);
+        loadResult_matmul_1x8 = nullptr;
+    }
+    if (loadResult_matmul_2x4) {
+        free(loadResult_matmul_2x4);
+        loadResult_matmul_2x4 = nullptr;
     }
 
-    if (blobDescriptor_matmul) {
-        free(blobDescriptor_matmul);
-        blobDescriptor_matmul = nullptr;
+    if (blobDescriptor_matmul_1x8) {
+        free(blobDescriptor_matmul_1x8);
+        blobDescriptor_matmul_1x8 = nullptr;
+    }
+    if (blobDescriptor_matmul_2x4) {
+        free(blobDescriptor_matmul_2x4);
+        blobDescriptor_matmul_2x4 = nullptr;
     }
 #endif
 
@@ -1221,11 +1233,19 @@ static inline void tsi_blob_unload_only() {
     }
 #endif
 #if TRITON_MAT_MUL
-    if (blobDescriptor_matmul) {
+    if (blobDescriptor_matmul_1x8) {
         for (uint32_t i = 0; i < TSI_RUN_TIME_INSTANCE; ++i) {
-            if (blobDescriptor_matmul[i]) {
-                tsi_unload_blob(blobDescriptor_matmul[i]);
-                blobDescriptor_matmul[i] = nullptr;
+            if (blobDescriptor_matmul_1x8[i]) {
+                tsi_unload_blob(blobDescriptor_matmul_1x8[i]);
+                blobDescriptor_matmul_1x8[i] = nullptr;
+            }
+        }
+    }
+    if (blobDescriptor_matmul_2x4) {
+        for (uint32_t i = 0; i < TSI_RUN_TIME_INSTANCE; ++i) {
+            if (blobDescriptor_matmul_2x4[i]) {
+                tsi_unload_blob(blobDescriptor_matmul_2x4[i]);
+                blobDescriptor_matmul_2x4[i] = nullptr;
             }
         }
     }
@@ -1236,8 +1256,11 @@ static inline void tsi_blob_unload_only() {
     if (loadResult_mult)     memset(loadResult_mult,     0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
     if (loadResult_rms_norm) memset(loadResult_rms_norm, 0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
 #if TRITON_MAT_MUL
-    if (loadResult_matmul) {
-        memset(loadResult_matmul, 0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
+    if (loadResult_matmul_1x8) {
+        memset(loadResult_matmul_1x8, 0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
+    }
+    if (loadResult_matmul_2x4) {
+        memset(loadResult_matmul_2x4, 0, TSI_RUN_TIME_INSTANCE * sizeof(void *));
     }
 #endif
 
@@ -1262,7 +1285,8 @@ static inline void tsi_blob_ensure_tables_allocated() {
     loadResult_triton_add = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
 #endif
 #if TRITON_MAT_MUL
-    loadResult_matmul   = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
+    loadResult_matmul_1x8 = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
+    loadResult_matmul_2x4 = (void **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(void *));
 #endif
 
     blobDescriptor_add      = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
@@ -1277,16 +1301,17 @@ static inline void tsi_blob_ensure_tables_allocated() {
     }
 #endif
 #if TRITON_MAT_MUL
-    blobDescriptor_matmul   = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
+    blobDescriptor_matmul_1x8 = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
+    blobDescriptor_matmul_2x4 = (BlobDescriptor **)calloc(TSI_RUN_TIME_INSTANCE, sizeof(BlobDescriptor *));
 #endif
 
     if (!loadResult_add || !loadResult_mult || !loadResult_rms_norm ||
 #if TRITON_MAT_MUL
-        !loadResult_matmul ||
+        !loadResult_matmul_1x8 || !loadResult_matmul_2x4 ||
 #endif
         !blobDescriptor_add || !blobDescriptor_mult || !blobDescriptor_rms_norm
 #if TRITON_MAT_MUL
-        || !blobDescriptor_matmul
+        || !blobDescriptor_matmul_1x8 || !blobDescriptor_matmul_2x4
 #endif
         ) {
         // free any partial allocations before abort
@@ -1320,6 +1345,7 @@ static void tsi_load_all_blobs() {
         char name_rms[64];
 #if TRITON_MAT_MUL
         char name_matmul[64];
+        char name_matmul_2x4[64];
 #endif
 #if TRITON_ADD
         char name_triton_add[64];
@@ -1332,6 +1358,7 @@ static void tsi_load_all_blobs() {
         snprintf(name_rms,  sizeof(name_rms),  "txe_rms_norm");
 #if TRITON_MAT_MUL
         snprintf(name_matmul, sizeof(name_matmul), "txe_blob_0");
+        snprintf(name_matmul_2x4, sizeof(name_matmul_2x4), "txe_blob_0");
 #endif
 #if TRITON_ADD
         snprintf(name_triton_add, sizeof(name_triton_add), "txe_blob_0");
@@ -1341,7 +1368,8 @@ static void tsi_load_all_blobs() {
         snprintf(name_mult, sizeof(name_mult), "txe_mult_dev%u", i);
         snprintf(name_rms,  sizeof(name_rms),  "txe_rms_norm_dev%u", i);
 #if TRITON_MAT_MUL
-        snprintf(name_matmul, sizeof(name_matmul), "txe_triton_mat_mul_dev%u", i);
+        snprintf(name_matmul, sizeof(name_matmul), "txe_triton_mat_mul_1x8_dev%u", i);
+        snprintf(name_matmul_2x4, sizeof(name_matmul_2x4), "txe_triton_mat_mul_2x4_dev%u", i);
 #endif
 #if TRITON_ADD
         snprintf(name_triton_add, sizeof(name_triton_add), "txe_blob_0");
@@ -1396,22 +1424,41 @@ static void tsi_load_all_blobs() {
 
 
     #if TRITON_MAT_MUL
-        // Triton MAT_MUL
-        loadResult_matmul[i] = tsi_load_blob(
+        // Triton MAT_MUL 1x8
+        loadResult_matmul_1x8[i] = tsi_load_blob(
             i,
             name_matmul,
             blob_prefix(
-                TSAVORITE_BLOB_BUILD_ROOT "/txe_triton_mat_mul/blobs/txe_blob_0"
+                TSAVORITE_BLOB_BUILD_ROOT "/txe_triton_mat_mul_1x8/blobs/txe_blob_0"
             ).c_str()
         );
 
-        if (!loadResult_matmul[i]) {
+        if (!loadResult_matmul_1x8[i]) {
             strcpy(blob_name, name_matmul);
             goto error;
         }
 
-        blobDescriptor_matmul[i] =
-            static_cast<BlobDescriptor *>(loadResult_matmul[i]);
+        blobDescriptor_matmul_1x8[i] =
+            static_cast<BlobDescriptor *>(loadResult_matmul_1x8[i]);
+
+        // Triton MAT_MUL 2x4. Same packed-args ABI as 1x8; only blob/wrapper differs.
+        if (advanced_matmul_shape_offload) {
+            loadResult_matmul_2x4[i] = tsi_load_blob(
+                i,
+                name_matmul_2x4,
+                blob_prefix(
+                    TSAVORITE_BLOB_BUILD_ROOT "/txe_triton_mat_mul_2x4/blobs/txe_blob_0"
+                ).c_str()
+            );
+
+            if (!loadResult_matmul_2x4[i]) {
+                strcpy(blob_name, name_matmul_2x4);
+                goto error;
+            }
+
+            blobDescriptor_matmul_2x4[i] =
+                static_cast<BlobDescriptor *>(loadResult_matmul_2x4[i]);
+        }
     #endif
 #if TRITON_ADD
         // Triton ADD
@@ -3036,9 +3083,11 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
      * Current 1x8 Triton shape padding.
      */
     const int64_t M_pad = ((M + 7)  / 8)  * 8;
-    const int64_t N_pad = ((N + 63) / 64) * 64;
+    const int64_t N_pad_legacy_unused = ((N + 63) / 64) * 64;
+    (void)N_pad_legacy_unused;
 
     const int64_t elems_A = M_pad * K;
+    const int64_t N_pad = ((N + 63) / 64) * 64;
     const int64_t elems_B = K * N_pad;
     const int64_t elems_C = M_pad * N_pad;
 
@@ -3555,16 +3604,58 @@ void _mlir_ciface_txe_mul_mat_tile_f32_k2048_host  (void *A_tile, void *B_tile, 
 //     uses the same flattened A[M,K], B[K,N], C[M,N] contract.
 #define TRITON_MATMUL_1X8_M_DIM      8
 #define TRITON_MATMUL_1X8_N_DIM     64
+#define TRITON_MATMUL_2X4_M_DIM     16
+#define TRITON_MATMUL_2X4_N_DIM     32
+
+enum triton_matmul_shape_kind_t {
+    TRITON_MATMUL_KIND_1X8 = 0,
+    TRITON_MATMUL_KIND_2X4 = 1,
+};
 
 struct triton_matmul_txe_shape_t {
     int64_t m_dim;
     int64_t n_dim;
+    triton_matmul_shape_kind_t kind;
+    const char *name;
 };
 
 static constexpr triton_matmul_txe_shape_t TRITON_MATMUL_SHAPE_1X8 = {
     TRITON_MATMUL_1X8_M_DIM,
     TRITON_MATMUL_1X8_N_DIM,
+    TRITON_MATMUL_KIND_1X8,
+    "1x8",
 };
+
+static constexpr triton_matmul_txe_shape_t TRITON_MATMUL_SHAPE_2X4 = {
+    TRITON_MATMUL_2X4_M_DIM,
+    TRITON_MATMUL_2X4_N_DIM,
+    TRITON_MATMUL_KIND_2X4,
+    "2x4",
+};
+
+static inline int64_t triton_matmul_padding_cost(
+    const triton_matmul_txe_shape_t &shape,
+    int64_t M,
+    int64_t N) {
+    if (M <= 0 || N <= 0 || shape.m_dim <= 0 || shape.n_dim <= 0) {
+        return INT64_MAX;
+    }
+    const int64_t M_pad = ((M + shape.m_dim - 1) / shape.m_dim) * shape.m_dim;
+    const int64_t N_pad = ((N + shape.n_dim - 1) / shape.n_dim) * shape.n_dim;
+    return M_pad * N_pad;
+}
+
+static inline const triton_matmul_txe_shape_t &triton_matmul_select_shape(
+    int64_t M,
+    int64_t N) {
+    if (!advanced_matmul_shape_offload) {
+        return TRITON_MATMUL_SHAPE_1X8;
+    }
+
+    const int64_t cost_1x8 = triton_matmul_padding_cost(TRITON_MATMUL_SHAPE_1X8, M, N);
+    const int64_t cost_2x4 = triton_matmul_padding_cost(TRITON_MATMUL_SHAPE_2X4, M, N);
+    return (cost_2x4 < cost_1x8) ? TRITON_MATMUL_SHAPE_2X4 : TRITON_MATMUL_SHAPE_1X8;
+}
 
 
 // Data type specific
@@ -3587,7 +3678,19 @@ extern "C" void _mlir_ciface_add_kernel_device_wrapper(
     void *grid_z_scalar,
     void *max_txes_scalar);
 
-extern "C" void _mlir_ciface_matmul_kernel_device_wrapper(
+extern "C" void _mlir_ciface_matmul_kernel_1x8_device_wrapper(
+    void *A,
+    void *B,
+    void *C,
+    void *M_scalar,
+    void *N_scalar,
+    void *K_scalar,
+    void *grid_x_scalar,
+    void *grid_y_scalar,
+    void *grid_z_scalar,
+    void *max_txes_scalar);
+
+extern "C" void _mlir_ciface_matmul_kernel_2x4_device_wrapper(
     void *A,
     void *B,
     void *C,
@@ -3603,10 +3706,10 @@ extern "C" void _mlir_ciface_matmul_kernel_device_wrapper(
 // Triton MAT_MUL manual memory wrapper
 //
 // TSISIM blob path:
-//   fpga-kernel/build-fpga/txe_triton_mat_mul/blobs/txe_blob_0.blob
+//   fpga-kernel/build-fpga/txe_triton_mat_mul_1x8/blobs/txe_blob_0.blob
 //
 // tsi_load_blob() expects prefix WITHOUT ".blob":
-//   .../txe_triton_mat_mul/blobs/txe_blob_0
+//   .../txe_triton_mat_mul_1x8/blobs/txe_blob_0
 //
 // Blob packed-args ABI:
 //   7 args:
@@ -3914,7 +4017,7 @@ static void _mlir_ciface_add_kernel_device_wrapper_triton_dispatch(
 }
 
 
-static void *_mlir_ciface_matmul_kernel_device_wrapper_triton_manual_internal(
+static void *triton_matmul_kernel_device_wrapper_triton_manual_internal(
     void *A_desc_v,
     void *B_desc_v,
     void *C_desc_v,
@@ -3922,6 +4025,7 @@ static void *_mlir_ciface_matmul_kernel_device_wrapper_triton_manual_internal(
     void *N_desc_v,
     void *K_desc_v,
     void *program_id_desc_v,
+    BlobDescriptor *blobDescriptor_matmul_selected,
     TSI_DeviceIdType deviceId) {
 
     constexpr int64_t kPackedArgsI64   = 14;
@@ -4003,8 +4107,17 @@ static void *_mlir_ciface_matmul_kernel_device_wrapper_triton_manual_internal(
     const int64_t packedHandle =
         tsi_shmem_handle_from_ptr(packed_args[deviceId]);
 
+    if (!blobDescriptor_matmul_selected) {
+        fprintf(stderr,
+                "ERROR: missing Triton MAT_MUL blob descriptor for selected shape device=%d\n",
+                (int)deviceId);
+        fflush(stderr);
+        tsi_cleanup();
+        abort();
+    }
+
     void *blobExecuteCmd = tsi_launch_blob(
-        blobDescriptor_matmul[0],
+        blobDescriptor_matmul_selected,
         packedHandle,
         kPackedArgsBytes);
 
@@ -4012,7 +4125,7 @@ static void *_mlir_ciface_matmul_kernel_device_wrapper_triton_manual_internal(
         fprintf(stderr,
                 "ERROR: tsi_launch_blob failed for Triton MAT_MUL device=%d blob_desc=%p packedHandle=%ld bytes=%ld\n",
                 (int)deviceId,
-                (void *)blobDescriptor_matmul[0],
+                (void *)blobDescriptor_matmul_selected,
                 (long)packedHandle,
                 (long)kPackedArgsBytes);
         fflush(stderr);
@@ -4024,7 +4137,45 @@ static void *_mlir_ciface_matmul_kernel_device_wrapper_triton_manual_internal(
     return commandList;
 }
 
-static void _mlir_ciface_matmul_kernel_device_wrapper_triton_dispatch (
+
+static inline BlobDescriptor *triton_matmul_blob_descriptor_for_shape(
+    const triton_matmul_txe_shape_t &shape) {
+    if (shape.kind == TRITON_MATMUL_KIND_2X4) {
+        return blobDescriptor_matmul_2x4 ? blobDescriptor_matmul_2x4[0] : nullptr;
+    }
+    return blobDescriptor_matmul_1x8 ? blobDescriptor_matmul_1x8[0] : nullptr;
+}
+
+static inline void triton_matmul_generated_wrapper_for_shape(
+    const triton_matmul_txe_shape_t &shape,
+    void *A_desc_v,
+    void *B_desc_v,
+    void *C_desc_v,
+    void *M_desc_v,
+    void *N_desc_v,
+    void *K_desc_v,
+    void *grid1_desc_v,
+    void *grid2_desc_v,
+    void *grid3_desc_v,
+    void *max_txes_desc_v) {
+    if (shape.kind == TRITON_MATMUL_KIND_2X4) {
+        _mlir_ciface_matmul_kernel_2x4_device_wrapper(
+            A_desc_v, B_desc_v, C_desc_v,
+            M_desc_v, N_desc_v, K_desc_v,
+            grid1_desc_v, grid2_desc_v, grid3_desc_v,
+            max_txes_desc_v);
+        return;
+    }
+
+    _mlir_ciface_matmul_kernel_1x8_device_wrapper(
+        A_desc_v, B_desc_v, C_desc_v,
+        M_desc_v, N_desc_v, K_desc_v,
+        grid1_desc_v, grid2_desc_v, grid3_desc_v,
+        max_txes_desc_v);
+}
+
+static void triton_matmul_kernel_device_wrapper_triton_dispatch(
+    const triton_matmul_txe_shape_t &txe_shape,
     void *A_desc_v,
     void *B_desc_v,
     void *C_desc_v,
@@ -4039,7 +4190,8 @@ static void _mlir_ciface_matmul_kernel_device_wrapper_triton_dispatch (
     tsi_init_per_txe_state_once();
 
     if (!multi_thread_enable) {
-        _mlir_ciface_matmul_kernel_device_wrapper(
+        triton_matmul_generated_wrapper_for_shape(
+            txe_shape,
             A_desc_v,
             B_desc_v,
             C_desc_v,
@@ -4058,7 +4210,7 @@ static void _mlir_ciface_matmul_kernel_device_wrapper_triton_dispatch (
     void *program_id_desc_v = grid1_desc_v;
 
     void *commandList =
-        _mlir_ciface_matmul_kernel_device_wrapper_triton_manual_internal(
+        triton_matmul_kernel_device_wrapper_triton_manual_internal(
             A_desc_v,
             B_desc_v,
             C_desc_v,
@@ -4066,6 +4218,7 @@ static void _mlir_ciface_matmul_kernel_device_wrapper_triton_dispatch (
             N_desc_v,
             K_desc_v,
             program_id_desc_v,
+            triton_matmul_blob_descriptor_for_shape(txe_shape),
             deviceId);
 
     if (!commandList) {
@@ -4301,6 +4454,7 @@ static inline void ensure_triton_full_buffers(
 }
 
 static inline void call_triton_matmul_full_packed(
+    const triton_matmul_txe_shape_t &txe_shape,
     float *A_full,     // physical [M_pad x K]
     float *B_full,     // physical [K x N_pad]
     float *C_full,     // physical [M_pad x N_pad]
@@ -4360,8 +4514,8 @@ static inline void call_triton_matmul_full_packed(
         inited = true;
     }
 
-    TSAVORITE_GGML_ASSERT((M_pad % TRITON_MATMUL_1X8_M_DIM) == 0);
-    TSAVORITE_GGML_ASSERT((N_pad % TRITON_MATMUL_1X8_N_DIM) == 0);
+    TSAVORITE_GGML_ASSERT((M_pad % txe_shape.m_dim) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % txe_shape.n_dim) == 0);
     TSAVORITE_GGML_ASSERT((K % TRITON_MATMUL_F32_K_DIM) == 0);
 
     init_rank1_memref_flat(
@@ -4388,7 +4542,8 @@ static inline void call_triton_matmul_full_packed(
     init_scalar_i32_memref_aligned(max_txes_desc, max_txes_payload, (int32_t)num_of_txes);
 
 
-    _mlir_ciface_matmul_kernel_device_wrapper_triton_dispatch(
+    triton_matmul_kernel_device_wrapper_triton_dispatch(
+        txe_shape,
         A_desc, B_desc, C_desc,
         M_desc, N_desc, K_desc,
         grid1_desc, grid2_desc, grid3_desc,
@@ -4425,8 +4580,6 @@ static inline void ensure_triton_full_buffers_for_device(
     TSAVORITE_GGML_ASSERT(M_pad > 0);
     TSAVORITE_GGML_ASSERT(N_pad > 0);
     TSAVORITE_GGML_ASSERT(K > 0);
-    TSAVORITE_GGML_ASSERT((M_pad % TRITON_MATMUL_1X8_M_DIM) == 0);
-    TSAVORITE_GGML_ASSERT((N_pad % TRITON_MATMUL_1X8_N_DIM) == 0);
     TSAVORITE_GGML_ASSERT((K % TRITON_MATMUL_F32_K_DIM) == 0);
 
     std::lock_guard<std::mutex> lk(g_triton_mt_alloc_mutex);
@@ -4589,6 +4742,7 @@ struct triton_matmul_dispatch_profile_t {
 };
 
 static inline triton_matmul_dispatch_profile_t call_triton_matmul_full_packed_on_device(
+    const triton_matmul_txe_shape_t &txe_shape,
     int deviceId,
     float *A_full,
     float *B_full,
@@ -4597,6 +4751,10 @@ static inline triton_matmul_dispatch_profile_t call_triton_matmul_full_packed_on
     int32_t N_pad,
     int32_t K) {
     triton_matmul_dispatch_profile_t prof;
+
+    TSAVORITE_GGML_ASSERT((M_pad % txe_shape.m_dim) == 0);
+    TSAVORITE_GGML_ASSERT((N_pad % txe_shape.n_dim) == 0);
+    TSAVORITE_GGML_ASSERT((K % TRITON_MATMUL_F32_K_DIM) == 0);
 
     TSAVORITE_GGML_ASSERT(deviceId >= 0);
     TSAVORITE_GGML_ASSERT((uint32_t)deviceId < num_of_txes);
@@ -4623,7 +4781,7 @@ static inline triton_matmul_dispatch_profile_t call_triton_matmul_full_packed_on
     auto *program_id_desc = s->grid1_desc;
 
     void *commandList =
-        _mlir_ciface_matmul_kernel_device_wrapper_triton_manual_internal(
+        triton_matmul_kernel_device_wrapper_triton_manual_internal(
             s->A_desc,
             s->B_desc,
             s->C_desc,
@@ -4631,6 +4789,7 @@ static inline triton_matmul_dispatch_profile_t call_triton_matmul_full_packed_on
             s->N_desc,
             s->K_desc,
             program_id_desc,
+            triton_matmul_blob_descriptor_for_shape(txe_shape),
             (TSI_DeviceIdType)deviceId);
 
     prof.launch_us = tsavorite_elapsed_us(launch_start_us);
@@ -4746,7 +4905,8 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
     const int64_t D2 = node->ne[2];
     const int64_t D3 = node->ne[3];
-    const int64_t N_pad = ((N + 63) / 64) * 64;
+    const int64_t N_pad_legacy_unused = ((N + 63) / 64) * 64;
+    (void)N_pad_legacy_unused;
 
 #if TRITON_DEBUG
     triton_matmul_log_offloaded_shape_once(A, B, node);
@@ -4796,12 +4956,13 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     //   future 2x4 path, then call the same transpose heuristic with that shape.
     // ============================================================
     if (!multi_thread_enable || num_of_txes <= 1) {
-        const triton_matmul_txe_shape_t &txe_shape = TRITON_MATMUL_SHAPE_1X8;
         const bool use_small_n_transpose =
-            triton_matmul_should_use_small_n_transpose(txe_shape, M, N, K);
+            triton_matmul_should_use_small_n_transpose(TRITON_MATMUL_SHAPE_1X8, M, N, K);
 
         const int64_t M_work = use_small_n_transpose ? N : M;
         const int64_t N_work = use_small_n_transpose ? M : N;
+        const triton_matmul_txe_shape_t &txe_shape =
+            triton_matmul_select_shape(M_work, N_work);
         const int64_t M_pad = tsi_round_up_i64(M_work, txe_shape.m_dim);
         const int64_t N_work_pad = tsi_round_up_i64(N_work, txe_shape.n_dim);
 
@@ -4880,6 +5041,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
                 t0 = tsavorite_now_us();
                 call_triton_matmul_full_packed(
+                    txe_shape,
                     g_triton_A_full,
                     g_triton_B_full,
                     g_triton_C_full,
@@ -4935,9 +5097,13 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
     // TXEWaitSum:
     //   Sum wait_us across every launched TXE.
     // ============================================================
+    const triton_matmul_txe_shape_t &txe_shape = triton_matmul_select_shape(M, N);
+    const int64_t N_pad = tsi_round_up_i64(N, txe_shape.n_dim);
+
     const int64_t active_txes = (int64_t)num_of_txes;
     const int64_t rows_per_txe_unaligned = (M + active_txes - 1) / active_txes;
-    const int64_t rows_per_txe = ((rows_per_txe_unaligned + 7) / 8) * 8;
+    const int64_t rows_per_txe =
+        tsi_round_up_i64(rows_per_txe_unaligned, txe_shape.m_dim);
 
     uint64_t launched_kernel_calls = 0;
 
@@ -4975,7 +5141,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
                     const int64_t M_valid =
                         (M - tile_m0 > rows_per_txe) ? rows_per_txe : (M - tile_m0);
                     const int64_t M_tile_pad =
-                        ((M_valid + 7) / 8) * 8;
+                        tsi_round_up_i64(M_valid, txe_shape.m_dim);
 
                     const int deviceId = acquire_device_blocking();
 
@@ -5067,6 +5233,7 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
         triton_matmul_dispatch_profile_t dispatch_prof =
             call_triton_matmul_full_packed_on_device(
+                txe_shape,
                 deviceId,
                 A_tile,
                 B_tile,

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3083,8 +3083,6 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
      * Current 1x8 Triton shape padding.
      */
     const int64_t M_pad = ((M + 7)  / 8)  * 8;
-    const int64_t N_pad_legacy_unused = ((N + 63) / 64) * 64;
-    (void)N_pad_legacy_unused;
 
     const int64_t elems_A = M_pad * K;
     const int64_t N_pad = ((N + 63) / 64) * 64;
@@ -4903,8 +4901,6 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
     const int64_t D2 = node->ne[2];
     const int64_t D3 = node->ne[3];
-    const int64_t N_pad_legacy_unused = ((N + 63) / 64) * 64;
-    (void)N_pad_legacy_unused;
 
 #if TRITON_DEBUG
     triton_matmul_log_offloaded_shape_once(A, B, node);

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1196,7 +1196,8 @@ tsi_kernels=(
 
 triton_kernels=(
   "triton_add"
-  "triton_mat_mul"
+  "triton_mat_mul_1x8"
+  "triton_mat_mul_2x4"
 )
 
 for kernel in "${tsi_kernels[@]}"; do


### PR DESCRIPTION
TSISIM Result
t seems we have improved from 97mins to 38mins after using all TMU Shapes
MODEL: Llama3.2:1B-1.2B-F32.gguf
 
 
here are result
oot@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
MODEL: Llama3.2:1B-1.2B-F32.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:true, triton_matmul_small_n_transpose_opt:true
 
TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=16 user_dram_size_bytes=17179869184 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=1
[2026-08-05 00:51:42.649] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-08-05 00:51:42.655] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 2
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xf0a825255000, size = 17079185408
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf0a825255000, map_size = 17079185408
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf0ad384403b8
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xf0a81f250000, size = 100683776
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf0a81f250000, map_size = 100683776
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf0ad38440490
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-08-05 00:51:42.657] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
is molly and she
 
 
llama_perf_sampler_print:    sampling time =      33.82 ms /    10 runs   (    3.38 ms per token,   295.66 tokens per second)
llama_perf_context_print:        load time =  466706.26 ms
llama_perf_context_print: prompt eval time =  462923.84 ms /     5 tokens (92584.77 ms per token,     0.01 tokens per second)
llama_perf_context_print:        eval time = 1821529.56 ms /     4 runs   (455382.39 ms per token,     0.00 tokens per second)
llama_perf_context_print:       total time = 2288278.58 ms /     9 tokens
 
=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          160             280             57312            358.20
  MUL              OPU          165             289             53174            322.27
  RMS_NORM         OPU          165             165             28285            171.42
  MUL_MAT          CPU         1556               0           3727174           2395.36
  MUL_MAT          OPU          320            6240        2257245264        7053891.45
  CONT             OPU          160               0             39766            248.54
  RESHAPE          CPU          652               0               729              1.12
  VIEW             CPU          684               0               107              0.16
  VIEW             OPU          160               0               242              1.51
  PERMUTE          CPU          457               0               110              0.24
  PERMUTE          OPU          160               0               122              0.76
  TRANSPOSE        CPU          225               0                63              0.28
  GET_ROWS         OPU           15               0               409             27.27
  SET_ROWS         CPU          542               0              5028              9.28
  SOFT_MAX         OPU           80               0             47794            597.42
  ROPE             CPU          533               0              7476             14.03
  GLU              OPU           80             140           9431972         117899.65
 
OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# /tsi/tsi-sw/check_tsictl.sh 
Index 0:     execute                     : 2930
    execute_debug               : 0
Index 1:     execute                     : 969
    execute_debug               : 0
Index 2:     execute                     : 969
    execute_debug               : 0
Index 3:     execute                     : 969
    execute_debug               : 0
Index 4:     execute                     : 969
    execute_debug               : 0
Index 5:     execute                     : 908
    execute_debug               : 0
Index 6:     execute                     : 765
    execute_debug               : 0
Index 7:     execute                     : 765
    execute_debug               : 0
Index 8:     execute                     : 765
    execute_debug               : 0
Index 9:     execute                     : 765
    execute_debug               : 0
Index 10:     execute                     : 765
    execute_debug               : 0
Index 11:     execute                     : 765
    execute_debug               : 0
Index 12:     execute                     : 765
    execute_debug               : 0
Index 13:     execute                     : 765
    execute_debug               : 0
Index 14:     execute                     : 765
    execute_debug               : 0
Index 15:     execute                     : 765
    execute_debug               : 0
Index 16:     execute                     : 765
    execute_debug               : 0
Index 17:     execute                     : 765
    execute_debug               : 0
Index 18:     execute                     : 765
    execute_debug               : 0
Index 19:     execute                     : 385
    execute_debug               : 0
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# cat ./tsi-ggml/tsavorite-model-deployment.yaml 
# Tsavorite deployment config
txe_count: 20
multi_thread_enable: true

## Runtime user DRAM size in GiB.
## Example: 1 = 1GB, 2 = 2GB.
## If this key is missing, runtime DeviceConfig default is used.

user_dram_size_gb: 16


# Enable additional Triton MAT_MUL shapes beyond stable baseline.
# false = old behavior
# true  = new offload shapes
advanced_matmul_shape_offload: true

# Enable Triton MAT_MUL small-N transpose optimization.
# false = old behavior
# true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
triton_matmul_small_n_transpose_opt: true
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
MODEL: Llama3.2:1B-1.2B-F32.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:true, triton_matmul_small_n_transpose_opt:true

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=16 user_dram_size_bytes=17179869184 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=1
[2026-08-05 03:07:33.182] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-08-05 03:07:33.187] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 2
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xfe08bccb5000, size = 17079185408
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xfe08bccb5000, map_size = 17079185408
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xfe0dcfea03b8
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xfe08b6cb0000, size = 100683776
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xfe08b6cb0000, map_size = 100683776
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xfe0dcfea0490
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-08-05 03:07:33.189] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
 is molly and she's a 3 year



llama_perf_sampler_print:    sampling time =      64.21 ms /    15 runs   (    4.28 ms per token,   233.62 tokens per second)
llama_perf_context_print:        load time =  468285.46 ms
llama_perf_context_print: prompt eval time =  464521.70 ms /     5 tokens (92904.34 ms per token,     0.01 tokens per second)
llama_perf_context_print:        eval time = 4123141.87 ms /     9 runs   (458126.87 ms per token,     0.00 tokens per second)
llama_perf_context_print:       total time = 4591505.93 ms /    14 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          320             440            112294            350.92
  MUL              OPU          330             454             94597            286.66
  RMS_NORM         OPU          330             330             59820            181.27
  MUL_MAT          CPU         3156               0           6778272           2147.74
  MUL_MAT          OPU          640           12480        4541443767        7096005.89
  CONT             OPU          320               0             80329            251.03
  RESHAPE          CPU         1307               0              1411              1.08
  VIEW             CPU         1390               0               230              0.17
  VIEW             OPU          320               0               567              1.77
  PERMUTE          CPU          902               0               256              0.28
  PERMUTE          OPU          320               0               306              0.96
  TRANSPOSE        CPU          446               0                78              0.17
  GET_ROWS         OPU           30               0               738             24.60
  SET_ROWS         CPU         1068               0              8375              7.84
  SOFT_MAX         OPU          160               0             74806            467.54
  ROPE             CPU         1066               0             13674             12.83
  GLU              OPU          160             220          14929403          93308.77

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# /tsi/tsi-sw/check_tsictl.sh 
Index 0:     execute                     : 4770
    execute_debug               : 0
Index 1:     execute                     : 1670
    execute_debug               : 0
Index 2:     execute                     : 1670
    execute_debug               : 0
Index 3:     execute                     : 1670
    execute_debug               : 0
Index 4:     execute                     : 1670
    execute_debug               : 0
Index 5:     execute                     : 1548
    execute_debug               : 0
Index 6:     execute                     : 1405
    execute_debug               : 0
Index 7:     execute                     : 1405
    execute_debug               : 0
Index 8:     execute                     : 1405
    execute_debug               : 0
Index 9:     execute                     : 1405
    execute_debug               : 0
Index 10:     execute                     : 1405
    execute_debug               : 0
Index 11:     execute                     : 1405
    execute_debug               : 0
Index 12:     execute                     : 1405
    execute_debug               : 0
Index 13:     execute                     : 1405
    execute_debug               : 0
Index 14:     execute                     : 1405
    execute_debug               : 0
Index 15:     execute                     : 1405
    execute_debug               : 0
Index 16:     execute                     : 1405
    execute_debug               : 0
Index 17:     execute                     : 1405
    execute_debug               : 0
Index 18:     execute                     : 1405
    execute_debug               : 0
Index 19:     execute                     : 705
    execute_debug               : 0
root@tsisim:/usr/bin/tsi/bin# 





Before 2x4 shape it was take time as below

Llama3.2:1B-1.2B-F32.gguf
20% TMU shape offloaded with optimization enable took 100mins at GH1
ot@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:true, triton_matmul_small_n_transpose_opt:true
 
TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=30 user_dram_size_bytes=32212254720 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=1
[2026-07-30 21:42:05.492] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-07-30 21:42:05.495] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 3
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xed12f0d55000, size = 17079185408
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xed12f0d55000, map_size = 17079185408
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xed1803f403b8
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xed10f0d55000, size = 8589934592
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xed10f0d55000, map_size = 8589934592
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xed1803f40490
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 2: start_addr = 0xed0f6ad50000, size = 6543134720
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xed0f6ad50000, map_size = 6543134720
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xed1803f40568
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 3
[2026-07-30 21:42:05.497] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
is molly and she
 
llama_perf_sampler_print:    sampling time =      32.00 ms /    10 runs   (    3.20 ms per token,   312.55 tokens per second)
 
 
llama_perf_context_print:        load time = 1223546.52 ms
llama_perf_context_print: prompt eval time = 1220404.53 ms /     5 tokens (244080.91 ms per token,     0.00 tokens per second)
llama_perf_context_print:        eval time = 4790633.44 ms /     4 runs   (1197658.36 ms per token,     0.00 tokens per second)
llama_perf_context_print:       total time = 6014217.74 ms /     9 tokens
 
=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          352             472           4862724          13814.56
  MUL              OPU          363             487             74615            205.55
  RMS_NORM         OPU          363             363             66384            182.88
  MUL_MAT          CPU         3451               0           7099085           2057.11
  MUL_MAT          OPU          704           14080       13151731883       18681437.33
  CONT             OPU          352               0             96101            273.01
  RESHAPE          CPU         1391               0              1137              0.82
  VIEW             CPU         1326               0               300              0.23
  VIEW             OPU          352               0               227              0.64
  PERMUTE          CPU          949               0               344              0.36
  PERMUTE          OPU          352               0               153              0.43
  TRANSPOSE        CPU          449               0               123              0.27
  GET_ROWS         OPU           33               0              1344             40.73
  SET_ROWS         CPU         1072               0              9825              9.17
  SOFT_MAX         OPU          176               0             78501            446.03
  ROPE             CPU         1154               0              9375              8.12
  GLU              OPU          176             236          17899647         101702.54
 
OPU Profiling Results:
Profiler disabled
 
root@tsisim:/usr/bin/tsi/bin# 

 
 
Now i will run again with optimization disable




root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# ./run_llama_cli.sh 
MODEL: Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
INFO: updated /usr/bin/tsi/bin/tsi-ggml/tsavorite-model-deployment.yaml with txe_count:20, multi_thread_enable:true; preserved advanced_matmul_shape_offload:true, triton_matmul_small_n_transpose_opt:true

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=20 multi_thread_enable=1 user_dram_size_gb=16 user_dram_size_bytes=17179869184 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=1
[2026-08-05 00:02:53.000] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:170> hal_lib_init: topology from tsi-soc-hal: ral_tag=SKYLP_G0741 num_chiplets=10 chiplet_stride=0x1c000000 ral_csr_base=0x20000000
[2026-08-05 00:02:53.006] [info] </proj/work/srv-ghr/ral/FlexHAL/src/hal.c:263> hal_lib_init: complete — 10 chiplets, ral_tag=SKYLP_G0741
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:823> num_vm_segments: 2
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 0: start_addr = 0xf7c8868c5000, size = 17079185408
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf7c8868c5000, map_size = 17079185408
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf7cd99ab03b8
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 1
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 100683776
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:826> VM segment 1: start_addr = 0xf7c8808c0000, size = 100683776
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:833> VMA: map_addr = 0xf7c8808c0000, map_size = 100683776
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:835> VMA: dev_buf = 0xf7cd99ab0490
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:836> VMA: dev_buf_num = 2
[2026-08-05 00:02:53.009] [info] </proj/work/srv-ghr/git-runner/sdk-ci-arm64-actions-runner/_work/sdk/sdk/runtime/third-party/common-runtime/src/cma/cma.c:837> VMA: dev_buf_offset = 0
 is Luna.




llama_perf_sampler_print:    sampling time =       9.95 ms /    11 runs   (    0.90 ms per token,  1105.64 tokens per second)
llama_perf_context_print:        load time =  497006.20 ms
llama_perf_context_print: prompt eval time =  494725.11 ms /     6 tokens (82454.18 ms per token,     0.01 tokens per second)
llama_perf_context_print:        eval time = 1922531.92 ms /     4 runs   (480632.98 ms per token,     0.00 tokens per second)
llama_perf_context_print:       total time = 2419553.12 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          220             430             83267            378.49
  MUL              OPU          225             440             77350            343.78
  RMS_NORM         OPU          225             225             36748            163.32
  MUL_MAT          CPU         2105               0           2180972           1036.09
  MUL_MAT          OPU          445            8680        2383050919        5355170.60
  CONT             OPU          220               0             27854            126.61
  RESHAPE          CPU          915               0               870              0.95
  VIEW             CPU          942               0               150              0.16
  VIEW             OPU          220               0               352              1.60
  PERMUTE          CPU          623               0               161              0.26
  PERMUTE          OPU          220               0               229              1.04
  TRANSPOSE        CPU          314               0                78              0.25
  GET_ROWS         OPU           15               0               374             24.93
  SET_ROWS         CPU          743               0              5002              6.73
  SOFT_MAX         OPU          110               0             76543            695.85
  ROPE             CPU          700               0              9738             13.91
  GLU              OPU          110             215          10370127          94273.88

OPU Profiling Results:
Profiler disabled

root@tsisim:/usr/bin/tsi/bin# 
root@tsisim:/usr/bin/tsi/bin# 




POSIX Result

akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ cat run.log 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1 user_dram_size_gb=16 user_dram_size_bytes=17179869184 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=1
 My cat's name is Luna. She



llama_perf_sampler_print:    sampling time =       7.92 ms /    11 runs   (    0.72 ms per token,  1389.59 tokens per second)
llama_perf_context_print:        load time =  118537.36 ms
llama_perf_context_print: prompt eval time =  108210.36 ms /     7 tokens (15458.62 ms per token,     0.06 tokens per second)
llama_perf_context_print:        eval time =  316795.15 ms /     3 runs   (105598.38 ms per token,     0.01 tokens per second)
llama_perf_context_print:       total time =  435343.57 ms /    10 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          176             428            124216            705.77
  MUL              OPU          180             438            310410           1724.50
  RMS_NORM         OPU          180             180            260411           1446.73
  MUL_MAT          CPU         1708               0           1713575           1003.26
  MUL_MAT          OPU          356             356         422058262        1185556.92
  CONT             OPU          176               0             30274            172.01
  RESHAPE          CPU          934               0               537              0.57
  VIEW             CPU          880               0               118              0.13
  VIEW             OPU          176               0                60              0.34
  PERMUTE          CPU          631               0               201              0.32
  PERMUTE          OPU          176               0                35              0.20
  TRANSPOSE        CPU          310               0                62              0.20
  GET_ROWS         OPU           12               0              2691            224.25
  SET_ROWS         CPU          691               0               955              1.38
  SOFT_MAX         OPU           88               0             59937            681.10
  ROPE             CPU          686               0              6253              9.12
  GLU              OPU           88             214            485250           5514.20

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 

This PR adds llama.cpp / ggml-tsavorite runtime support for Triton MAT_MUL shape-specific execution using 1x8 and 2x4 TXE MMA shapes.

It loads separate 1x8 and 2x4 blobs/wrappers, keeps 1x8 as the default stable path, enables 2x4 only through advanced_matmul_shape_offload, and selects the best shape based on padding cost while reusing the existing packed-args ABI and small-N transpose flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime support in `ggml-tsavorite` for Triton MAT_MUL TXE shapes 1x8 and 2x4. 1x8 stays default; 2x4 is opt-in via `advanced_matmul_shape_offload` with per-call shape selection by padding cost. Addresses FIR-2147.

- **New Features**
  - Load separate MAT_MUL blobs for 1x8 and 2x4; 2x4 loads only when `advanced_matmul_shape_offload` is enabled.
  - Runtime selects the lower padding-cost shape per op and applies it to small‑N transpose logic and multi‑TXE tiling/padding.
  - Added shape-specific wrappers `_mlir_ciface_matmul_kernel_1x8_device_wrapper` and `_mlir_ciface_matmul_kernel_2x4_device_wrapper`, plus manual-path dispatch to the correct blob with validation.
  - Updated `tsi-pkg-build.sh` to build `triton_mat_mul_1x8` and `triton_mat_mul_2x4` and switched blob paths accordingly.

- **Migration**
  - No changes needed; 1x8 remains the stable path.
  - To try 2x4, rebuild kernel packages to include the new blobs and enable `advanced_matmul_shape_offload`.

<sup>Written for commit 0a77d0d9022f334ea04d8249f834de96fd8b993f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/llama.cpp/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

