### PR TITLE
FIR-2167 - Extend advanced Triton MAT_MUL offload coverage PR #154

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3130,6 +3130,11 @@ static inline void tsavorite_tensor_scatter_k_to_f32_strided(
 }
 
 #if TRITON_MAT_MUL
+static inline bool tsavorite_triton_matmul_dims_within_caps(
+    int64_t K,
+    int64_t M,
+    int64_t N);
+
 static inline bool tsavorite_mul_mat_advanced_shape_ok(
     const struct ggml_tensor * op);
 
@@ -3196,7 +3201,7 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     const int64_t M = a->ne[1];
     const int64_t N = b->ne[1];
 
-    if (K <= 0 || M <= 0 || N <= 0) {
+    if (!tsavorite_triton_matmul_dims_within_caps(K, M, N)) {
         return false;
     }
 
@@ -3332,9 +3337,9 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     /*
      * Broad sanity caps only.
      */
-    if (K > 8192)  return false;
-    if (M > 32768) return false;
-    if (N > 4096)  return false;
+    if (!tsavorite_triton_matmul_dims_within_caps(K, M, N)) {
+        return false;
+    }
 
 #if TRITON_DEBUG
     fprintf(stderr,
@@ -3879,6 +3884,19 @@ static inline const triton_matmul_txe_shape_t &triton_matmul_select_shape(
 
 // Data type specific
 #define TRITON_MATMUL_F32_K_DIM      32
+#define TSAV_TRITON_MATMUL_MAX_K 8192
+#define TSAV_TRITON_MATMUL_MAX_M 32768
+#define TSAV_TRITON_MATMUL_MAX_N 4096
+
+static inline bool tsavorite_triton_matmul_dims_within_caps(
+    int64_t K,
+    int64_t M,
+    int64_t N) {
+    return K > 0 && M > 0 && N > 0 &&
+           K <= TSAV_TRITON_MATMUL_MAX_K &&
+           M <= TSAV_TRITON_MATMUL_MAX_M &&
+           N <= TSAV_TRITON_MATMUL_MAX_N;
+}
 
 #define TRITON_MATMUL_ALIGNMENT_BYTES      128
 #define TRITON_MATMUL_ALIGNMENT_MASK      (TRITON_MATMUL_ALIGNMENT_BYTES - 1)
@@ -3895,24 +3913,27 @@ static inline bool tsavorite_mul_mat_advanced_shape_ok(const struct ggml_tensor 
         return false;
     }
 
-    if (!tsavorite_tensor_type_can_pack_to_f32(a->type) ||
-        !tsavorite_tensor_type_can_pack_to_f32(b->type)) {
-        return false;
-    }
-
     const int64_t K  = a->ne[0];
     const int64_t M  = a->ne[1];
     const int64_t N  = b->ne[1];
+
+    if (!tsavorite_triton_matmul_dims_within_caps(K, M, N)) {
+        return false;
+    }
+
+    const int64_t a_nb0 = tsavorite_tensor_nb0_or_type_size(a);
+    const int64_t b_nb0 = tsavorite_tensor_nb0_or_type_size(b);
+
+    if (!tsavorite_tensor_type_can_pack_to_f32_k(a->type, K, a_nb0) ||
+        !tsavorite_tensor_type_can_pack_to_f32_k(b->type, K, b_nb0)) {
+        return false;
+    }
     const int64_t A2 = a->ne[2];
     const int64_t A3 = a->ne[3];
     const int64_t B2 = b->ne[2];
     const int64_t B3 = b->ne[3];
     const int64_t D2 = op->ne[2];
     const int64_t D3 = op->ne[3];
-
-    if (K <= 0 || M <= 0 || N <= 0) {
-        return false;
-    }
 
     if (b->ne[0] != K || op->ne[0] != M || op->ne[1] != N) {
         return false;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3334,13 +3334,6 @@ static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     const int64_t total_bytes =
         (elems_A + elems_B + elems_C) * (int64_t)sizeof(float);
 
-    /*
-     * Broad sanity caps only.
-     */
-    if (!tsavorite_triton_matmul_dims_within_caps(K, M, N)) {
-        return false;
-    }
-
 #if TRITON_DEBUG
     fprintf(stderr,
             "MUL_MAT_TRITON_ENABLE: K=%ld M=%ld N=%ld D2=%ld D3=%ld "

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3130,8 +3130,27 @@ static inline void tsavorite_tensor_scatter_k_to_f32_strided(
 }
 
 #if TRITON_MAT_MUL
+static inline bool tsavorite_mul_mat_advanced_shape_ok(
+    const struct ggml_tensor * op);
+
 static bool mul_mat_supported_size(const struct ggml_tensor *op) {
     if (!op) return false;
+
+    if (advanced_matmul_shape_offload && tsavorite_mul_mat_advanced_shape_ok(op)) {
+#if TRITON_DEBUG
+        const struct ggml_tensor * a_dbg = op->src[0];
+        const struct ggml_tensor * b_dbg = op->src[1];
+        fprintf(stderr,
+                "MUL_MAT_ADVANCED_SHAPE_ENABLE: a_type=%d b_type=%d op_type=%d "
+                "a=[%ld,%ld,%ld,%ld] b=[%ld,%ld,%ld,%ld] op=[%ld,%ld,%ld,%ld]\n",
+                (int)a_dbg->type, (int)b_dbg->type, (int)op->type,
+                (long)a_dbg->ne[0], (long)a_dbg->ne[1], (long)a_dbg->ne[2], (long)a_dbg->ne[3],
+                (long)b_dbg->ne[0], (long)b_dbg->ne[1], (long)b_dbg->ne[2], (long)b_dbg->ne[3],
+                (long)op->ne[0], (long)op->ne[1], (long)op->ne[2], (long)op->ne[3]);
+#endif
+        return true;
+    }
+
 
     const struct ggml_tensor *a = op->src[0];
     const struct ggml_tensor *b = op->src[1];
@@ -3863,6 +3882,70 @@ static inline const triton_matmul_txe_shape_t &triton_matmul_select_shape(
 
 #define TRITON_MATMUL_ALIGNMENT_BYTES      128
 #define TRITON_MATMUL_ALIGNMENT_MASK      (TRITON_MATMUL_ALIGNMENT_BYTES - 1)
+
+static inline bool tsavorite_mul_mat_advanced_shape_ok(const struct ggml_tensor * op) {
+    if (!op || !op->src[0] || !op->src[1]) {
+        return false;
+    }
+
+    const struct ggml_tensor * a = op->src[0];
+    const struct ggml_tensor * b = op->src[1];
+
+    if (op->type != GGML_TYPE_F32) {
+        return false;
+    }
+
+    if (!tsavorite_tensor_type_can_pack_to_f32(a->type) ||
+        !tsavorite_tensor_type_can_pack_to_f32(b->type)) {
+        return false;
+    }
+
+    const int64_t K  = a->ne[0];
+    const int64_t M  = a->ne[1];
+    const int64_t N  = b->ne[1];
+    const int64_t A2 = a->ne[2];
+    const int64_t A3 = a->ne[3];
+    const int64_t B2 = b->ne[2];
+    const int64_t B3 = b->ne[3];
+    const int64_t D2 = op->ne[2];
+    const int64_t D3 = op->ne[3];
+
+    if (K <= 0 || M <= 0 || N <= 0) {
+        return false;
+    }
+
+    if (b->ne[0] != K || op->ne[0] != M || op->ne[1] != N) {
+        return false;
+    }
+
+    if ((K % TRITON_MATMUL_F32_K_DIM) != 0) {
+        return false;
+    }
+
+    if (D2 != ((A2 > B2) ? A2 : B2) || D3 != ((A3 > B3) ? A3 : B3)) {
+        return false;
+    }
+
+    if (!(A2 == D2 || A2 == 1) || !(B2 == D2 || B2 == 1)) {
+        return false;
+    }
+
+    if (!(A3 == D3 || A3 == 1) || !(B3 == D3 || B3 == 1)) {
+        return false;
+    }
+
+    const triton_matmul_txe_shape_t & shape = triton_matmul_select_shape(M, N);
+    const int64_t M_pad = ((M + shape.m_dim - 1) / shape.m_dim) * shape.m_dim;
+    const int64_t N_pad = ((N + shape.n_dim - 1) / shape.n_dim) * shape.n_dim;
+    const int64_t total_bytes = (M_pad * K + K * N_pad + M_pad * N_pad) * (int64_t)sizeof(float);
+
+    if (M_pad <= 0 || N_pad <= 0 || total_bytes <= 0) {
+        return false;
+    }
+
+    return true;
+}
+
 
 static int32_t g_triton_cur_M_tile = TMU_M_TILE_MAX;
 static int32_t g_triton_cur_N_tile = TMU_N_BLOCK;


### PR DESCRIPTION

## Summary

This PR extends the existing `advanced_matmul_shape_offload` path to support additional safe Triton MAT_MUL shapes.

No new deployment flag is added. The change reuses the existing `advanced_matmul_shape_offload` runtime option and expands the MAT_MUL shape gate for cases that already satisfy the current Triton runtime constraints.

## Changes

- Added a generic advanced MAT_MUL shape helper:
  - `tsavorite_mul_mat_advanced_shape_ok()`
- Offloads additional MAT_MUL ops when:
  - result dtype is F32
  - src0/src1 can be packed to F32
  - K satisfies the Triton MAT_MUL alignment requirement
  - D2/D3 broadcast is limited to safe cases where each input dimension either matches the output dimension or is 1
- Kept grouped-head/repeat-head 4D broadcast shapes rejected for now because simple gate relaxation caused incorrect prompt output.

## Validation

Validated with `advanced_matmul_shape_offload=true` and `triton_matmul_small_n_transpose_opt=true`.

- `tinyllama-vo-5m-para.gguf`
  - MAT_MUL OPU coverage increased.
  - Prompt output remained correct.

- `Tiny-Llama-v0.3-FP32-1.1B-F32.gguf`
  - Prompt output remained correct:
    - `My cat's name is Luna`
  - MAT_MUL OPU coverage increased.
  - Remaining rejected MAT_MUL shapes are grouped-head/repeat-head 4D broadcast patterns and will be handled in a follow-up PR.

## Follow-up

Grouped-head/repeat-head 4D broadcast MAT_MUL shapes such as `A2=4, B2=32, D2=32` need a proper runtime packing/copyback fix. They are intentionally not enabled in this PR.




POSIX result
ed [-Wunused-but-set-variable]
  516 |         const char * control_message;
      |                      ^~~~~~~~~~~~~~~
/proj/work/akapoor/llama.cpp-aug-6-sdk-4.22/llama.cpp/tools/main/main.cpp:597:27: warning: unused variable ‘skipped_tokens’ [-Wunused-variable]
  597 |                 const int skipped_tokens = (int) embd.size() - max_embd_size;
      |                           ^~~~~~~~~~~~~~
[100%] Linking CXX executable ../../bin/llama-cli
/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/bin/../lib/gcc/aarch64-none-linux-gnu/14.2.1/../../../../aarch64-none-linux-gnu/bin/ld: skipping incompatible /lib/libm.so when searching for -lm
/proj/rel/sw/arm-gnu-toolchain-14.2.rel1-x86_64-aarch64-none-linux-gnu/bin/../lib/gcc/aarch64-none-linux-gnu/14.2.1/../../../../aarch64-none-linux-gnu/bin/ld: skipping incompatible /lib/libc.so when searching for -lc
[100%] Built target llama-cli
INFO: creating tar bundle for fpga (build-fpga)
INFO: included ./tsavorite-model-deployment.yaml in FPGA package
tsi-ggml/blobs/
tsi-ggml/blobs/txe_mul_mat_tile_f32_k128.blob
tsi-ggml/blobs/txe_mul_mat_tile_f32_k64.blob
tsi-ggml/blobs/txe_mul_mat_tile_f32_k32.blob
tsi-ggml/blobs/txe_add.blob
tsi-ggml/blobs/txe_sub.blob
tsi-ggml/blobs/txe_mult.blob
tsi-ggml/blobs/txe_div.blob
tsi-ggml/blobs/txe_abs.blob
tsi-ggml/blobs/txe_neg.blob
tsi-ggml/blobs/txe_sqrt.blob
tsi-ggml/blobs/txe_sqr.blob
tsi-ggml/blobs/txe_inv.blob
tsi-ggml/blobs/txe_sin.blob
tsi-ggml/blobs/txe_silu.blob
tsi-ggml/blobs/txe_sigmoid.blob
tsi-ggml/blobs/txe_swiglu.blob
tsi-ggml/blobs/txe_rms_norm.blob
tsi-ggml/blobs/txe_soft_max.blob
tsi-ggml/blobs/txe_add_16.blob
tsi-ggml/blobs/txe_sub_16.blob
tsi-ggml/blobs/txe_mult_16.blob
tsi-ggml/blobs/txe_div_16.blob
tsi-ggml/blobs/txe_abs_16.blob
tsi-ggml/blobs/txe_neg_16.blob
tsi-ggml/blobs/txe_sqrt_16.blob
tsi-ggml/blobs/txe_sqr_16.blob
tsi-ggml/blobs/txe_inv_16.blob
tsi-ggml/blobs/txe_sin_16.blob
tsi-ggml/blobs/txe_sigmoid_16.blob
tsi-ggml/blobs/txe_triton_add/
tsi-ggml/blobs/txe_triton_add/txe_blob_0.blob
tsi-ggml/blobs/txe_silu_16.blob
tsi-ggml/blobs/txe_swiglu_16.blob
tsi-ggml/blobs/txe_rms_norm_16.blob
tsi-ggml/blobs/txe_triton_mat_mul_1x8/
tsi-ggml/blobs/txe_triton_mat_mul_1x8/txe_blob_0.blob
tsi-ggml/blobs/txe_triton_mat_mul_2x4/
tsi-ggml/blobs/txe_triton_mat_mul_2x4/txe_blob_0.blob
tsi-ggml/ggml.sh
tsi-ggml/libggml-base.so
tsi-ggml/libggml-cpu.so
tsi-ggml/libggml.so
tsi-ggml/libggml-tsavorite.so
tsi-ggml/libllama.so
tsi-ggml/llama-cli
tsi-ggml/simple-backend-tsi
tsi-ggml/tsavorite-model-deployment.yaml
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf --device tsavorite   -c 12288   --temp 0.0   --n-predict 2   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=1
 My cat's name is Luna

llama_perf_sampler_print:    sampling time =       4.05 ms /     9 runs   (    0.45 ms per token,  2222.77 tokens per second)


llama_perf_context_print:        load time =  108636.40 ms
llama_perf_context_print: prompt eval time =  104586.96 ms /     7 tokens (14940.99 ms per token,     0.07 tokens per second)
llama_perf_context_print:        eval time =  103577.65 ms /     1 runs   (103577.65 ms per token,     0.01 tokens per second)
llama_perf_context_print:       total time =  212218.74 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU           88             340            102782           1167.98
  MUL              OPU           90             348            248551           2761.68
  RMS_NORM         OPU           90              90            158487           1760.97
  MUL_MAT          CPU          830               0           1256219           1513.52
  MUL_MAT          OPU          178             178         206660943        1161016.53
  CONT             OPU           88               0             15045            170.97
  RESHAPE          CPU          473               0               265              0.56
  VIEW             CPU          439               0                60              0.14
  VIEW             OPU           88               0                40              0.45
  PERMUTE          CPU          315               0                99              0.31
  PERMUTE          OPU           88               0                16              0.18
  TRANSPOSE        CPU          124               0                17              0.14
  GET_ROWS         OPU            6               0              2597            432.83
  SET_ROWS         CPU          330               0               515              1.56
  SOFT_MAX         OPU           44               0             46750           1062.50
  ROPE             CPU          346               0              4221             12.20
  GLU              OPU           44             170            382109           8684.30

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/tinyllama-vo-5m-para.gguf --device tsavorite   -c 12288   --temp 0.0   --n-predict 2   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation 

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1 user_dram_size_gb=8 user_dram_size_bytes=8589934592 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=1
 My cat's name is Tim.



llama_perf_sampler_print:    sampling time =       3.82 ms /     9 runs   (    0.42 ms per token,  2356.02 tokens per second)
llama_perf_context_print:        load time =    1142.18 ms
llama_perf_context_print: prompt eval time =     688.71 ms /     7 tokens (   98.39 ms per token,    10.16 tokens per second)
llama_perf_context_print:        eval time =     447.21 ms /     1 runs   (  447.21 ms per token,     2.24 tokens per second)
llama_perf_context_print:       total time =    1593.81 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU           32             116             25600            800.00
  MUL              OPU           34             124            145153           4269.21
  RMS_NORM         OPU           34              34             25853            760.38
  MUL_MAT          CPU          290               0             34124            117.67
  MUL_MAT          OPU           66              66            821077          12440.56
  CONT             OPU           32               0              1560             48.75
  RESHAPE          CPU          176               0                41              0.23
  VIEW             CPU          176               0                23              0.13
  VIEW             OPU           32               0                 6              0.19
  PERMUTE          CPU          104               0                25              0.24
  PERMUTE          OPU           32               0                 4              0.12
  TRANSPOSE        CPU           61               0                19              0.31
  GET_ROWS         OPU            6               0                25              4.17
  SET_ROWS         CPU          113               0               145              1.28
  SOFT_MAX         OPU           16               0              9346            584.12
  ROPE             CPU          120               0               553              4.61
  GLU              OPU           16              58             45383           2836.44

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ cat ggml_op_shape_dtype_catalog.tsv 
Op                 Decision      Count Result                           Src0                             Src1                            
------------------ ---------- -------- -------------------------------- -------------------------------- --------------------------------
ADD                SUPPORTED        18 f32 [64,1,1,1]                   f32 [64,1,1,1]                   f32 [64,1,1,1]                  
ADD                SUPPORTED        11 f32 [64,512,1,1]                 f32 [64,512,1,1]                 f32 [64,512,1,1]                
ADD                SUPPORTED        14 f32 [64,7,1,1]                   f32 [64,7,1,1]                   f32 [64,7,1,1]                  
CONT               SUPPORTED         8 f16 [12288,4,16,1]               f16 [12288,4,16,1]               none [0,0,0,0]                  
CONT               SUPPORTED         8 f16 [256,4,16,1]                 f16 [256,4,16,1]                 none [0,0,0,0]                  
CONT               SUPPORTED         8 f32 [64,512,1,1]                 f32 [4,16,512,1]                 none [0,0,0,0]                  
CONT               SUPPORTED         8 f32 [64,7,1,1]                   f32 [4,16,7,1]                   none [0,0,0,0]                  
CPY                SUPPORTED         1 f16 [12288,64,1,1]               f32 [12288,64,1,1]               f16 [12288,64,1,1]              
FLASH_ATTN_EXT     REJECTED          8 f32 [4,16,1,1]                   f32 [4,1,16,1]                   f16 [4,12288,16,1]              
GET_ROWS           SUPPORTED         1 f32 [64,1,1,1]                   bf16 [64,32000,1,1]              i32 [1,1,1,1]                   
GET_ROWS           SUPPORTED         2 f32 [64,1,1,1]                   f32 [64,1,1,1]                   i32 [1,1,1,1]                   
GET_ROWS           SUPPORTED         2 f32 [64,1,1,1]                   f32 [64,7,1,1]                   i32 [1,1,1,1]                   
GET_ROWS           SUPPORTED         2 f32 [64,512,1,1]                 f32 [64,512,1,1]                 i32 [512,1,1,1]                 
GET_ROWS           SUPPORTED         1 f32 [64,7,1,1]                   bf16 [64,32000,1,1]              i32 [7,1,1,1]                   
GLU                SUPPORTED         9 f32 [256,1,1,1]                  f32 [256,1,1,1]                  f32 [256,1,1,1]                 
GLU                SUPPORTED         7 f32 [256,512,1,1]                f32 [256,512,1,1]                f32 [256,512,1,1]               
GLU                SUPPORTED         7 f32 [256,7,1,1]                  f32 [256,7,1,1]                  f32 [256,7,1,1]                 
MUL_MAT            REJECTED          8 f32 [12288,512,16,1]             f16 [4,12288,16,1]               f32 [4,512,16,1]                
MUL_MAT            REJECTED          8 f32 [256,7,16,1]                 f16 [4,256,16,1]                 f32 [4,7,16,1]                  
MUL_MAT            SUPPORTED        18 f32 [256,1,1,1]                  bf16 [64,256,1,1]                f32 [64,1,1,1]                  
MUL_MAT            SUPPORTED        15 f32 [256,512,1,1]                bf16 [64,256,1,1]                f32 [64,512,1,1]                
MUL_MAT            SUPPORTED        14 f32 [256,7,1,1]                  bf16 [64,256,1,1]                f32 [64,7,1,1]                  
MUL_MAT            SUPPORTED         2 f32 [32000,1,1,1]                bf16 [64,32000,1,1]              f32 [64,1,1,1]                  
MUL_MAT            SUPPORTED         2 f32 [32000,512,1,1]              bf16 [64,32000,1,1]              f32 [64,512,1,1]                
MUL_MAT            SUPPORTED         6 f32 [4,512,16,1]                 f16 [12288,4,16,1]               f32 [12288,512,16,1]            
MUL_MAT            SUPPORTED         8 f32 [4,7,16,1]                   f16 [256,4,16,1]                 f32 [256,7,16,1]                
MUL_MAT            SUPPORTED         9 f32 [64,1,1,1]                   bf16 [256,64,1,1]                f32 [256,1,1,1]                 
MUL_MAT            SUPPORTED        32 f32 [64,1,1,1]                   bf16 [64,64,1,1]                 f32 [64,1,1,1]                  
MUL_MAT            SUPPORTED         6 f32 [64,512,1,1]                 bf16 [256,64,1,1]                f32 [256,512,1,1]               
MUL_MAT            SUPPORTED        29 f32 [64,512,1,1]                 bf16 [64,64,1,1]                 f32 [64,512,1,1]                
MUL_MAT            SUPPORTED         7 f32 [64,7,1,1]                   bf16 [256,64,1,1]                f32 [256,7,1,1]                 
MUL_MAT            SUPPORTED        32 f32 [64,7,1,1]                   bf16 [64,64,1,1]                 f32 [64,7,1,1]                  
MUL                SUPPORTED        23 f32 [64,1,1,1]                   f32 [64,1,1,1]                   f32 [64,1,1,1]                  
MUL                SUPPORTED        13 f32 [64,512,1,1]                 f32 [64,512,1,1]                 f32 [64,1,1,1]                  
MUL                SUPPORTED        15 f32 [64,7,1,1]                   f32 [64,7,1,1]                   f32 [64,1,1,1]                  
NONE               SUPPORTED         8 bf16 [256,64,1,1]                none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        16 bf16 [64,256,1,1]                none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED         1 bf16 [64,32000,1,1]              none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        32 bf16 [64,64,1,1]                 none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        17 f32 [64,1,1,1]                   none [0,0,0,0]                   none [0,0,0,0]                  
RMS_NORM           SUPPORTED        19 f32 [64,1,1,1]                   f32 [64,1,1,1]                   none [0,0,0,0]                  
RMS_NORM           SUPPORTED        13 f32 [64,512,1,1]                 f32 [64,512,1,1]                 none [0,0,0,0]                  
RMS_NORM           SUPPORTED        15 f32 [64,7,1,1]                   f32 [64,7,1,1]                   none [0,0,0,0]                  
ROPE               SUPPORTED        16 f32 [4,16,1,1]                   f32 [4,16,1,1]                   i32 [1,1,1,1]                   
ROPE               SUPPORTED        15 f32 [4,16,512,1]                 f32 [4,16,512,1]                 i32 [512,1,1,1]                 
ROPE               SUPPORTED        16 f32 [4,16,7,1]                   f32 [4,16,7,1]                   i32 [7,1,1,1]                   
SOFT_MAX           SUPPORTED         8 f32 [12288,512,16,1]             f32 [12288,512,16,1]             f32 [12288,512,1,1]             
SOFT_MAX           SUPPORTED         8 f32 [256,7,16,1]                 f32 [256,7,16,1]                 f32 [256,64,1,1]                
[akapoor@wspd0 llama.cpp]$ 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends `advanced_matmul_shape_offload` to offload more safe Triton MAT_MUL shapes to the OPU, and centralizes size caps for consistency. No new flags; addresses FIR-2167.

- **New Features**
  - Adds `tsavorite_mul_mat_advanced_shape_ok()` to gate offload when: result is F32; inputs pack to F32; `K % 32 == 0`; dims within caps (`K<=8192`, `M<=32768`, `N<=4096`); safe D2/D3 broadcast; and padded sizes/byte count are valid.
  - Introduces `tsavorite_triton_matmul_dims_within_caps()` and uses it in both the advanced path and the standard `mul_mat_supported_size()` checks.
  - Enables the advanced path early when `advanced_matmul_shape_offload` is set (with `TRITON_DEBUG` logging); keeps grouped-head/repeat-head 4D broadcasts disabled pending a proper fix.

<sup>Written for commit 9aa38cbc32a52c78f57a10b8112ccaad82d847c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/llama.cpp/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/gemma3:1b-it-q4_K_M --device tsavorite   -c 12288   --temp 0.0   --n-predict 2   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1 user_dram_size_gb=16 user_dram_size_bytes=17179869184 advanced_matmul_shape_offload=1 triton_matmul_small_n_transpose_opt=1
 My cat's name is Luna and



llama_perf_sampler_print:    sampling time =      28.97 ms /     9 runs   (    3.22 ms per token,   310.71 tokens per second)
llama_perf_context_print:        load time =  119929.54 ms
llama_perf_context_print: prompt eval time =  116954.17 ms /     7 tokens (16707.74 ms per token,     0.06 tokens per second)
llama_perf_context_print:        eval time =  114028.31 ms /     1 runs   (114028.31 ms per token,     0.01 tokens per second)
llama_perf_context_print:       total time =  233988.86 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU          104             404            102939            989.80
  MUL              OPU          314            1856           1236923           3939.25
  RMS_NORM         OPU          314             314            404363           1287.78
  MUL_MAT          CPU          813               0           1129998           1389.91
  MUL_MAT          OPU          262             418         228647937         872702.05
  SCALE            CPU           54               0               336              6.22
  CONT             OPU          104               0             19154            184.17
  RESHAPE          CPU          563               0               347              0.62
  VIEW             CPU          552               0                72              0.13
  VIEW             OPU          104               0                44              0.42
  PERMUTE          CPU          362               0               130              0.36
  PERMUTE          OPU          104               0                11              0.11
  TRANSPOSE        CPU          188               0                35              0.19
  GET_ROWS         OPU            6               0                84             14.00
  SET_ROWS         CPU          384               0               586              1.53
  SOFT_MAX         OPU           52               0              7894            151.81
  ROPE             CPU          204               0              3217             15.77
  ROPE             OPU           52               0              2089             40.17
  GLU              CPU          198               0             76917            388.47

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ cat ggml_op_shape_dtype_catalog.tsv 
Op                 Decision      Count Result                           Src0                             Src1                            
------------------ ---------- -------- -------------------------------- -------------------------------- --------------------------------
ADD                SUPPORTED        54 f32 [1152,1,1,1]                 f32 [1152,1,1,1]                 f32 [1152,1,1,1]                
ADD                SUPPORTED        36 f32 [1152,512,1,1]               f32 [1152,512,1,1]               f32 [1152,512,1,1]              
ADD                SUPPORTED        50 f32 [1152,7,1,1]                 f32 [1152,7,1,1]                 f32 [1152,7,1,1]                
CONT               SUPPORTED        22 f16 [1024,256,1,1]               f16 [1024,256,1,1]               none [0,0,0,0]                  
CONT               SUPPORTED         4 f16 [12288,256,1,1]              f16 [12288,256,1,1]              none [0,0,0,0]                  
CONT               SUPPORTED        26 f16 [256,256,1,1]                f16 [256,256,1,1]                none [0,0,0,0]                  
CONT               SUPPORTED        26 f32 [1024,512,1,1]               f32 [256,4,512,1]                none [0,0,0,0]                  
CONT               SUPPORTED        26 f32 [1024,7,1,1]                 f32 [256,4,7,1]                  none [0,0,0,0]                  
CPY                SUPPORTED         1 f16 [1024,64,1,1]                f32 [1024,64,1,1]                f16 [1024,64,1,1]               
CPY                SUPPORTED         1 f16 [12288,64,1,1]               f32 [12288,64,1,1]               f16 [12288,64,1,1]              
FLASH_ATTN_EXT     REJECTED         22 f32 [256,4,1,1]                  f32 [256,1,4,1]                  f16 [256,1024,1,1]              
FLASH_ATTN_EXT     REJECTED          4 f32 [256,4,1,1]                  f32 [256,1,4,1]                  f16 [256,12288,1,1]             
GET_ROWS           SUPPORTED         2 f32 [1152,1,1,1]                 f32 [1152,1,1,1]                 i32 [1,1,1,1]                   
GET_ROWS           SUPPORTED         2 f32 [1152,1,1,1]                 f32 [1152,7,1,1]                 i32 [1,1,1,1]                   
GET_ROWS           SUPPORTED         1 f32 [1152,1,1,1]                 q8_0 [1152,262144,1,1]           i32 [1,1,1,1]                   
GET_ROWS           SUPPORTED         2 f32 [1152,512,1,1]               f32 [1152,512,1,1]               i32 [512,1,1,1]                 
GET_ROWS           SUPPORTED         1 f32 [1152,7,1,1]                 q8_0 [1152,262144,1,1]           i32 [7,1,1,1]                   
GLU                REJECTED         27 f32 [6912,1,1,1]                 f32 [6912,1,1,1]                 f32 [6912,1,1,1]                
GLU                REJECTED         26 f32 [6912,512,1,1]               f32 [6912,512,1,1]               f32 [6912,512,1,1]              
GLU                REJECTED         25 f32 [6912,7,1,1]                 f32 [6912,7,1,1]                 f32 [6912,7,1,1]                
MUL_MAT            SUPPORTED        26 f32 [1024,1,1,1]                 q5_0 [1152,1024,1,1]             f32 [1152,1,1,1]                
MUL_MAT            SUPPORTED        27 f32 [1024,512,1,1]               q5_0 [1152,1024,1,1]             f32 [1152,512,1,1]              
MUL_MAT            SUPPORTED        16 f32 [1024,512,4,1]               f16 [256,1024,1,1]               f32 [256,512,4,1]               
MUL_MAT            SUPPORTED        26 f32 [1024,7,1,1]                 q5_0 [1152,1024,1,1]             f32 [1152,7,1,1]                
MUL_MAT            SUPPORTED        26 f32 [1152,1,1,1]                 q4_K [1024,1152,1,1]             f32 [1024,1,1,1]                
MUL_MAT            SUPPORTED        13 f32 [1152,1,1,1]                 q4_K [6912,1152,1,1]             f32 [6912,1,1,1]                
MUL_MAT            SUPPORTED        14 f32 [1152,1,1,1]                 q6_K [6912,1152,1,1]             f32 [6912,1,1,1]                
MUL_MAT            SUPPORTED        27 f32 [1152,512,1,1]               q4_K [1024,1152,1,1]             f32 [1024,512,1,1]              
MUL_MAT            SUPPORTED        10 f32 [1152,512,1,1]               q4_K [6912,1152,1,1]             f32 [6912,512,1,1]              
MUL_MAT            SUPPORTED        12 f32 [1152,512,1,1]               q6_K [6912,1152,1,1]             f32 [6912,512,1,1]              
MUL_MAT            SUPPORTED        26 f32 [1152,7,1,1]                 q4_K [1024,1152,1,1]             f32 [1024,7,1,1]                
MUL_MAT            SUPPORTED        13 f32 [1152,7,1,1]                 q4_K [6912,1152,1,1]             f32 [6912,7,1,1]                
MUL_MAT            SUPPORTED        12 f32 [1152,7,1,1]                 q6_K [6912,1152,1,1]             f32 [6912,7,1,1]                
MUL_MAT            SUPPORTED         4 f32 [12288,512,4,1]              f16 [256,12288,1,1]              f32 [256,512,4,1]               
MUL_MAT            SUPPORTED        39 f32 [256,1,1,1]                  q5_0 [1152,256,1,1]              f32 [1152,1,1,1]                
MUL_MAT            SUPPORTED        13 f32 [256,1,1,1]                  q8_0 [1152,256,1,1]              f32 [1152,1,1,1]                
MUL_MAT            SUPPORTED        35 f32 [256,512,1,1]                q5_0 [1152,256,1,1]              f32 [1152,512,1,1]              
MUL_MAT            SUPPORTED        12 f32 [256,512,1,1]                q8_0 [1152,256,1,1]              f32 [1152,512,1,1]              
MUL_MAT            SUPPORTED        17 f32 [256,512,4,1]                f16 [1024,256,1,1]               f32 [1024,512,4,1]              
MUL_MAT            SUPPORTED         3 f32 [256,512,4,1]                f16 [12288,256,1,1]              f32 [12288,512,4,1]             
MUL_MAT            SUPPORTED        39 f32 [256,7,1,1]                  q5_0 [1152,256,1,1]              f32 [1152,7,1,1]                
MUL_MAT            SUPPORTED        13 f32 [256,7,1,1]                  q8_0 [1152,256,1,1]              f32 [1152,7,1,1]                
MUL_MAT            SUPPORTED        52 f32 [256,7,4,1]                  f16 [256,256,1,1]                f32 [256,7,4,1]                 
MUL_MAT            SUPPORTED         2 f32 [262144,1,1,1]               q8_0 [1152,262144,1,1]           f32 [1152,1,1,1]                
MUL_MAT            SUPPORTED         2 f32 [262144,512,1,1]             q8_0 [1152,262144,1,1]           f32 [1152,512,1,1]              
MUL_MAT            SUPPORTED        54 f32 [6912,1,1,1]                 q5_0 [1152,6912,1,1]             f32 [1152,1,1,1]                
MUL_MAT            SUPPORTED        45 f32 [6912,512,1,1]               q5_0 [1152,6912,1,1]             f32 [1152,512,1,1]              
MUL_MAT            SUPPORTED        50 f32 [6912,7,1,1]                 q5_0 [1152,6912,1,1]             f32 [1152,7,1,1]                
MUL                SUPPORTED       116 f32 [1152,1,1,1]                 f32 [1152,1,1,1]                 f32 [1152,1,1,1]                
MUL                SUPPORTED        73 f32 [1152,512,1,1]               f32 [1152,512,1,1]               f32 [1152,1,1,1]                
MUL                SUPPORTED       101 f32 [1152,7,1,1]                 f32 [1152,7,1,1]                 f32 [1152,1,1,1]                
MUL                SUPPORTED        28 f32 [256,1,1,1]                  f32 [256,1,1,1]                  f32 [256,1,1,1]                 
MUL                SUPPORTED        20 f32 [256,1,512,1]                f32 [256,1,512,1]                f32 [256,1,1,1]                 
MUL                SUPPORTED        26 f32 [256,1,7,1]                  f32 [256,1,7,1]                  f32 [256,1,1,1]                 
MUL                SUPPORTED        26 f32 [256,4,1,1]                  f32 [256,4,1,1]                  f32 [256,1,1,1]                 
MUL                SUPPORTED        16 f32 [256,4,512,1]                f32 [256,4,512,1]                f32 [256,1,1,1]                 
MUL                SUPPORTED        26 f32 [256,4,7,1]                  f32 [256,4,7,1]                  f32 [256,1,1,1]                 
NONE               SUPPORTED       105 f32 [1152,1,1,1]                 none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        52 f32 [256,1,1,1]                  none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        26 q4_K [1024,1152,1,1]             none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        13 q4_K [6912,1152,1,1]             none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        26 q5_0 [1152,1024,1,1]             none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        39 q5_0 [1152,256,1,1]              none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        52 q5_0 [1152,6912,1,1]             none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        13 q6_K [6912,1152,1,1]             none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED        13 q8_0 [1152,256,1,1]              none [0,0,0,0]                   none [0,0,0,0]                  
NONE               SUPPORTED         1 q8_0 [1152,262144,1,1]           none [0,0,0,0]                   none [0,0,0,0]                  
RMS_NORM           SUPPORTED       109 f32 [1152,1,1,1]                 f32 [1152,1,1,1]                 none [0,0,0,0]                  
RMS_NORM           SUPPORTED        73 f32 [1152,512,1,1]               f32 [1152,512,1,1]               none [0,0,0,0]                  
RMS_NORM           SUPPORTED       101 f32 [1152,7,1,1]                 f32 [1152,7,1,1]                 none [0,0,0,0]                  
RMS_NORM           SUPPORTED        26 f32 [256,1,1,1]                  f32 [256,1,1,1]                  none [0,0,0,0]                  
RMS_NORM           SUPPORTED        17 f32 [256,1,512,1]                f32 [256,1,512,1]                none [0,0,0,0]                  
RMS_NORM           SUPPORTED        26 f32 [256,1,7,1]                  f32 [256,1,7,1]                  none [0,0,0,0]                  
RMS_NORM           SUPPORTED        26 f32 [256,4,1,1]                  f32 [256,4,1,1]                  none [0,0,0,0]                  
RMS_NORM           SUPPORTED        17 f32 [256,4,512,1]                f32 [256,4,512,1]                none [0,0,0,0]                  
RMS_NORM           SUPPORTED        26 f32 [256,4,7,1]                  f32 [256,4,7,1]                  none [0,0,0,0]                  
ROPE               SUPPORTED        26 f32 [256,1,1,1]                  f32 [256,1,1,1]                  i32 [1,1,1,1]                   
ROPE               SUPPORTED        26 f32 [256,1,512,1]                f32 [256,1,512,1]                i32 [512,1,1,1]                 
ROPE               SUPPORTED        26 f32 [256,1,7,1]                  f32 [256,1,7,1]                  i32 [7,1,1,1]                   
ROPE               SUPPORTED        26 f32 [256,4,1,1]                  f32 [256,4,1,1]                  i32 [1,1,1,1]                   
ROPE               SUPPORTED        23 f32 [256,4,512,1]                f32 [256,4,512,1]                i32 [512,1,1,1]                 
ROPE               SUPPORTED        26 f32 [256,4,7,1]                  f32 [256,4,7,1]                  i32 [7,1,1,1]                   
SCALE              REJECTED          1 f32 [1152,1,1,1]                 f32 [1152,1,1,1]                 none [0,0,0,0]                  
SCALE              REJECTED          1 f32 [1152,7,1,1]                 f32 [1152,7,1,1]                 none [0,0,0,0]                  
SCALE              REJECTED         26 f32 [256,4,1,1]                  f32 [256,4,1,1]                  none [0,0,0,0]                  
SCALE              REJECTED         26 f32 [256,4,512,1]                f32 [256,4,512,1]                none [0,0,0,0]                  
SCALE              REJECTED         26 f32 [256,4,7,1]                  f32 [256,4,7,1]                  none [0,0,0,0]                  
SOFT_MAX           SUPPORTED        22 f32 [1024,512,4,1]               f32 [1024,512,4,1]               f32 [1024,512,1,1]              
SOFT_MAX           SUPPORTED         4 f32 [12288,512,4,1]              f32 [12288,512,4,1]              f32 [12288,512,1,1]             
SOFT_MAX           SUPPORTED        26 f32 [256,7,4,1]                  f32 [256,7,4,1]                  f32 [256,64,1,1]                


