### PR TITLE
@FIR-2243 - llama.cpp: fix stale tsi_kernel_runs carryover and per-thread perf-counter multiplication in GGML accounting

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2890,7 +2890,13 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
         struct ggml_tensor * node = cgraph->nodes[node_n];
 
 #if defined(GGML_PERF) || defined(GGML_PERF_RELEASE) || defined(GGML_PERF_DETAIL)
-        int64_t t_start = ggml_time_us();
+        // Only the leader reads this (see the ith==0 guard below), so only the
+        // leader needs to pay for the ggml_time_us() call -- every other
+        // worker thread would otherwise read a timestamp it never uses.
+        int64_t t_start = 0;
+        if (state->ith == 0) {
+            t_start = ggml_time_us();
+        }
 #endif /* GGML_PERF-related flags */
         ggml_compute_forward(&params, node);
 

--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2895,13 +2895,21 @@ static thread_ret_t ggml_graph_compute_thread(void * data) {
         ggml_compute_forward(&params, node);
 
 #if defined(GGML_PERF) || defined(GGML_PERF_RELEASE) || defined(GGML_PERF_DETAIL)
-        int64_t t_end = ggml_time_us();
-        node->perf_runs++;
-        if (t_end >= t_start) {
-            node->perf_time_us += (t_end - t_start);
-        } else {
-            // Handle wraparound by assuming timer rolls over at max int64_t value
-            node->perf_time_us += (INT64_MAX - t_start + t_end + 1);
+        // Every thread in the pool runs this same loop over cgraph->nodes,
+        // each processing its own slice of a node's data (ggml_compute_forward
+        // splits work across threads internally) -- only the leader (ith==0)
+        // should count the node as "one run", otherwise perf_runs/perf_time_us
+        // get multiplied by the thread count instead of reflecting real
+        // per-node activity.
+        if (state->ith == 0) {
+            int64_t t_end = ggml_time_us();
+            node->perf_runs++;
+            if (t_end >= t_start) {
+                node->perf_time_us += (t_end - t_start);
+            } else {
+                // Handle wraparound by assuming timer rolls over at max int64_t value
+                node->perf_time_us += (INT64_MAX - t_start + t_end + 1);
+            }
         }
 #endif /* GGML_PERF-related flags */
         if (state->ith == 0 && cplan->abort_callback &&

--- a/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
+++ b/ggml/src/ggml-tsavorite/ggml-tsavorite.cpp
@@ -6257,6 +6257,14 @@ std::lock_guard<std::mutex> _lk(g_tsavorite_compute_mutex);
     int64_t t_start = ggml_time_us();
 #endif /* GGML_PERF-related flags */
     node = cgraph->nodes[i];
+#if defined(GGML_PERF) || defined(GGML_PERF_RELEASE) || defined(GGML_PERF_DETAIL)
+    // tsi_kernel_runs must reflect only this pass's real kernel launches (if
+    // any of the increment sites below fire for this node). Clear it before
+    // dispatch so a node whose kernel_type never launches a real TXE blob
+    // (e.g. CONT/SOFT_MAX/GET_ROWS taking the CPU-fallback path) reports 0
+    // instead of carrying over an unrelated value.
+    node->tsi_kernel_runs = 0;
+#endif /* GGML_PERF-related flags */
     src0 = node->src[0];
     src1 = node->src[1];
     min_num_of_elem = 0;


### PR DESCRIPTION
## Summary

Two independent bugs in the GGML Perf Summary accounting path, found while chasing why ollama's perf table didn't match llama-cli's for the same model/prompt.

### 1. `tsi_kernel_runs` carries over across dispatch passes (`ggml-tsavorite.cpp`)

`node->tsi_kernel_runs` is only incremented by dispatch paths that launch a real TXE kernel; CPU-fallback ops (CONT/SOFT_MAX/GET_ROWS, etc.) never touch it. `ggml_perf_accumulate()` resets it to 0, but only *after* a successful read -- and on some callers (ollama's dlsym-resolved accumulate call, see companion ollama PR) that read can be skipped. When skipped, a value left by an earlier TXE-launching pass on the same reused tensor struct gets reported against a later pass whose op never launched a kernel at all.

**Fix**: reset `tsi_kernel_runs = 0` at the top of every dispatch pass, before that pass decides whether to touch it, so each read reflects only that pass's own activity regardless of whether the prior accumulate cycle ran.

### 2. `perf_runs`/`perf_time_us` multiplied by thread count (`ggml-cpu.c`)

`ggml_graph_compute_thread`'s per-node loop runs once per worker thread (each computes its own data slice via `ggml_compute_forward`), but the `perf_runs++`/`perf_time_us` accounting was unguarded -- every CPU-dispatched node's reported Runs/Total us was multiplied by the thread count instead of counted once.

**Fix**: guard with `if (state->ith == 0)`, matching the existing leader-only pattern already used for `cplan->abort_callback` right below it.

Both bugs affect any `GGML_PERF`/`GGML_PERF_RELEASE`/`GGML_PERF_DETAIL` consumer equally (native llama-cli and ollama share this code); harder to notice under llama-cli's single-shot, fixed-thread-count usage.

## Testing

Fresh clone of this repo, both commits cherry-picked onto master (`d0d09fc0f`), posix debug build, `--device tSavorite`. 3 runs across 2 models, no crashes, no garbage values.

### tinyllama-5M-para, run 1 (`-p "My cat's name is" --n-predict 2`)
```
My cat's name is Tim

=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU           32             116            120977           3780.53
  MUL              OPU           34             124            140990           4146.76
  RMS_NORM         OPU           34              34             40734           1198.06
  MUL_MAT          CPU          117               0             38856            332.10
  MUL_MAT          OPU           29              29            854383          29461.48
  CONT             OPU           32               0              4759            148.72
  RESHAPE          CPU           48               0                16              0.33
  VIEW             CPU           48               0                12              0.25
  VIEW             OPU           32               0                12              0.38
  PERMUTE          CPU           32               0                13              0.41
  PERMUTE          OPU           32               0                 3              0.09
  TRANSPOSE        CPU           16               0                 3              0.19
  GET_ROWS         OPU            6               0              1877            312.83
  SET_ROWS         CPU           32               0                54              1.69
  SOFT_MAX         OPU           16               0             10081            630.06
  ROPE             CPU           32               0               124              3.88
  GLU              OPU           16              58            108935           6808.44
```

### tinyllama-5M-para, run 2 (`-p "The capital of France is" --n-predict 3`)
```
=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              OPU           48             118             63334           1319.46
  MUL              OPU           51             126            150780           2956.47
  RMS_NORM         OPU           51              51             82787           1623.27
  MUL_MAT          CPU          190               0             54090            284.68
  MUL_MAT          OPU           29              29            774301          26700.03
  CONT             OPU           48               0              2583             53.81
  RESHAPE          CPU           72               0                15              0.21
  VIEW             CPU           72               0                11              0.15
  VIEW             OPU           48               0                12              0.25
  PERMUTE          CPU           48               0                10              0.21
  PERMUTE          OPU           48               0                10              0.21
  TRANSPOSE        CPU           24               0                 8              0.33
  GET_ROWS         OPU            9               0                32              3.56
  SET_ROWS         CPU           48               0                62              1.29
  SOFT_MAX         OPU           24               0              9691            403.79
  ROPE             CPU           48               0               136              2.83
  GLU              OPU           24              59             54173           2257.21
```

### qwen2-0.5b-instruct, run 1 (`-p "My cat's name is" --n-predict 3`)
```
=== GGML Perf Summary ===
  Op               Target      Runs  TSI_KERNEL-RUN          Total us            Avg us
  ADD              CPU          216               0              2592             12.00
  ADD              OPU          144             328             79958            555.26
  MUL              OPU          147             335            228002           1551.03
  RMS_NORM         OPU          147             147            164944           1122.07
  MUL_MAT          CPU          486               0           1046864           2154.04
  MUL_MAT          OPU          165             165         313681025        1901097.12
  CONT             OPU          144               0             14190             98.54
  RESHAPE          CPU          216               0                83              0.38
  VIEW             CPU          216               0                35              0.16
  VIEW             OPU          144               0                43              0.30
  PERMUTE          CPU          144               0                27              0.19
  PERMUTE          OPU          144               0                23              0.16
  TRANSPOSE        CPU           72               0                18              0.25
  GET_ROWS         OPU            9               0                70              7.78
  SET_ROWS         CPU          144               0               222              1.54
  SOFT_MAX         OPU           72               0            121747           1690.93
  ROPE             CPU          144               0              1013              7.03
  GLU              OPU           72             164            454378           6310.81
```

No crashes, no negative/garbage values, CPU/OPU splits consistent across all three runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FIR-2243: corrects GGML Perf Summary by zeroing per-pass tsi_kernel_runs, counting CPU perf once per node, and skipping unused timer reads on non-leader threads. This aligns perf tables between llama-cli and long-running hosts like Ollama without changing compute behavior.

- ggml-tsavorite: clear node->tsi_kernel_runs at the start of each dispatch pass so CPU-fallback ops report 0 kernel launches and no stale carryover if a prior accumulate was skipped.
- ggml-cpu: update node->perf_runs and node->perf_time_us only on the leader thread (state->ith == 0) to avoid per-thread multiplication; also read ggml_time_us() only on the leader to avoid unused timer calls.
- Affects only builds with GGML_PERF* flags; expect lower CPU op Runs/Total us and zero kernel-run counts for CPU-fallback paths; no API or execution-path changes.

<sup>Written for commit e781da9e34d506b6d3a88618cab574af1ebcd34f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tsisw/llama.cpp/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

