### PR TITLE
ggml-tsavorite: don't report OPU Target for ops with no kernel invocation

### DIFF
--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -6261,6 +6261,11 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
     src1 = node->src[1];
     min_num_of_elem = 0;
     max_num_of_elem = 0;
+    // Some op types with no kernel/blob (GET_ROWS, SOFT_MAX, etc.) are handled
+    // by calling ggml's own CPU compute function directly further below,
+    // rather than launching a Tsavorite kernel. Snapshot the kernel-run count
+    // here so the perf Target label below can tell the two cases apart.
+    const int64_t tsi_kernel_runs_before_node = node->tsi_kernel_runs;
     if(node->type == GGML_TYPE_F32 && src0->type == GGML_TYPE_F32 && (!src1 || src1->type == GGML_TYPE_F32))
 	    kernel_sub_type = DATA_TYPE_F32_INDEX;
     /*
@@ -6871,7 +6876,15 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
 #if defined(GGML_PERF) || defined(GGML_PERF_RELEASE) || defined(GGML_PERF_DETAIL)
     int64_t t_end = ggml_time_us();
     node->perf_runs++;
-    node->ggml_compute_backend = GGML_COMPUTE_BACKEND_TSAVORITE;
+    // Only report this node as having run on OPU if a kernel was actually
+    // launched for it this call. Op types with no kernel (GET_ROWS, SOFT_MAX,
+    // etc.) reach this point too, having been computed via a direct call to
+    // ggml's own CPU function further up -- without this check they were
+    // unconditionally marked TSAVORITE/OPU despite zero kernel runs, which is
+    // exactly what the Target/TSI_KERNEL-RUN columns are meant to make visible.
+    node->ggml_compute_backend = (node->tsi_kernel_runs > tsi_kernel_runs_before_node)
+        ? GGML_COMPUTE_BACKEND_TSAVORITE
+        : GGML_COMPUTE_BACKEND_CPU;
     if (t_end >= t_start) {
         node->perf_time_us += (t_end - t_start);
     } else {


### PR DESCRIPTION
## Summary

Found while reviewing GGML Perf Summary output enabled by FIR-2216/PR #158. Some ops with
TSI_KERNEL-RUN == 0 kernel launches were still labeled "OPU" in the Target column, which reads
as if they ran on Tsavorite hardware when they were actually computed via a direct call to
ggml's own CPU compute function.

Example (before this fix):
```
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  SET_ROWS         CPU          728               0              4799              6.59
  GET_ROWS         OPU           15               0               369             24.60
  SOFT_MAX         OPU          110               0             78947            717.70
  ROPE             CPU          716               0             10128             14.15
```
SET_ROWS and ROPE correctly showed CPU, but GET_ROWS and SOFT_MAX -- going through the exact
same "no blob, call the plain CPU compute function directly" pattern in the dispatch switch --
showed OPU instead, despite also having 0 kernel runs.

## Root cause

The per-node compute loop unconditionally marked every node it processed as
`GGML_COMPUTE_BACKEND_TSAVORITE` at the end of each iteration, regardless of whether a kernel
actually launched or the node was computed via the CPU-fallback path
(`ggml_compute_forward_get_rows`/`ggml_compute_forward_soft_max`/etc., called directly a few
lines earlier for op types with no kernel implementation).

`ggml_tsavorite_internal_supports_op()` accepts these op types identically (unconditional
`return true` for GET_ROWS, SOFT_MAX, SET_ROWS, ROPE, etc.), so the inconsistency in the example
above isn't explained there -- it's specifically the backend-label assignment at the end of the
compute loop.

## Fix

Snapshot `tsi_kernel_runs` at the start of each node's processing and only report
`GGML_COMPUTE_BACKEND_TSAVORITE` if it actually increased during this node's compute; otherwise
report `GGML_COMPUTE_BACKEND_CPU`.

## Validation

Verified via ollama (Makefile.sync temporarily pointed at this branch, merged with the
FIR-2238 perf_reset fix for a combined test): GET_ROWS, SOFT_MAX, and CONT (also affected, same
pattern) now correctly show CPU instead of OPU. ADD/MUL/RMS_NORM/MUL_MAT/GLU -- which do launch
real kernels -- are unaffected and still correctly show OPU. Confirmed the underlying
TSI_KERNEL-RUN magnitude for the reclassified ops is unchanged before/after this fix (this fix
only changes which Target bucket the existing numbers land in, not the numbers themselves).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mislabeling in GGML Perf Summary: nodes with zero TSI_KERNEL-RUN are no longer reported as OPU. Old behavior marked all processed nodes as OPU; new behavior reports OPU only if a kernel launched, otherwise CPU. This changes reporting only.

- Captures `tsi_kernel_runs` at node start and sets `node->ggml_compute_backend` to `TSAVORITE` only if it increases; otherwise sets `CPU`.
- Applies to ops without kernels (e.g., GET_ROWS, SOFT_MAX, CONT); kernel-backed ops remain OPU.
- No change to execution path, run counts, or timings; only the Target classification is corrected.

<sup>Written for commit 09600238c6598879b96b7ee49ea41200deb594cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/llama.cpp/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

