### PR TITLE
@FIR-2216 - llama.cpp: expose ggml perf-summary symbols across ollama's split-binary backend boundary

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -77,6 +77,7 @@ extern "C" {
     GGML_API ggml_guid_t  ggml_backend_guid(ggml_backend_t backend);
     GGML_API const char * ggml_backend_name(ggml_backend_t backend);
     GGML_API void         ggml_backend_free(ggml_backend_t backend);
+    GGML_API void         ggml_backend_log_profile_info(ggml_backend_t backend);
 
     GGML_API ggml_backend_buffer_type_t ggml_backend_get_default_buffer_type(ggml_backend_t backend);
     GGML_API ggml_backend_buffer_t      ggml_backend_alloc_buffer(ggml_backend_t backend, size_t size);

--- a/ggml/src/ggml-backend-impl.h
+++ b/ggml/src/ggml-backend-impl.h
@@ -117,6 +117,15 @@ extern "C" {
 
         // (optional) sort/optimize the nodes in the graph
         void                      (*graph_optimize)    (ggml_backend_t backend, struct ggml_cgraph * cgraph);
+
+        // (optional) reserve a graph without allocating (used by ollama)
+        enum ggml_status          (*graph_reserve)      (ggml_backend_t backend, struct ggml_cgraph * cgraph, bool alloc);
+        // (optional) report backend-specific buffer size (used by ollama)
+        size_t                    (*buffer_size)        (ggml_backend_t backend);
+        // (optional) reset backend state (used by ollama)
+        void                      (*reset)              (ggml_backend_t backend);
+        // (optional) print backend-specific profiling info
+        void                      (*profile)            ();
     };
 
     struct ggml_backend {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -233,6 +233,16 @@ void ggml_backend_free(ggml_backend_t backend) {
     backend->iface.free(backend);
 }
 
+void ggml_backend_log_profile_info(ggml_backend_t backend) {
+    if (backend == NULL) {
+        return;
+    }
+    if (backend->iface.profile == NULL) {
+        return;
+    }
+    backend->iface.profile();
+}
+
 ggml_backend_buffer_type_t ggml_backend_get_default_buffer_type(ggml_backend_t backend) {
     GGML_ASSERT(backend);
     return ggml_backend_dev_buffer_type(backend->device);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -101,6 +101,7 @@ struct TsavoriteRuntimeState {
     std::mutex workers_mutex;
     std::mutex device_mutex;
     std::mutex tsi_pack_mutex;
+    std::mutex tsi_init_mutex;
     std::condition_variable device_cv;
     // blobs
     BlobDescriptor **blobDescriptor_add = nullptr;
@@ -161,6 +162,7 @@ auto &workers = g_rt.workers;
 auto &workers_mutex = g_rt.workers_mutex;
 auto &device_mutex = g_rt.device_mutex;
 auto &tsi_pack_mutex = g_rt.tsi_pack_mutex;
+auto &tsi_init_mutex = g_rt.tsi_init_mutex;
 auto &device_cv = g_rt.device_cv;
 
 auto &blobDescriptor_add      = g_rt.blobDescriptor_add;
@@ -1528,6 +1530,14 @@ static void tsi_unload_all_blobs() {
 }
 
 static inline void tsi_init_per_txe_state_once() {
+    // Guards device_free/packed_args/scalar_*_args lazy allocation below.
+    // Multiple op-dispatch entry points call this unconditionally on every
+    // invocation when multi_thread_enable=true, so concurrent worker threads
+    // can race into the check-then-act allocation (a non-atomic std::vector
+    // mutation) on first use, corrupting packed_args and causing an
+    // intermittent, hard-to-repro crash later inside the SDK.
+    std::lock_guard<std::mutex> lock(tsi_init_mutex);
+
     // allocate device_free[]
     if (!device_free) {
         device_free = (bool*)calloc(num_of_txes, sizeof(bool));

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -4827,6 +4827,18 @@ static inline void ensure_triton_full_buffers(
 #endif
 }
 
+// Guards the static descriptor/payload buffers below: they are shared,
+// process-wide storage reused across every call (not per-device, unlike
+// call_triton_matmul_full_packed_on_device()'s g_triton_desc_mt). With
+// multi_thread_enable=true, concurrent calls into this function race on
+// populating those buffers (init_rank1_memref_flat/init_scalar_i32_memref_aligned
+// write them with no synchronization) before ever reaching the
+// tsi_pack_mutex-protected dispatch call -- one caller's in-flight descriptor
+// data can be overwritten by another's mid-dispatch, corrupting the handle
+// tsi_shmem_handle_from_ptr() resolves it to. Serializing the whole
+// populate+dispatch sequence here closes that race.
+static std::mutex g_full_packed_static_mutex;
+
 static inline void call_triton_matmul_full_packed(
     const triton_matmul_txe_shape_t &txe_shape,
     float *A_full,     // physical [M_pad x K]
@@ -4835,6 +4847,8 @@ static inline void call_triton_matmul_full_packed(
     int32_t M_pad,
     int32_t N_pad,
     int32_t K) {
+
+    std::lock_guard<std::mutex> lock(g_full_packed_static_mutex);
 
     static MemRefDescriptor<Rank_Triton> *A_desc = nullptr;
     static MemRefDescriptor<Rank_Triton> *B_desc = nullptr;

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -84,6 +84,12 @@ struct TsavoriteRuntimeState {
     // device / threading
     uint32_t num_of_txes = 1;
     bool *device_free = nullptr;
+    // Mirrors whether device_free/packed_args/scalar_*_args are currently
+    // allocated. Must be reset to false everywhere device_free is freed
+    // (tsi_cleanup, ggml_tsavorite_free, tsi_log_profile_info) or the next
+    // tsi_init_per_txe_state_once() call will wrongly skip reallocating
+    // them, leaving dangling pointers behind.
+    std::atomic<bool> per_txe_state_initialized{false};
     bool multi_thread_enable = false;
     // one packed-args buffer per TXE
     std::vector<void *> packed_args;
@@ -147,6 +153,7 @@ static TsavoriteRuntimeState g_rt;
 // aliases (USE THESE EVERYWHERE)
 auto &num_of_txes = g_rt.num_of_txes;
 auto &device_free = g_rt.device_free;
+auto &per_txe_state_initialized = g_rt.per_txe_state_initialized;
 auto &multi_thread_enable     = g_rt.multi_thread_enable;
 auto &packed_args     = g_rt.packed_args;
 
@@ -1533,9 +1540,12 @@ static void tsi_unload_all_blobs() {
 static inline void tsi_init_per_txe_state_once() {
     // This is called unconditionally at the top of every op-dispatch entry
     // point, so once initialization is done, skip the lock entirely rather
-    // than paying a mutex acquisition on every single dispatch.
-    static std::atomic<bool> initialized{false};
-    if (initialized.load(std::memory_order_acquire)) {
+    // than paying a mutex acquisition on every single dispatch. The flag
+    // lives in shared runtime state (not a function-local static) because
+    // tsi_cleanup()/ggml_tsavorite_free()/tsi_log_profile_info() free
+    // device_free and must reset this alongside it, or a later dispatch
+    // would skip reallocation and dereference the freed pointer.
+    if (per_txe_state_initialized.load(std::memory_order_acquire)) {
         return;
     }
 
@@ -1545,7 +1555,7 @@ static inline void tsi_init_per_txe_state_once() {
     // packed_args and causing an intermittent, hard-to-repro crash later
     // inside the SDK.
     std::lock_guard<std::mutex> lock(tsi_init_mutex);
-    if (initialized.load(std::memory_order_relaxed)) {
+    if (per_txe_state_initialized.load(std::memory_order_relaxed)) {
         return; // another thread finished initializing while we waited for the lock
     }
 
@@ -1640,7 +1650,7 @@ static inline void tsi_init_per_txe_state_once() {
         }
     }
 
-    initialized.store(true, std::memory_order_release);
+    per_txe_state_initialized.store(true, std::memory_order_release);
 }
 
 // Centralized TSI runtime initialization - called once globally
@@ -2878,6 +2888,7 @@ static void ggml_tsavorite_free(struct ggml_backend_tsavorite_context *ctx) {
           free(device_free);
          device_free = NULL;
       }
+      per_txe_state_initialized.store(false, std::memory_order_release);
       sleep(2);
       tsi_finalize();
       tsirt::utils::TSIProfiler::finalize();
@@ -2906,6 +2917,7 @@ tsi_cleanup() {
         free(device_free);
         device_free = NULL;
     }
+    per_txe_state_initialized.store(false, std::memory_order_release);
     sleep(2);
     tsi_finalize();
     GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
@@ -7241,6 +7253,7 @@ tsi_log_profile_info() {
         free(device_free);
         device_free = NULL;
     }
+    per_txe_state_initialized.store(false, std::memory_order_release);
     printf("\n finalize 4 \n");
     tsi_finalize();
     tsirt::utils::TSIProfiler::finalize();

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -1537,6 +1537,26 @@ static void tsi_unload_all_blobs() {
     tsi_blob_free_tables();
 }
 
+// Call at every teardown site that frees device_free (tsi_cleanup,
+// ggml_tsavorite_free, tsi_log_profile_info). tsi_finalize() invalidates
+// the per-TXE tsi_alloc buffers, but packed_args/scalar_*_args keep their
+// old (now dangling) pointers -- tsi_init_per_txe_state_once() only
+// reallocates when a vector's size changes, so leaving them at their
+// current size would make the next dispatch use stale buffers. Clearing
+// them (not just resetting per_txe_state_initialized) forces a full
+// reallocation on the next init.
+static inline void tsi_reset_per_txe_state_after_teardown() {
+    packed_args.clear();
+    scalar_loop_args.clear();
+    scalar_m_args.clear();
+    scalar_n_args.clear();
+    scalar_k_args.clear();
+    scalar_grid1_args.clear();
+    scalar_grid2_args.clear();
+    scalar_grid3_args.clear();
+    per_txe_state_initialized.store(false, std::memory_order_release);
+}
+
 static inline void tsi_init_per_txe_state_once() {
     // This is called unconditionally at the top of every op-dispatch entry
     // point, so once initialization is done, skip the lock entirely rather
@@ -2888,7 +2908,7 @@ static void ggml_tsavorite_free(struct ggml_backend_tsavorite_context *ctx) {
           free(device_free);
          device_free = NULL;
       }
-      per_txe_state_initialized.store(false, std::memory_order_release);
+      tsi_reset_per_txe_state_after_teardown();
       sleep(2);
       tsi_finalize();
       tsirt::utils::TSIProfiler::finalize();
@@ -2917,7 +2937,7 @@ tsi_cleanup() {
         free(device_free);
         device_free = NULL;
     }
-    per_txe_state_initialized.store(false, std::memory_order_release);
+    tsi_reset_per_txe_state_after_teardown();
     sleep(2);
     tsi_finalize();
     GGML_TSAVORITE_LOG_INFO("Start %s\n", __func__);
@@ -7253,7 +7273,7 @@ tsi_log_profile_info() {
         free(device_free);
         device_free = NULL;
     }
-    per_txe_state_initialized.store(false, std::memory_order_release);
+    tsi_reset_per_txe_state_after_teardown();
     printf("\n finalize 4 \n");
     tsi_finalize();
     tsirt::utils::TSIProfiler::finalize();

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -7832,12 +7832,18 @@ static void * ggml_backend_tsavorite_get_proc_address(ggml_backend_reg_t reg, co
     if (strcmp(name, "ggml_perf_accumulate") == 0) {
         return (void *)ggml_perf_accumulate;
     }
+#if defined(GGML_PERF_DETAIL)
+    // ggml_perf_log_open/write_detailed_csv only exist in ggml.c under
+    // GGML_PERF_DETAIL (see ggml.c's own #if guard around their definitions);
+    // taking their address here unconditionally would leave a dangling
+    // undefined reference in GGML_PERF_RELEASE/GGML_PERF builds.
     if (strcmp(name, "ggml_perf_log_open") == 0) {
         return (void *)ggml_perf_log_open;
     }
     if (strcmp(name, "ggml_perf_write_detailed_csv") == 0) {
         return (void *)ggml_perf_write_detailed_csv;
     }
+#endif
     if (strcmp(name, "ggml_backend_type") == 0) {
         return (void *)ggml_backend_type;
     }

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -57,6 +57,7 @@ using TsavoriteDeviceConfig = tsi::runtime::FPGADeviceConfig;
 #endif
 
 #include <thread>
+#include <atomic>
 #include <vector>
 #include  <mutex>
 #include <condition_variable>
@@ -1530,13 +1531,23 @@ static void tsi_unload_all_blobs() {
 }
 
 static inline void tsi_init_per_txe_state_once() {
+    // This is called unconditionally at the top of every op-dispatch entry
+    // point, so once initialization is done, skip the lock entirely rather
+    // than paying a mutex acquisition on every single dispatch.
+    static std::atomic<bool> initialized{false};
+    if (initialized.load(std::memory_order_acquire)) {
+        return;
+    }
+
     // Guards device_free/packed_args/scalar_*_args lazy allocation below.
-    // Multiple op-dispatch entry points call this unconditionally on every
-    // invocation when multi_thread_enable=true, so concurrent worker threads
-    // can race into the check-then-act allocation (a non-atomic std::vector
-    // mutation) on first use, corrupting packed_args and causing an
-    // intermittent, hard-to-repro crash later inside the SDK.
+    // Concurrent worker threads can race into the check-then-act allocation
+    // (a non-atomic std::vector mutation) on first use, corrupting
+    // packed_args and causing an intermittent, hard-to-repro crash later
+    // inside the SDK.
     std::lock_guard<std::mutex> lock(tsi_init_mutex);
+    if (initialized.load(std::memory_order_relaxed)) {
+        return; // another thread finished initializing while we waited for the lock
+    }
 
     // allocate device_free[]
     if (!device_free) {
@@ -1628,6 +1639,8 @@ static inline void tsi_init_per_txe_state_once() {
             }
         }
     }
+
+    initialized.store(true, std::memory_order_release);
 }
 
 // Centralized TSI runtime initialization - called once globally

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -7759,6 +7759,9 @@ static void * ggml_backend_tsavorite_get_proc_address(ggml_backend_reg_t reg, co
         return (void *)ggml_backend_tsavorite_set_threadpool;
     }
 #endif
+    if (strcmp(name, "ggml_perf_accumulate") == 0) {
+        return (void *)ggml_perf_accumulate;
+    }
     return NULL;
 
     GGML_UNUSED(reg);

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -7786,6 +7786,15 @@ static void * ggml_backend_tsavorite_get_proc_address(ggml_backend_reg_t reg, co
     if (strcmp(name, "ggml_perf_accumulate") == 0) {
         return (void *)ggml_perf_accumulate;
     }
+    if (strcmp(name, "ggml_perf_log_open") == 0) {
+        return (void *)ggml_perf_log_open;
+    }
+    if (strcmp(name, "ggml_perf_write_detailed_csv") == 0) {
+        return (void *)ggml_perf_write_detailed_csv;
+    }
+    if (strcmp(name, "ggml_backend_type") == 0) {
+        return (void *)ggml_backend_type;
+    }
     return NULL;
 
     GGML_UNUSED(reg);

--- a/include/llama.h
+++ b/include/llama.h
@@ -399,6 +399,9 @@ extern "C" {
     // Call once at the end of the program - currently only used for MPI
     LLAMA_API void llama_backend_free(void);
 
+    // Call once at the end of the program to log profile - currently only used for MPI
+    LLAMA_API void llama_backend_log_profile(void);
+
     //optional:
     LLAMA_API void llama_numa_init(enum ggml_numa_strategy numa);
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -399,7 +399,7 @@ extern "C" {
     // Call once at the end of the program - currently only used for MPI
     LLAMA_API void llama_backend_free(void);
 
-    // Call once at the end of the program to log profile - currently only used for MPI
+    // Call once at the end of the program to log profile
     LLAMA_API void llama_backend_log_profile(void);
 
     //optional:

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -961,30 +961,61 @@ int llama_context::encode(const llama_batch & batch_inp) {
 
 #ifdef OLLAMA
 // Ollama statically links this file into its Go binary while the ggml core
-// (where ggml_perf_accumulate is defined) is built into a separately
-// dlopen'd backend shared library, so the symbol is not link-time visible
-// here. Resolve it once, dynamically, through whichever loaded backend
-// exports it (the function itself is backend-agnostic).
+// (where these ggml_perf_*/ggml_backend_type functions are defined) is built
+// into a separately dlopen'd backend shared library, so the symbols are not
+// link-time visible here. Resolve each one once, dynamically, through
+// whichever loaded backend exports it (they're all backend-agnostic).
+static void * llama_resolve_ggml_proc_address(const char * name) {
+    for (size_t i = 0; i < ggml_backend_reg_count(); i++) {
+        ggml_backend_reg_t reg = ggml_backend_reg_get(i);
+        void * addr = ggml_backend_reg_get_proc_address(reg, name);
+        if (addr) {
+            return addr;
+        }
+    }
+    return nullptr;
+}
+
 typedef void (*ggml_perf_accumulate_t)(struct ggml_perf_totals totals[GGML_OP_COUNT], struct ggml_cgraph * cgraph);
+typedef FILE * (*ggml_perf_log_open_t)(const char * filename);
+typedef void (*ggml_perf_write_detailed_csv_t)(struct ggml_cgraph * cgraph, FILE * fp);
+typedef const char * (*ggml_backend_type_t)(enum ggml_compute_backend_type backend);
 
 static void llama_perf_ggml_accumulate(struct ggml_perf_totals totals[GGML_OP_COUNT], struct ggml_cgraph * cgraph) {
-    static ggml_perf_accumulate_t fn = []() -> ggml_perf_accumulate_t {
-        for (size_t i = 0; i < ggml_backend_reg_count(); i++) {
-            ggml_backend_reg_t reg = ggml_backend_reg_get(i);
-            void * addr = ggml_backend_reg_get_proc_address(reg, "ggml_perf_accumulate");
-            if (addr) {
-                return reinterpret_cast<ggml_perf_accumulate_t>(addr);
-            }
-        }
-        return nullptr;
-    }();
+    static auto fn = reinterpret_cast<ggml_perf_accumulate_t>(llama_resolve_ggml_proc_address("ggml_perf_accumulate"));
     if (fn) {
         fn(totals, cgraph);
     }
 }
+
+static FILE * llama_perf_ggml_log_open(const char * filename) {
+    static auto fn = reinterpret_cast<ggml_perf_log_open_t>(llama_resolve_ggml_proc_address("ggml_perf_log_open"));
+    return fn ? fn(filename) : nullptr;
+}
+
+static void llama_perf_ggml_write_detailed_csv(struct ggml_cgraph * cgraph, FILE * fp) {
+    static auto fn = reinterpret_cast<ggml_perf_write_detailed_csv_t>(llama_resolve_ggml_proc_address("ggml_perf_write_detailed_csv"));
+    if (fn) {
+        fn(cgraph, fp);
+    }
+}
+
+static const char * llama_perf_ggml_backend_type(enum ggml_compute_backend_type backend) {
+    static auto fn = reinterpret_cast<ggml_backend_type_t>(llama_resolve_ggml_proc_address("ggml_backend_type"));
+    return fn ? fn(backend) : "UNK";
+}
 #else
 static inline void llama_perf_ggml_accumulate(struct ggml_perf_totals totals[GGML_OP_COUNT], struct ggml_cgraph * cgraph) {
     ggml_perf_accumulate(totals, cgraph);
+}
+static inline FILE * llama_perf_ggml_log_open(const char * filename) {
+    return ggml_perf_log_open(filename);
+}
+static inline void llama_perf_ggml_write_detailed_csv(struct ggml_cgraph * cgraph, FILE * fp) {
+    ggml_perf_write_detailed_csv(cgraph, fp);
+}
+static inline const char * llama_perf_ggml_backend_type(enum ggml_compute_backend_type backend) {
+    return ggml_backend_type(backend);
 }
 #endif
 
@@ -1103,7 +1134,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
     static bool perf_all_shape_written_once = false;
 
     if (!perf_all_shape_fp) {
-        perf_all_shape_fp = ggml_perf_log_open("ggml_perf-all-shape.log");
+        perf_all_shape_fp = llama_perf_ggml_log_open("ggml_perf-all-shape.log");
     }
 #endif /* GGML_PERF_DETAIL */
 
@@ -1136,7 +1167,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
 #elif defined(GGML_PERF_DETAIL)
     if (res) {
         if (!perf_all_shape_written_once && perf_all_shape_fp) {
-            ggml_perf_write_detailed_csv(res->get_gf(), perf_all_shape_fp);
+            llama_perf_ggml_write_detailed_csv(res->get_gf(), perf_all_shape_fp);
             fflush(perf_all_shape_fp);
             perf_all_shape_written_once = true;
         } 
@@ -2866,7 +2897,7 @@ void ggml_perf_print_totals(struct ggml_perf_totals totals[GGML_OP_COUNT]) {
         if (totals[i].runs > 0) {
             for (int b = 0; b < GGML_COMPUTE_BACKEND_COUNT; ++b) {
                 if (totals[i].backend_subtotals[b].runs > 0) {
-                    const char *backend_name = ggml_backend_type((enum ggml_compute_backend_type) b);
+                    const char *backend_name = llama_perf_ggml_backend_type((enum ggml_compute_backend_type) b);
                     char padded_backend[7] = {0}; // 6 chars + null terminator
                     snprintf(padded_backend, sizeof(padded_backend), "%-6s", backend_name);
 
@@ -2888,7 +2919,7 @@ void ggml_perf_print_totals(struct ggml_perf_totals totals[GGML_OP_COUNT]) {
                         const char *backend_name = NULL;
                         for (int b = 0; b < GGML_COMPUTE_BACKEND_COUNT; ++b) {
                             if (totals[i].backend_subtotals[b].runs > 0) {
-                                backend_name = ggml_backend_type((enum ggml_compute_backend_type) b);
+                                backend_name = llama_perf_ggml_backend_type((enum ggml_compute_backend_type) b);
                                 break;
                             }
                         }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1,5 +1,9 @@
 #include "llama-context.h"
 
+#ifdef OLLAMA
+#include "ggml-backend.h"
+#endif
+
 #include "llama-impl.h"
 #include "llama-batch.h"
 #include "llama-io.h"
@@ -955,6 +959,35 @@ int llama_context::encode(const llama_batch & batch_inp) {
     return 0;
 }
 
+#ifdef OLLAMA
+// Ollama statically links this file into its Go binary while the ggml core
+// (where ggml_perf_accumulate is defined) is built into a separately
+// dlopen'd backend shared library, so the symbol is not link-time visible
+// here. Resolve it once, dynamically, through whichever loaded backend
+// exports it (the function itself is backend-agnostic).
+typedef void (*ggml_perf_accumulate_t)(struct ggml_perf_totals totals[GGML_OP_COUNT], struct ggml_cgraph * cgraph);
+
+static void llama_perf_ggml_accumulate(struct ggml_perf_totals totals[GGML_OP_COUNT], struct ggml_cgraph * cgraph) {
+    static ggml_perf_accumulate_t fn = []() -> ggml_perf_accumulate_t {
+        for (size_t i = 0; i < ggml_backend_reg_count(); i++) {
+            ggml_backend_reg_t reg = ggml_backend_reg_get(i);
+            void * addr = ggml_backend_reg_get_proc_address(reg, "ggml_perf_accumulate");
+            if (addr) {
+                return reinterpret_cast<ggml_perf_accumulate_t>(addr);
+            }
+        }
+        return nullptr;
+    }();
+    if (fn) {
+        fn(totals, cgraph);
+    }
+}
+#else
+static inline void llama_perf_ggml_accumulate(struct ggml_perf_totals totals[GGML_OP_COUNT], struct ggml_cgraph * cgraph) {
+    ggml_perf_accumulate(totals, cgraph);
+}
+#endif
+
 int llama_context::decode(const llama_batch & batch_inp) {
     GGML_ASSERT((!batch_inp.token && batch_inp.embd) || (batch_inp.token && !batch_inp.embd)); // NOLINT
 
@@ -1098,7 +1131,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
 #if defined(GGML_PERF) || defined(GGML_PERF_RELEASE)
     if (res) {
-        ggml_perf_accumulate(perf_totals, res->get_gf());
+        llama_perf_ggml_accumulate(perf_totals, res->get_gf());
     }
 #elif defined(GGML_PERF_DETAIL)
     if (res) {
@@ -1107,7 +1140,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
             fflush(perf_all_shape_fp);
             perf_all_shape_written_once = true;
         } 
-        ggml_perf_accumulate(perf_totals, res->get_gf());
+        llama_perf_ggml_accumulate(perf_totals, res->get_gf());
     } 
 #endif /* GML_PERF-related flags */
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -981,27 +981,42 @@ typedef FILE * (*ggml_perf_log_open_t)(const char * filename);
 typedef void (*ggml_perf_write_detailed_csv_t)(struct ggml_cgraph * cgraph, FILE * fp);
 typedef const char * (*ggml_backend_type_t)(enum ggml_compute_backend_type backend);
 
+// Note: each lookup below retries (rather than permanently caching a null
+// result) since backends can register with the reg after the first call.
 static void llama_perf_ggml_accumulate(struct ggml_perf_totals totals[GGML_OP_COUNT], struct ggml_cgraph * cgraph) {
-    static auto fn = reinterpret_cast<ggml_perf_accumulate_t>(llama_resolve_ggml_proc_address("ggml_perf_accumulate"));
+    static ggml_perf_accumulate_t fn = nullptr;
+    if (!fn) {
+        fn = reinterpret_cast<ggml_perf_accumulate_t>(llama_resolve_ggml_proc_address("ggml_perf_accumulate"));
+    }
     if (fn) {
         fn(totals, cgraph);
     }
 }
 
 static FILE * llama_perf_ggml_log_open(const char * filename) {
-    static auto fn = reinterpret_cast<ggml_perf_log_open_t>(llama_resolve_ggml_proc_address("ggml_perf_log_open"));
+    static ggml_perf_log_open_t fn = nullptr;
+    if (!fn) {
+        fn = reinterpret_cast<ggml_perf_log_open_t>(llama_resolve_ggml_proc_address("ggml_perf_log_open"));
+    }
     return fn ? fn(filename) : nullptr;
 }
 
 static void llama_perf_ggml_write_detailed_csv(struct ggml_cgraph * cgraph, FILE * fp) {
-    static auto fn = reinterpret_cast<ggml_perf_write_detailed_csv_t>(llama_resolve_ggml_proc_address("ggml_perf_write_detailed_csv"));
+    static ggml_perf_write_detailed_csv_t fn = nullptr;
+    if (!fn) {
+        fn = reinterpret_cast<ggml_perf_write_detailed_csv_t>(
+            llama_resolve_ggml_proc_address("ggml_perf_write_detailed_csv"));
+    }
     if (fn) {
         fn(cgraph, fp);
     }
 }
 
 static const char * llama_perf_ggml_backend_type(enum ggml_compute_backend_type backend) {
-    static auto fn = reinterpret_cast<ggml_backend_type_t>(llama_resolve_ggml_proc_address("ggml_backend_type"));
+    static ggml_backend_type_t fn = nullptr;
+    if (!fn) {
+        fn = reinterpret_cast<ggml_backend_type_t>(llama_resolve_ggml_proc_address("ggml_backend_type"));
+    }
     return fn ? fn(backend) : "UNK";
 }
 #else

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -11,6 +11,7 @@
 #include "llama-mmap.h"
 #include "llama-model.h"
 
+#include <atomic>
 #include <cinttypes>
 #include <cstring>
 #include <limits>
@@ -983,10 +984,16 @@ typedef const char * (*ggml_backend_type_t)(enum ggml_compute_backend_type backe
 
 // Note: each lookup below retries (rather than permanently caching a null
 // result) since backends can register with the reg after the first call.
+// The cache itself is an atomic (not a plain static pointer) because
+// decode() can run concurrently for these -- an unsynchronized read/write
+// of a non-atomic function-local static from multiple threads is a data
+// race even though every writer would store the same resolved value.
 static void llama_perf_ggml_accumulate(struct ggml_perf_totals totals[GGML_OP_COUNT], struct ggml_cgraph * cgraph) {
-    static ggml_perf_accumulate_t fn = nullptr;
+    static std::atomic<ggml_perf_accumulate_t> cached_fn{nullptr};
+    ggml_perf_accumulate_t fn = cached_fn.load(std::memory_order_relaxed);
     if (!fn) {
         fn = reinterpret_cast<ggml_perf_accumulate_t>(llama_resolve_ggml_proc_address("ggml_perf_accumulate"));
+        cached_fn.store(fn, std::memory_order_relaxed);
     }
     if (fn) {
         fn(totals, cgraph);
@@ -994,18 +1001,22 @@ static void llama_perf_ggml_accumulate(struct ggml_perf_totals totals[GGML_OP_CO
 }
 
 static FILE * llama_perf_ggml_log_open(const char * filename) {
-    static ggml_perf_log_open_t fn = nullptr;
+    static std::atomic<ggml_perf_log_open_t> cached_fn{nullptr};
+    ggml_perf_log_open_t fn = cached_fn.load(std::memory_order_relaxed);
     if (!fn) {
         fn = reinterpret_cast<ggml_perf_log_open_t>(llama_resolve_ggml_proc_address("ggml_perf_log_open"));
+        cached_fn.store(fn, std::memory_order_relaxed);
     }
     return fn ? fn(filename) : nullptr;
 }
 
 static void llama_perf_ggml_write_detailed_csv(struct ggml_cgraph * cgraph, FILE * fp) {
-    static ggml_perf_write_detailed_csv_t fn = nullptr;
+    static std::atomic<ggml_perf_write_detailed_csv_t> cached_fn{nullptr};
+    ggml_perf_write_detailed_csv_t fn = cached_fn.load(std::memory_order_relaxed);
     if (!fn) {
         fn = reinterpret_cast<ggml_perf_write_detailed_csv_t>(
             llama_resolve_ggml_proc_address("ggml_perf_write_detailed_csv"));
+        cached_fn.store(fn, std::memory_order_relaxed);
     }
     if (fn) {
         fn(cgraph, fp);
@@ -1013,9 +1024,11 @@ static void llama_perf_ggml_write_detailed_csv(struct ggml_cgraph * cgraph, FILE
 }
 
 static const char * llama_perf_ggml_backend_type(enum ggml_compute_backend_type backend) {
-    static ggml_backend_type_t fn = nullptr;
+    static std::atomic<ggml_backend_type_t> cached_fn{nullptr};
+    ggml_backend_type_t fn = cached_fn.load(std::memory_order_relaxed);
     if (!fn) {
         fn = reinterpret_cast<ggml_backend_type_t>(llama_resolve_ggml_proc_address("ggml_backend_type"));
+        cached_fn.store(fn, std::memory_order_relaxed);
     }
     return fn ? fn(backend) : "UNK";
 }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -90,7 +90,13 @@ void llama_numa_init(enum ggml_numa_strategy numa) {
     }
 }
 
+extern "C"
+void llama_backend_log_profile(void) {
+    ggml_backend_log_profile_info(ggml_backend_init_by_name("TSAVORITE", NULL));
+}
+
 void llama_backend_free(void) {
+    ggml_backend_free(ggml_backend_init_by_name("TSAVORITE", NULL));
     ggml_quantize_free();
 }
 

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -96,6 +96,12 @@ void llama_numa_init(enum ggml_numa_strategy numa) {
 // instance created for profiling/shutdown here instead of creating (and,
 // for the profile path, leaking) a new one on every call.
 static ggml_backend_t g_tsavorite_profile_backend = nullptr;
+// TSAVORITE's .profile hook (tsi_log_profile_info) doesn't just print --
+// it also finalizes the runtime (unloads blobs, frees device state, calls
+// tsi_finalize()). Once that's run, g_tsavorite_profile_backend wraps an
+// already-torn-down context, so ggml_backend_free()'s normal teardown path
+// must not run on it again afterward.
+static bool g_tsavorite_profile_backend_finalized = false;
 
 static ggml_backend_t llama_tsavorite_backend_for_profile(void) {
     if (!g_tsavorite_profile_backend) {
@@ -107,10 +113,15 @@ static ggml_backend_t llama_tsavorite_backend_for_profile(void) {
 extern "C"
 void llama_backend_log_profile(void) {
     ggml_backend_log_profile_info(llama_tsavorite_backend_for_profile());
+    g_tsavorite_profile_backend_finalized = true;
 }
 
 void llama_backend_free(void) {
-    ggml_backend_free(llama_tsavorite_backend_for_profile());
+    if (g_tsavorite_profile_backend && !g_tsavorite_profile_backend_finalized) {
+        ggml_backend_free(g_tsavorite_profile_backend);
+    }
+    // else: already finalized by the profile hook, or never created --
+    // nothing left to safely tear down, and the process is exiting anyway.
     g_tsavorite_profile_backend = nullptr;
     ggml_quantize_free();
 }

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -90,13 +90,28 @@ void llama_numa_init(enum ggml_numa_strategy numa) {
     }
 }
 
+// ggml_backend_init_by_name("TSAVORITE", ...) allocates a fresh backend
+// instance (and runtime context) on every call -- it also resets the
+// device's op-run stats and re-acquires the device. Cache the single
+// instance created for profiling/shutdown here instead of creating (and,
+// for the profile path, leaking) a new one on every call.
+static ggml_backend_t g_tsavorite_profile_backend = nullptr;
+
+static ggml_backend_t llama_tsavorite_backend_for_profile(void) {
+    if (!g_tsavorite_profile_backend) {
+        g_tsavorite_profile_backend = ggml_backend_init_by_name("TSAVORITE", NULL);
+    }
+    return g_tsavorite_profile_backend;
+}
+
 extern "C"
 void llama_backend_log_profile(void) {
-    ggml_backend_log_profile_info(ggml_backend_init_by_name("TSAVORITE", NULL));
+    ggml_backend_log_profile_info(llama_tsavorite_backend_for_profile());
 }
 
 void llama_backend_free(void) {
-    ggml_backend_free(ggml_backend_init_by_name("TSAVORITE", NULL));
+    ggml_backend_free(llama_tsavorite_backend_for_profile());
+    g_tsavorite_profile_backend = nullptr;
     ggml_quantize_free();
 }
 


### PR DESCRIPTION
## Summary

Ollama statically links `llama-context.cpp` into its Go binary via cgo, while the ggml core (`ggml.c`) and the Tsavorite backend are built into separately `dlopen`'d shared libraries (`libggml-base.so`, `libggml-tsavorite.so`). Several symbols the "GGML Perf Summary" table depends on are defined in `ggml.c` and were link-time unreachable from `llama-context.cpp` in that configuration:

- `ggml_perf_accumulate` — undefined reference at link time (table never printed at all).
- `ggml_perf_log_open`, `ggml_perf_write_detailed_csv`, `ggml_backend_type` — same issue, only surfaced once the detailed (`Target`/`TSI_KERNEL-RUN` column) table variant was exercised.

Also, `ggml-tsavorite.cpp`'s existing `#ifdef OLLAMA` backend struct literal already references `.profile`, `.graph_reserve`, `.buffer_size`, `.reset`, but `ggml-backend-impl.h` didn't yet define those `ggml_backend_i` fields, and `ggml_backend_log_profile_info()` (declared in `ggml-backend.h`) had no definition — both needed for that file to even compile under `-DOLLAMA`.

## Changes

- `include/llama.h`, `src/llama.cpp`: add `llama_backend_log_profile()`; restore the `ggml_backend_free(TSAVORITE)` call in `llama_backend_free()`.
- `ggml/include/ggml-backend.h`, `ggml/src/ggml-backend.cpp`: add `ggml_backend_log_profile_info()`.
- `ggml/src/ggml-backend-impl.h`: add `graph_reserve`, `buffer_size`, `reset`, `profile` fields to `struct ggml_backend_i`.
- `ggml/src/ggml-tsavorite/ggml-tsavorite.cpp`: expose `ggml_perf_accumulate`, `ggml_perf_log_open`, `ggml_perf_write_detailed_csv`, `ggml_backend_type` via `ggml_backend_tsavorite_get_proc_address()`.
- `src/llama-context.cpp`: add a shared `llama_resolve_ggml_proc_address()` helper plus `#ifdef OLLAMA`-gated wrappers (`llama_perf_ggml_accumulate`, `llama_perf_ggml_log_open`, `llama_perf_ggml_write_detailed_csv`, `llama_perf_ggml_backend_type`) that resolve these symbols dynamically at runtime through the backend registry. Native (non-`OLLAMA`) builds keep the original direct calls, unchanged.

Scope is intentionally llama.cpp-only. Ollama picks this up via a separate `Makefile.sync` commit-id bump once this merges -- no ollama-side changes in this PR.

Also included (found while investigating a separate, still-open `multi_thread_enable:true` intermittent crash in ollama, unrelated to the perf-symbol work above but touching the same file):
- Fix a real data race in `tsi_init_per_txe_state_once()`: unsynchronized `std::vector` mutation (`packed_args`, `device_free`) on first use from concurrent callers.
- Harden `call_triton_matmul_full_packed()`: its static descriptor buffers were populated with no synchronization before reaching the `tsi_pack_mutex`-protected dispatch call.

These are real, standalone concurrency fixes, but do not fully resolve the intermittent `multi_thread_enable:true` SIGSEGV in the Triton MAT_MUL dispatch path (still under investigation, tracked separately).

## Validation

Tested in ollama (posix build, `SDK_VERSION=0.4.24`), via a temporary local sync pointed at this branch:

- Native llama.cpp posix debug build compiles and links cleanly with all changes (sanity check independent of ollama).
- Ollama posix debug build (`GGML_PERF_DETAIL`) — full detail table prints correctly, matching llama.cpp's own `tsi-pkg-build.sh` dev output format:
  ```
  === GGML Perf Summary ===
    Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
    ADD              OPU          480        30496556            677744           1411.97
    MUL              OPU          490        30847744            653504           1333.68
    RMS_NORM         OPU           10          970154             14996           1499.60
    MUL_MAT          OPU          165        51087589          63340037         383879.01
    CONT             OPU          240        15149184             16538             68.91
    GET_ROWS         OPU           30         2201664              2113             70.43
    SOFT_MAX         OPU          240        15096192             27038            112.66
    GLU              OPU          240        15274774            696186           2900.78
  ```
  Verified via `qwen:0.5b`, HTTP 200, no crash.
- Ollama posix release build (`GGML_PERF_RELEASE`) — plain customer-safe table prints correctly, no CPU/OPU breakdown:
  ```
  === GGML Perf Summary ===
    Op                   Runs        Total us            Avg us
    ADD                   144          287062           1993.49
    MUL                   147          558433           3798.86
    RMS_NORM                3           37089          12363.00
    MUL_MAT               165        61081193         370189.05
    CONT                   72           16335            226.88
    GET_ROWS                9            2070            230.00
    SOFT_MAX               72           24200            336.11
    GLU                    72          545814           7580.75
  ```
  Verified via `qwen:0.5b`, HTTP 200, no crash.
- Both tested with `multi_thread_enable:false` (the known-stable path); `multi_thread_enable:true` remains separately tracked as an open, intermittent issue unrelated to this fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores GGML perf-summary tables in `ollama` split-binary builds and adds a backend profile hook. Previously `llama-context.cpp` could not reach `ggml_perf_*`/`ggml_backend_type` and printed no tables; now runtime resolution restores detailed and release tables, and exports for detailed CSV are correctly guarded to prevent release build link errors. Addresses FIR-2216.

- Dynamic perf symbols for `ollama`: `ggml-tsavorite.cpp` exposes `ggml_perf_accumulate` and `ggml_backend_type` in all perf modes, and exposes `ggml_perf_log_open`/`ggml_perf_write_detailed_csv` only under `GGML_PERF_DETAIL`; `src/llama-context.cpp` adds OLLAMA-only wrappers that resolve these at runtime with atomic caches and retry after late backend registration; native `llama.cpp` builds keep direct calls.
- Backend profiling: adds `ggml_backend_log_profile_info()` and optional `graph_reserve`, `buffer_size`, `reset`, `profile` in `struct ggml_backend_i`. Introduces `llama_backend_log_profile()` and caches a single `TSAVORITE` backend; tracks when the profile hook finalizes the runtime to avoid double teardown in `llama_backend_free()`.
- Concurrency hardening in `ggml-tsavorite`: serializes first-use lazy init in `tsi_init_per_txe_state_once()` via an atomic flag plus mutex; serializes `call_triton_matmul_full_packed()` descriptor populate+dispatch; on all teardown paths, clears `packed_args` and all `scalar_*` per‑TXE vectors and resets the init flag to force clean reallocation on the next init.
- Rollout: no migration required; `ollama` will pick this via Makefile sync.

<sup>Written for commit bcb7c7efe16d643f41b36f0905700cc97a3fc8b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/llama.cpp/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

