### PR TITLE
@FIR-2239 - llama-context: fix perf_reset() to also clear GGML per-op totals

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -6261,11 +6261,6 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
     src1 = node->src[1];
     min_num_of_elem = 0;
     max_num_of_elem = 0;
-    // Some op types with no kernel/blob (GET_ROWS, SOFT_MAX, etc.) are handled
-    // by calling ggml's own CPU compute function directly further below,
-    // rather than launching a Tsavorite kernel. Snapshot the kernel-run count
-    // here so the perf Target label below can tell the two cases apart.
-    const int64_t tsi_kernel_runs_before_node = node->tsi_kernel_runs;
     if(node->type == GGML_TYPE_F32 && src0->type == GGML_TYPE_F32 && (!src1 || src1->type == GGML_TYPE_F32))
 	    kernel_sub_type = DATA_TYPE_F32_INDEX;
     /*
@@ -6876,15 +6871,7 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
 #if defined(GGML_PERF) || defined(GGML_PERF_RELEASE) || defined(GGML_PERF_DETAIL)
     int64_t t_end = ggml_time_us();
     node->perf_runs++;
-    // Only report this node as having run on OPU if a kernel was actually
-    // launched for it this call. Op types with no kernel (GET_ROWS, SOFT_MAX,
-    // etc.) reach this point too, having been computed via a direct call to
-    // ggml's own CPU function further up -- without this check they were
-    // unconditionally marked TSAVORITE/OPU despite zero kernel runs, which is
-    // exactly what the Target/TSI_KERNEL-RUN columns are meant to make visible.
-    node->ggml_compute_backend = (node->tsi_kernel_runs > tsi_kernel_runs_before_node)
-        ? GGML_COMPUTE_BACKEND_TSAVORITE
-        : GGML_COMPUTE_BACKEND_CPU;
+    node->ggml_compute_backend = GGML_COMPUTE_BACKEND_TSAVORITE;
     if (t_end >= t_start) {
         node->perf_time_us += (t_end - t_start);
     } else {

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -6261,6 +6261,11 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
     src1 = node->src[1];
     min_num_of_elem = 0;
     max_num_of_elem = 0;
+    // Some op types with no kernel/blob (GET_ROWS, SOFT_MAX, etc.) are handled
+    // by calling ggml's own CPU compute function directly further below,
+    // rather than launching a Tsavorite kernel. Snapshot the kernel-run count
+    // here so the perf Target label below can tell the two cases apart.
+    const int64_t tsi_kernel_runs_before_node = node->tsi_kernel_runs;
     if(node->type == GGML_TYPE_F32 && src0->type == GGML_TYPE_F32 && (!src1 || src1->type == GGML_TYPE_F32))
 	    kernel_sub_type = DATA_TYPE_F32_INDEX;
     /*
@@ -6871,7 +6876,15 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
 #if defined(GGML_PERF) || defined(GGML_PERF_RELEASE) || defined(GGML_PERF_DETAIL)
     int64_t t_end = ggml_time_us();
     node->perf_runs++;
-    node->ggml_compute_backend = GGML_COMPUTE_BACKEND_TSAVORITE;
+    // Only report this node as having run on OPU if a kernel was actually
+    // launched for it this call. Op types with no kernel (GET_ROWS, SOFT_MAX,
+    // etc.) reach this point too, having been computed via a direct call to
+    // ggml's own CPU function further up -- without this check they were
+    // unconditionally marked TSAVORITE/OPU despite zero kernel runs, which is
+    // exactly what the Target/TSI_KERNEL-RUN columns are meant to make visible.
+    node->ggml_compute_backend = (node->tsi_kernel_runs > tsi_kernel_runs_before_node)
+        ? GGML_COMPUTE_BACKEND_TSAVORITE
+        : GGML_COMPUTE_BACKEND_CPU;
     if (t_end >= t_start) {
         node->perf_time_us += (t_end - t_start);
     } else {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2142,6 +2142,16 @@ void llama_context::perf_reset() {
     t_eval_us   = n_eval = 0;
     t_p_eval_us = n_p_eval = 0;
     n_reused    = 0;
+#if defined(GGML_PERF) || defined(GGML_PERF_RELEASE) || defined(GGML_PERF_DETAIL)
+    // perf_totals was added to llama_context after this function was written
+    // and never got wired in here, so callers resetting perf state via this
+    // function (e.g. ollama's per-completion PerfPrint/reset) left the GGML
+    // per-op totals accumulating across every reset, unlike every other
+    // field this function resets.
+    for (auto & t : perf_totals) {
+        t = {};
+    }
+#endif /* GGML_PERF-related flags */
 }
 
 std::map<ggml_backend_buffer_type_t, llama_memory_breakdown_data> llama_context::memory_breakdown() const {


### PR DESCRIPTION
## Summary

`llama_context::perf_reset()` resets every other perf field it owns (t_eval_us, n_eval,
t_p_eval_us, n_p_eval, n_reused) but never cleared `perf_totals` (the GGML per-op totals
array) -- there is literally a "// add this to llama_context" comment next to its declaration
in llama-context.h, suggesting it was added later and never wired in.

This is a real llama.cpp bug, not an ollama-only concern: `common_init_from_params()`
(common/common.cpp:1086) already calls `llama_perf_context_reset()` itself, as part of the
standard model warmup path used by llama-cli and other tools by default (a dummy warmup batch
runs first, then perf_reset() is called specifically to wipe the warmup's own stats before the
"real" run starts). Without this fix, that call was a no-op for perf_totals, so any llama.cpp
tool using the default warmup path could have its first real run's GGML per-op table
contaminated with leftover warmup-pass stats.

Ollama additionally calls the same (buggy) reset once per completion, intending each printed
report to reflect just that completion, not a running total since server start -- that
specific symptom is what surfaced this bug. Ollama-side companion PR:
https://github.com/tsisw/ollama/pull/74 (FIR-2238). Ollama picks this fix up through the
normal Makefile.sync FETCH_HEAD sync once this merges; no ollama code changes needed for the
fix itself.

## Fix

perf_reset() now also clears perf_totals.

## Validation

**Native posix build + llama-cli**, direct against qwen 0.5b's GGUF, no ollama involved,
`multi_thread_enable:false`, default warmup enabled (i.e. this run exercises the exact
`common_init_from_params()` warmup-then-`perf_reset()` path this fix addresses):

```
> Why is the sky blue?
The sky blue is due to the scattering of light by the atmosphere. When light is scattered
from the Earth, the angle of incidence changes. This causes the blue color of the sky to
appear.

llama_perf_sampler_print:    sampling time =      27.81 ms /    54 runs   (    0.51 ms per token,  1942.03 tokens per second)
llama_perf_context_print:        load time =  264758.61 ms
llama_perf_context_print: prompt eval time =  264005.07 ms /    14 tokens (18857.50 ms per token,     0.05 tokens per second)
llama_perf_context_print:        eval time =   34744.82 ms /    39 runs   (  890.89 ms per token,     1.12 tokens per second)
llama_perf_context_print:       total time =  298855.93 ms /    53 tokens

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              CPU        11003               0             50524              4.59
  ADD              OPU         1920            2518           3223963           1679.15
  MUL              OPU         1960            2571           2828118           1442.92
  RMS_NORM         OPU         1960            1960           2334139           1190.89
  MUL_MAT          CPU        33997               0          61170653           1799.30
  MUL_MAT          OPU          165             165         262296766        1589677.37
  CONT             OPU         1920               0           1329956            692.69
  RESHAPE          CPU         9965               0              2575              0.26
  VIEW             CPU         9798               0              1217              0.12
  VIEW             OPU         1920               0               503              0.26
  PERMUTE          CPU         6674               0              1452              0.22
  PERMUTE          OPU         1920               0               292              0.15
  TRANSPOSE        CPU         3358               0               480              0.14
  GET_ROWS         OPU          120               0               572              4.77
  SET_ROWS         CPU         7031               0              7602              1.08
  SOFT_MAX         OPU          960               0            181843            189.42
  ROPE             CPU         7443               0             41029              5.51
  GLU              OPU          960            1259           3838703           3998.65
```

`MUL_MAT OPU Runs=165` matches the same baseline seen in every other clean single-run test this
session, not double it (330) -- if the fix weren't working, warmup's own dummy-batch stats
would have doubled every count here, the same way the original bug doubled a second ollama
request's counts before this fix landed. This confirms the warmup pass's stats were correctly
cleared before the real run's table was accumulated.

**Ollama round-trip** (fresh clone, Makefile.sync pointed at this branch, debug build, posix,
qwen:0.5b, multi_thread_enable:false): two sequential completions against the same server show
independent per-request numbers (e.g. ADD Runs: 2016 then 144, not 2016 then 2160), not the
second including the first's cumulative stats.

## Note on history

An earlier version of this PR also included a change to ggml-tsavorite.cpp's OPU/CPU Target
labeling, believing ops with 0 kernel runs showing "OPU" was a mislabeling bug. Per review
(Ashish): Target and TSI_KERNEL-RUN are intentionally independent -- Target reports which
backend claimed/dispatched an op, TSI_KERNEL-RUN separately reports how many of those dispatched
ops actually launched a real TXE kernel vs. were computed via a direct CPU-equivalent call
within the same backend. An op showing OPU with 0 kernel runs is not a contradiction, it's the
intended signal that the Tsavorite backend handled it without needing hardware. That change has
been reverted; this PR now contains only the perf_reset() fix.
