### PR TITLE
@FIR-2172 - Add runtime-controlled broadcast Triton MAT_MUL offload support

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -3722,6 +3722,15 @@ static inline int64_t map_repeat_i64(int64_t out_idx, int64_t in_dim) {
     return (r < 0) ? (r + in_dim) : r;
 }
 
+/*
+ * Map an output D2/D3 batch index to the corresponding input batch index for
+ * grouped broadcast MAT_MUL layouts.
+ *
+ * This is intentionally not generic GGML_OP_REPEAT modulo mapping. For grouped
+ * head layouts such as A2=4, D2=32, output heads 0..7 map to input head 0,
+ * 8..15 map to input head 1, etc. This matches the grouped-head MAT_MUL
+ * packing requirement used by the Triton offload path.
+ */
 static inline int64_t map_repeat_dim_i64(int64_t out_idx, int64_t out_dim, int64_t in_dim) {
     if (in_dim <= 1) return 0;
     if (out_dim <= 0) return 0;
@@ -3964,8 +3973,14 @@ static inline bool tsavorite_mul_mat_advanced_shape_ok(const struct ggml_tensor 
     const int64_t D2 = op->ne[2];
     const int64_t D3 = op->ne[3];
 
+    /*
+     * Only require the broadcast flag for actual broadcast layouts where an
+     * input batch dimension differs from the output batch dimension. Batched
+     * non-broadcast layouts such as A2=B2=D2=2 should remain controlled by
+     * advanced_matmul_shape_offload and must not require the broadcast flag.
+     */
     const bool has_broadcast_dims =
-        (A2 != 1 || A3 != 1 || B2 != 1 || B3 != 1 || D2 != 1 || D3 != 1);
+        (A2 != D2 || B2 != D2 || A3 != D3 || B3 != D3);
 
     if (has_broadcast_dims && !advanced_matmul_broadcast_offload) {
         return false;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -125,6 +125,7 @@ struct TsavoriteRuntimeState {
     void **loadResult_matmul_1x8 = nullptr;
     void **loadResult_matmul_2x4 = nullptr;
     bool advanced_matmul_shape_offload = false;
+    bool advanced_matmul_broadcast_offload = false;
     bool triton_matmul_small_n_transpose_opt = false;
 #endif
 
@@ -184,6 +185,7 @@ auto &loadResult_triton_add = g_rt.loadResult_triton_add;
 auto &loadResult_matmul_1x8     = g_rt.loadResult_matmul_1x8;
 auto &loadResult_matmul_2x4     = g_rt.loadResult_matmul_2x4;
 auto &advanced_matmul_shape_offload = g_rt.advanced_matmul_shape_offload;
+auto &advanced_matmul_broadcast_offload = g_rt.advanced_matmul_broadcast_offload;
 auto &triton_matmul_small_n_transpose_opt = g_rt.triton_matmul_small_n_transpose_opt;
 #endif
 } // anonymous namespace
@@ -282,6 +284,8 @@ struct tsi_deploy_cfg_t {
 #if TRITON_MAT_MUL
     bool advanced_matmul_shape_offload = false;
     bool has_advanced_matmul_shape_offload = false;
+    bool advanced_matmul_broadcast_offload = false;
+    bool has_advanced_matmul_broadcast_offload = false;
     bool triton_matmul_small_n_transpose_opt = false;
     bool has_triton_matmul_small_n_transpose_opt = false;
 #endif
@@ -359,6 +363,15 @@ static tsi_deploy_cfg_t tsi_read_deploy_yaml(const std::string &path) {
                 cfg.has_advanced_matmul_shape_offload = true;
             }
         }
+        if (t.find("advanced_matmul_broadcast_offload") != std::string::npos &&
+            t.find(':') != std::string::npos) {
+            bool b = false;
+            if (tsi_parse_bool_after_colon(t, &b)) {
+                cfg.advanced_matmul_broadcast_offload = b;
+                cfg.has_advanced_matmul_broadcast_offload = true;
+            }
+        }
+
         if (t.find("triton_matmul_small_n_transpose_opt") != std::string::npos &&
             t.find(':') != std::string::npos) {
             bool b = false;
@@ -1648,6 +1661,11 @@ static void ensure_tsi_runtime_initialized() {
         cfg.has_advanced_matmul_shape_offload ?
         cfg.advanced_matmul_shape_offload :
         false;
+
+    advanced_matmul_broadcast_offload =
+        cfg.has_advanced_matmul_broadcast_offload ?
+        cfg.advanced_matmul_broadcast_offload :
+        false;
     triton_matmul_small_n_transpose_opt =
         cfg.has_triton_matmul_small_n_transpose_opt ?
         cfg.triton_matmul_small_n_transpose_opt :
@@ -1680,6 +1698,8 @@ static void ensure_tsi_runtime_initialized() {
 #if TRITON_MAT_MUL
     printf(" advanced_matmul_shape_offload=%d",
            (int)advanced_matmul_shape_offload);
+    printf(" advanced_matmul_broadcast_offload=%d",
+           (int)advanced_matmul_broadcast_offload);
     printf(" triton_matmul_small_n_transpose_opt=%d",
            (int)triton_matmul_small_n_transpose_opt);
 #endif
@@ -3702,6 +3722,22 @@ static inline int64_t map_repeat_i64(int64_t out_idx, int64_t in_dim) {
     return (r < 0) ? (r + in_dim) : r;
 }
 
+static inline int64_t map_repeat_dim_i64(int64_t out_idx, int64_t out_dim, int64_t in_dim) {
+    if (in_dim <= 1) return 0;
+    if (out_dim <= 0) return 0;
+    if (in_dim == out_dim) return out_idx;
+
+    if ((out_dim % in_dim) == 0) {
+        const int64_t group = out_dim / in_dim;
+        int64_t r = out_idx / group;
+        if (r < 0) r = 0;
+        if (r >= in_dim) r = in_dim - 1;
+        return r;
+    }
+
+    return map_repeat_i64(out_idx, in_dim);
+}
+
 
 // ============================================================================
 // ABI WRAPPERS: raw pointers -> MemRefDescriptor<4> -> call MLIR ciface
@@ -3877,7 +3913,7 @@ static inline const triton_matmul_txe_shape_t &triton_matmul_select_shape(
 
 // Data type specific
 #define TRITON_MATMUL_F32_K_DIM      32
-#define TSAV_TRITON_MATMUL_MAX_K 8192
+#define TSAV_TRITON_MATMUL_MAX_K 12288
 #define TSAV_TRITON_MATMUL_MAX_M 32768
 #define TSAV_TRITON_MATMUL_MAX_N 4096
 
@@ -3928,6 +3964,13 @@ static inline bool tsavorite_mul_mat_advanced_shape_ok(const struct ggml_tensor 
     const int64_t D2 = op->ne[2];
     const int64_t D3 = op->ne[3];
 
+    const bool has_broadcast_dims =
+        (A2 != 1 || A3 != 1 || B2 != 1 || B3 != 1 || D2 != 1 || D3 != 1);
+
+    if (has_broadcast_dims && !advanced_matmul_broadcast_offload) {
+        return false;
+    }
+
     if (b->ne[0] != K || op->ne[0] != M || op->ne[1] != N) {
         return false;
     }
@@ -3936,15 +3979,24 @@ static inline bool tsavorite_mul_mat_advanced_shape_ok(const struct ggml_tensor 
         return false;
     }
 
+    if (A2 <= 0 || A3 <= 0 || B2 <= 0 || B3 <= 0 || D2 <= 0 || D3 <= 0) {
+        return false;
+    }
+
     if (D2 != ((A2 > B2) ? A2 : B2) || D3 != ((A3 > B3) ? A3 : B3)) {
         return false;
     }
 
-    if (!(A2 == D2 || A2 == 1) || !(B2 == D2 || B2 == 1)) {
+    /*
+     * Allow GGML repeat/broadcast layouts where an input batch dimension divides
+     * the output batch dimension. Runtime packing uses map_repeat_dim_i64(), so
+     * shapes such as A2=4, B2=32, D2=32 are valid.
+     */
+    if ((D2 % A2) != 0 || (D2 % B2) != 0) {
         return false;
     }
 
-    if (!(A3 == D3 || A3 == 1) || !(B3 == D3 || B3 == 1)) {
+    if ((D3 % A3) != 0 || (D3 % B3) != 0) {
         return false;
     }
 
@@ -5265,10 +5317,10 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
         for (int64_t d3 = 0; d3 < D3; ++d3) {
             for (int64_t d2 = 0; d2 < D2; ++d2) {
-                const int64_t a_d2 = map_repeat_i64(d2, A2);
-                const int64_t a_d3 = map_repeat_i64(d3, A3);
-                const int64_t b_d2 = map_repeat_i64(d2, B2);
-                const int64_t b_d3 = map_repeat_i64(d3, B3);
+                const int64_t a_d2 = map_repeat_dim_i64(d2, D2, A2);
+                const int64_t a_d3 = map_repeat_dim_i64(d3, D3, A3);
+                const int64_t b_d2 = map_repeat_dim_i64(d2, D2, B2);
+                const int64_t b_d3 = map_repeat_dim_i64(d3, D3, B3);
 
                 char *A_ptr = A_base + a_d2 * a_nb2 + a_d3 * a_nb3;
                 char *B_ptr = B_base + b_d2 * b_nb2 + b_d3 * b_nb3;
@@ -5406,10 +5458,10 @@ static enum ggml_status ggml_tsavorite_run_tmu_mul_mat(
 
     for (int64_t d3 = 0; d3 < D3; ++d3) {
         for (int64_t d2 = 0; d2 < D2; ++d2) {
-            const int64_t a_d2 = map_repeat_i64(d2, A2);
-            const int64_t a_d3 = map_repeat_i64(d3, A3);
-            const int64_t b_d2 = map_repeat_i64(d2, B2);
-            const int64_t b_d3 = map_repeat_i64(d3, B3);
+            const int64_t a_d2 = map_repeat_dim_i64(d2, D2, A2);
+            const int64_t a_d3 = map_repeat_dim_i64(d3, D3, A3);
+            const int64_t b_d2 = map_repeat_dim_i64(d2, D2, B2);
+            const int64_t b_d3 = map_repeat_dim_i64(d3, D3, B3);
 
             char *A_ptr = A_base + a_d2 * a_nb2 + a_d3 * a_nb3;
             char *B_ptr = B_base + b_d2 * b_nb2 + b_d3 * b_nb3;

--- a/tsavorite-model-deployment.yaml
+++ b/tsavorite-model-deployment.yaml
@@ -17,7 +17,7 @@ multi_thread_enable: true
 ##   user_dram_size_gb: 8
 ##   user_dram_size_gb: 12
 ##   user_dram_size_gb: 24
-user_dram_size_gb: 16
+user_dram_size_gb: 8
 
 # Enable additional Triton MAT_MUL shapes beyond stable baseline.
 # false = old behavior

--- a/tsavorite-model-deployment.yaml
+++ b/tsavorite-model-deployment.yaml
@@ -17,7 +17,7 @@ multi_thread_enable: true
 ##   user_dram_size_gb: 8
 ##   user_dram_size_gb: 12
 ##   user_dram_size_gb: 24
-user_dram_size_gb: 8
+user_dram_size_gb: 16
 
 # Enable additional Triton MAT_MUL shapes beyond stable baseline.
 # false = old behavior
@@ -28,3 +28,9 @@ advanced_matmul_shape_offload: false
 # false = old behavior
 # true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
 triton_matmul_small_n_transpose_opt: false
+
+## Enable Triton MAT_MUL broadcast/batched D2/D3 offload.
+## false = keep broadcast MAT_MUL on fallback path
+## true  = allow advanced MAT_MUL helper to offload supported broadcast shapes
+
+advanced_matmul_broadcast_offload: false

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1070,6 +1070,7 @@ local user_dram_size_gb="8"
 
   if [ -f "${deployment_yaml_path}" ]; then
     local existing_advanced
+    local existing_broadcast
     local existing_small_n_opt
 local existing_user_dram_size_gb
 

--- a/tsi-pkg-build.sh
+++ b/tsi-pkg-build.sh
@@ -1062,6 +1062,7 @@ update_one_tsavorite_deployment_yaml() {
   local deployment_yaml_path="$1"
   local txe_count="$2"
   local advanced_matmul_shape_offload="false"
+  local advanced_matmul_broadcast_offload="false"
   local triton_matmul_small_n_transpose_opt="false"
 local user_dram_size_gb="8"
 
@@ -1073,12 +1074,16 @@ local user_dram_size_gb="8"
 local existing_user_dram_size_gb
 
     existing_advanced="$(extract_deployment_yaml_value "${deployment_yaml_path}" "advanced_matmul_shape_offload")"
+    existing_broadcast="$(extract_deployment_yaml_value "${deployment_yaml_path}" "advanced_matmul_broadcast_offload")"
     existing_small_n_opt="$(extract_deployment_yaml_value "${deployment_yaml_path}" "triton_matmul_small_n_transpose_opt")"
 
     if [ -n "${existing_advanced}" ]; then
       advanced_matmul_shape_offload="${existing_advanced}"
     fi
 
+    if [ -n "${existing_broadcast}" ]; then
+      advanced_matmul_broadcast_offload="${existing_broadcast}"
+    fi
     if [ -n "${existing_small_n_opt}" ]; then
       triton_matmul_small_n_transpose_opt="${existing_small_n_opt}"
     fi
@@ -1116,13 +1121,18 @@ user_dram_size_gb: $user_dram_size_gb
 # true  = new offload shapes
 advanced_matmul_shape_offload: ${advanced_matmul_shape_offload}
 
+## Enable Triton MAT_MUL broadcast/batched D2/D3 offload.
+## false = keep broadcast MAT_MUL on fallback path
+## true  = allow advanced MAT_MUL helper to offload supported broadcast shapes
+advanced_matmul_broadcast_offload: ${advanced_matmul_broadcast_offload}
+
 # Enable Triton MAT_MUL small-N transpose optimization.
 # false = old behavior
 # true  = for M >> N, compute swapped [N x M] and transpose copyback to [M x N]
 triton_matmul_small_n_transpose_opt: ${triton_matmul_small_n_transpose_opt}
 EOF
 
-  echo "INFO: updated ${deployment_yaml_path} with txe_count:${txe_count}, multi_thread_enable:true; preserved advanced_matmul_shape_offload:${advanced_matmul_shape_offload}, triton_matmul_small_n_transpose_opt:${triton_matmul_small_n_transpose_opt}"
+  echo "INFO: updated ${deployment_yaml_path} with txe_count:${txe_count}, multi_thread_enable:true; preserved advanced_matmul_shape_offload:${advanced_matmul_shape_offload}, advanced_matmul_broadcast_offload:${advanced_matmul_broadcast_offload}, triton_matmul_small_n_transpose_opt:${triton_matmul_small_n_transpose_opt}"
   return 0
 }
 


### PR DESCRIPTION
Summary

This PR adds broadcast/batched D2/D3 Triton MAT_MUL offload support behind a new runtime deployment flag:

advanced_matmul_broadcast_offload

Supported broadcast layouts can be offloaded when enabled, while existing fallback behavior remains unchanged when disabled.

Changes

- Added advanced_matmul_broadcast_offload runtime deployment flag.
- Enabled supported broadcast/batched D2/D3 Triton MAT_MUL shapes.
- Preserved default fallback behavior when the flag is disabled.
- Added grouped D2/D3 mapping support for broadcast MAT_MUL packing.
- Preserved the new flag during deployment YAML regeneration.

Validation

- Tiny-Llama prompt output remained correct: Luna.
- Broadcast MAT_MUL OPU execution verified.
- Existing non-broadcast MAT_MUL offload behavior preserved.

Follow-up

- Additional grouped-head/repeat-head broadcast MAT_MUL patterns will be evaluated in a future PR.


TESTED on POSIX
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/tinyllama-vo-5m-para.gguf --device tSavorite   -c 12288   --temp 0.0   --n-predict 2   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1 user_dram_size_gb=16 user_dram_size_bytes=17179869184 advanced_matmul_shape_offload=1 advanced_matmul_broadcast_offload=1 triton_matmul_small_n_transpose_opt=1
 My cat's name is Tim.



llama_perf_sampler_print:    sampling time =       3.83 ms /     9 runs   (    0.43 ms per token,  2346.81 tokens per second)
llama_perf_context_print:        load time =    1082.19 ms
llama_perf_context_print: prompt eval time =     681.79 ms /     7 tokens (   97.40 ms per token,    10.27 tokens per second)
llama_perf_context_print:        eval time =     449.93 ms /     1 runs   (  449.93 ms per token,     2.22 tokens per second)
llama_perf_context_print:       total time =    1536.75 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU           32             116             25360            792.50
  MUL              OPU           34             124            146173           4299.21
  RMS_NORM         OPU           34              34             56419           1659.38
  MUL_MAT          CPU          290               0             31741            109.45
  MUL_MAT          OPU           66              66            813995          12333.26
  CONT             OPU           32               0              8902            278.19
  RESHAPE          CPU          187               0                59              0.32
  VIEW             CPU          177               0                15              0.08
  VIEW             OPU           32               0                 5              0.16
  PERMUTE          CPU          117               0                22              0.19
  PERMUTE          OPU           32               0                 7              0.22
  TRANSPOSE        CPU           58               0                17              0.29
  GET_ROWS         OPU            6               0              1572            262.00
  SET_ROWS         CPU          124               0               144              1.16
  SOFT_MAX         OPU           16               0              8598            537.38
  ROPE             CPU          120               0               426              3.55
  GLU              OPU           16              58             43814           2738.38

OPU Profiling Results:
Profiler disabled

[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ 
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf--device tSavorite   -c 12288   --temp 0.0   --n-predict 2   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1 user_dram_size_gb=16 user_dram_size_bytes=17179869184 advanced_matmul_shape_offload=1 advanced_matmul_broadcast_offload=1 triton_matmul_small_n_transpose_opt=1
error: invalid argument: tSavorite
[akapoor@wspd0 llama.cpp]$ build-posix/bin/llama-cli   -p "My cat's name is"   -m /proj/rel/sw/ggml/models/Tiny-Llama-v0.3-FP32-1.1B-F32.gguf --device tSavorite   -c 12288   --temp 0.0   --n-predict 2   --repeat-penalty 1.5   -b 1024   --top-k 50   --top-p 0.9   --repeat-last-n 5   --no-warmup   --no-conversation

 TSI deploy yaml=tsavorite-model-deployment.yaml txe_count=1 multi_thread_enable=1 user_dram_size_gb=16 user_dram_size_bytes=17179869184 advanced_matmul_shape_offload=1 advanced_matmul_broadcast_offload=1 triton_matmul_small_n_transpose_opt=1
 My cat's name is Luna



llama_perf_sampler_print:    sampling time =       6.90 ms /     9 runs   (    0.77 ms per token,  1304.54 tokens per second)
llama_perf_context_print:        load time =  148486.67 ms
llama_perf_context_print: prompt eval time =  108607.46 ms /     7 tokens (15515.35 ms per token,     0.06 tokens per second)
llama_perf_context_print:        eval time =  107299.95 ms /     1 runs   (107299.95 ms per token,     0.01 tokens per second)
llama_perf_context_print:       total time =  255806.37 ms /     8 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU           88             340            111535           1267.44
  MUL              OPU           90             348            253851           2820.57
  RMS_NORM         OPU           90              90            312472           3471.91
  MUL_MAT          CPU          664               0           1195937           1801.11
  MUL_MAT          OPU          222            1586         211273483         951682.36
  CONT             OPU           88               0             15360            174.55
  RESHAPE          CPU          479               0               317              0.66
  VIEW             CPU          453               0                47              0.10
  VIEW             OPU           88               0                22              0.25
  PERMUTE          CPU          316               0               176              0.56
  PERMUTE          OPU           88               0                21              0.24
  TRANSPOSE        CPU          147               0                33              0.22
  GET_ROWS         OPU            6               0             11730           1955.00
  SET_ROWS         CPU          342               0              2987              8.73
  SOFT_MAX         OPU           44               0             87001           1977.30
  ROPE             CPU          350               0              9458             27.02
  GLU              OPU           44             170            402795           9154.43

OPU Profiling Results:
Profiler disabled


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends Triton MAT_MUL offload to support grouped broadcast D2/D3 batches and raises the K cap to 12288 to widen safe OPU coverage. Addresses Linear FIR-2172 and keeps broadcast offload behind a runtime flag.

- **New Features**
  - Adds `advanced_matmul_broadcast_offload` runtime flag (read from YAML, printed at init, preserved by `tsi-pkg-build.sh`).
  - Requires the flag only when input batch dims differ from output; non-broadcast batched shapes stay under `advanced_matmul_shape_offload`.
  - Implements `map_repeat_dim_i64` and updates packing loops; relaxes shape checks to allow D2/D3 that are multiples of input batch dims.
  - Increases `TSAV_TRITON_MATMUL_MAX_K` from 8192 to 12288.
  - Adds YAML option for broadcast offload.

- **Migration**
  - Default stays unchanged; broadcast offload is disabled. Enable via `advanced_matmul_broadcast_offload: true` in `tsavorite-model-deployment.yaml`.

<sup>Written for commit a29c9bbb343f1b9f649f16ae3996acbb18420f40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/llama.cpp/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



